### PR TITLE
Publish Godot playtest without Pages setup

### DIFF
--- a/.github/workflows/godot-web-playtest.yml
+++ b/.github/workflows/godot-web-playtest.yml
@@ -166,25 +166,36 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Upload GitHub Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: build/web
-
-  deploy-pages:
-    name: Publish browser playtest
+  publish-playtest:
+    name: Publish public playtest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: export-web
     runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      contents: write
 
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Download verified Web build
+        uses: actions/download-artifact@v4
+        with:
+          name: godot-web-playtest-${{ github.sha }}
+          path: publish
+
+      - name: Stamp source revision
+        shell: bash
+        run: printf '%s\n' "$GITHUB_SHA" > publish/PLAYTEST_BUILD.txt
+
+      - name: Publish playtest-web branch
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cd publish
+          git init -b playtest-web
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Publish Godot playtest ${GITHUB_SHA}"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force origin HEAD:refs/heads/playtest-web


### PR DESCRIPTION
Replaces the GitHub Pages dependency with a zero-config `playtest-web` branch. `main` builds the verified Godot Web artifact, stamps the source SHA, and force-publishes only the generated browser files to that branch. PRs remain build-only.