### PR TITLE
Publish Godot Web playtest to GitHub Pages

### DIFF
--- a/.github/workflows/godot-web-playtest.yml
+++ b/.github/workflows/godot-web-playtest.yml
@@ -165,3 +165,26 @@ jobs:
           path: build/web
           if-no-files-found: error
           retention-days: 14
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: build/web
+
+  deploy-pages:
+    name: Publish browser playtest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: export-web
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Publishes the already-verified Godot Web export from `main` to a stable GitHub Pages URL. Pull requests remain build-only; only `main` uploads the Pages artifact and deploys it.