### PR TITLE
Camera A/B — dynamic heading follow on current desktop controls

### DIFF
--- a/.github/workflows/dynamic-camera-ab.yml
+++ b/.github/workflows/dynamic-camera-ab.yml
@@ -1,0 +1,60 @@
+name: Dynamic Camera A/B Regression
+
+on:
+  push:
+    branches:
+      - chatgpt/desktop-controls-dynamic-camera-ab
+    paths:
+      - "godot/**"
+      - ".github/workflows/dynamic-camera-ab.yml"
+  pull_request:
+    paths:
+      - "godot/scripts/camera/**"
+      - "godot/scripts/player/runner.gd"
+      - "godot/tests/dynamic_camera_follow_test.gd"
+      - ".github/workflows/dynamic-camera-ab.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  dynamic-camera:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GODOT_RELEASE: "4.7.1-stable"
+      GODOT_BIN: "${{ github.workspace }}/.godot-bin/Godot_v4.7.1-stable_linux.x86_64"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Install Godot 4.7.1 editor
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            --output godot.zip \
+            https://github.com/godotengine/godot/releases/download/${GODOT_RELEASE}/Godot_v${GODOT_RELEASE}_linux.x86_64.zip
+          echo "c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba  godot.zip" | sha256sum --check --strict
+          mkdir -p .godot-bin
+          unzip -q godot.zip -d .godot-bin
+          chmod +x "$GODOT_BIN"
+
+      - name: Prime Godot metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path godot --quit
+
+      - name: Run dynamic camera integration regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/dynamic_camera_follow_test.gd

--- a/godot/scripts/camera/camera_3d.gd
+++ b/godot/scripts/camera/camera_3d.gd
@@ -2,7 +2,7 @@ class_name ChinatownCamera3D
 extends Camera3D
 
 # Chinatown Camera 3D: 3/4 Top-Down Dynamic Follow Camera
-# Dynamic Speed FOV, Damped Velocity Look-Ahead, & Fixed 3/4 Perspective
+# Dynamic Speed FOV, Damped Velocity Look-Ahead, & heading-following 3/4 perspective
 
 @export var target_node: Node3D = null
 @export var follow_speed: float = 5.0 # Focus point damping rate (s⁻¹)
@@ -10,9 +10,18 @@ extends Camera3D
 @export var max_speed_fov: float = 38.0
 @export var max_speed_ref: float = 14.0
 
+# Dynamic yaw follow (#30 candidate B), preserving the original 12/18/12 rig geometry.
+@export var dynamic_yaw_enabled: bool = true
+@export var vehicle_yaw_rate: float = 2.8 # s⁻¹
+@export var foot_yaw_rate: float = 1.5 # s⁻¹
+@export var max_yaw_speed: float = 2.5 # rad/s max slew
+
+const RIG_GROUND_RADIUS: float = 16.9705627 # sqrt(12^2 + 12^2)
+const RIG_ELEVATION_HEIGHT: float = 18.0
+
+var _current_yaw_rad: float = PI / 4.0
 var _interaction_target: Node3D = null
 var _is_interaction_mode: bool = false
-var _camera_offset: Vector3 = Vector3(12.0, 18.0, 12.0)
 var _focus_height_offset: Vector3 = Vector3(0.0, 0.5, 0.0)
 
 # Filtered state tracking
@@ -41,6 +50,7 @@ func reset_camera_instant(target: Node3D) -> void:
 	target_node = target
 	_is_interaction_mode = false
 	_interaction_target = null
+	_current_yaw_rad = PI / 4.0
 	fov = default_fov
 	if target:
 		_smoothed_focus_pos = target.global_position
@@ -49,20 +59,22 @@ func reset_camera_instant(target: Node3D) -> void:
 	_smoothed_look_ahead = Vector3.ZERO
 	_is_initialized = true
 	var framing_center: Vector3 = _smoothed_focus_pos
-	global_position = framing_center + _camera_offset
+	var offset_x: float = RIG_GROUND_RADIUS * sin(_current_yaw_rad)
+	var offset_z: float = RIG_GROUND_RADIUS * cos(_current_yaw_rad)
+	global_position = framing_center + Vector3(offset_x, RIG_ELEVATION_HEIGHT, offset_z)
 	look_at(framing_center + _focus_height_offset)
 
 func _process(delta: float) -> void:
 	if delta <= 0.0:
 		return
-		
+
 	# -------------------------------------------------------------------------
 	# STAGE 1: Determine Raw Target Position & Velocity
 	# -------------------------------------------------------------------------
 	var raw_target_pos: Vector3 = Vector3.ZERO
 	var raw_velocity: Vector3 = Vector3.ZERO
 	var speed: float = 0.0
-	
+
 	if _is_interaction_mode and _interaction_target:
 		raw_target_pos = _interaction_target.global_position
 		raw_velocity = Vector3.ZERO
@@ -98,7 +110,7 @@ func _process(delta: float) -> void:
 	if raw_velocity.length() > 0.2:
 		var lead_dist: float = clampf(speed * 0.18, 0.0, 3.0)
 		target_look_ahead = raw_velocity.normalized() * lead_dist
-	
+
 	# Rate selection: 7.0 s⁻¹ on direction reversal / braking, 3.5 s⁻¹ on continuous acceleration
 	var look_ahead_rate: float = 3.5
 	if _smoothed_look_ahead.length() > 0.1 and target_look_ahead.dot(_smoothed_look_ahead) < 0.0:
@@ -107,10 +119,38 @@ func _process(delta: float) -> void:
 	_smoothed_look_ahead = _smoothed_look_ahead.lerp(target_look_ahead, look_ahead_factor)
 
 	# -------------------------------------------------------------------------
-	# STAGE 4: Combined Framing Center & Fixed Rig Transform
+	# STAGE 4: Dynamic heading follow + preserved polar 3/4 rig
 	# -------------------------------------------------------------------------
+	if dynamic_yaw_enabled and not _is_interaction_mode:
+		var target_yaw: float = _current_yaw_rad
+		var yaw_rate: float = 0.0
+
+		if target_node is CourierBike or target_node is ScrapHauler or (target_node != null and target_node.is_in_group("vehicles")):
+			var vehicle_forward: Vector3 = -target_node.global_transform.basis.z
+			vehicle_forward.y = 0.0
+			if vehicle_forward.length_squared() > 0.01:
+				vehicle_forward = vehicle_forward.normalized()
+				target_yaw = atan2(vehicle_forward.x, vehicle_forward.z) + PI
+				yaw_rate = vehicle_yaw_rate
+		elif speed > 1.2 and raw_velocity.length() > 1.2:
+			var move_forward: Vector3 = raw_velocity
+			move_forward.y = 0.0
+			if move_forward.length_squared() > 0.01:
+				move_forward = move_forward.normalized()
+				target_yaw = atan2(move_forward.x, move_forward.z) + PI
+				yaw_rate = foot_yaw_rate
+
+		if yaw_rate > 0.0:
+			var angle_diff: float = wrapf(target_yaw - _current_yaw_rad, -PI, PI)
+			var step: float = angle_diff * (1.0 - exp(-yaw_rate * delta))
+			step = clampf(step, -max_yaw_speed * delta, max_yaw_speed * delta)
+			_current_yaw_rad = wrapf(_current_yaw_rad + step, -PI, PI)
+
+	var offset_x: float = RIG_GROUND_RADIUS * sin(_current_yaw_rad)
+	var offset_z: float = RIG_GROUND_RADIUS * cos(_current_yaw_rad)
+	var dynamic_offset := Vector3(offset_x, RIG_ELEVATION_HEIGHT, offset_z)
 	var framing_center: Vector3 = _smoothed_focus_pos + _smoothed_look_ahead
-	global_position = framing_center + _camera_offset
+	global_position = framing_center + dynamic_offset
 	look_at(framing_center + _focus_height_offset)
 
 	# -------------------------------------------------------------------------
@@ -124,6 +164,6 @@ func _process(delta: float) -> void:
 	else:
 		var speed_ratio: float = clampf(speed / max_speed_ref, 0.0, 1.0)
 		target_fov = lerpf(default_fov, max_speed_fov, speed_ratio)
-	
+
 	var fov_factor: float = 1.0 - exp(-fov_rate * delta)
 	fov = lerpf(fov, target_fov, fov_factor)

--- a/godot/scripts/player/runner.gd
+++ b/godot/scripts/player/runner.gd
@@ -21,9 +21,6 @@ var joystick_vector := Vector2.ZERO
 var is_input_locked: bool = false
 var is_mounted: bool = false
 
-# Screen-to-World direction relative to 45 deg yaw camera
-var _camera_yaw_deg: float = 45.0
-
 signal footstep_triggered
 
 var _step_timer: float = 0.0
@@ -33,12 +30,12 @@ func _physics_process(delta: float) -> void:
 	if is_mounted:
 		# Posture handled via set_mounted_posture
 		return
-		
+
 	if is_input_locked:
 		velocity = Vector3.ZERO
 		_reset_standing_pose()
 		return
-		
+
 	# Touch joystick has authority while active; otherwise accept physical/logical desktop keys.
 	var input_dir := joystick_vector
 	if input_dir.length() < 0.05:
@@ -55,37 +52,51 @@ func _physics_process(delta: float) -> void:
 		input_dir = Vector2(kb_x, kb_y)
 		if input_dir.length() > 1.0:
 			input_dir = input_dir.normalized()
-			
+
 	if input_dir.length() > 0.05:
-		# Convert screen-relative 2D input (Up = -Y screen) to 3D world direction
-		var yaw_rad := deg_to_rad(_camera_yaw_deg)
-		var forward := Vector3(-sin(yaw_rad), 0.0, -cos(yaw_rad)).normalized()
-		var right := Vector3(cos(yaw_rad), 0.0, -sin(yaw_rad)).normalized()
-		
-		var move_dir := (right * input_dir.x + forward * input_dir.y).normalized()
-		var target_vel := move_dir * (move_speed * input_dir.length())
-		
+		# Preserve analog touch magnitude while deriving direction from the live camera basis.
+		var input_strength: float = minf(input_dir.length(), 1.0)
+		var normalized_input := input_dir.normalized()
+
+		# Project the active camera's basis onto the horizontal plane. If no camera is
+		# active yet, retain the historical 45-degree frame as a startup fallback.
+		var camera_3d := get_viewport().get_camera_3d() if is_inside_tree() else null
+		var forward_xz := Vector3(-0.707107, 0.0, -0.707107)
+		var right_xz := Vector3(0.707107, 0.0, -0.707107)
+		if camera_3d:
+			var camera_basis := camera_3d.global_transform.basis
+			var forward_candidate := Vector3(-camera_basis.z.x, 0.0, -camera_basis.z.z)
+			if forward_candidate.length_squared() > 0.001:
+				forward_xz = forward_candidate.normalized()
+			var right_candidate := Vector3(camera_basis.x.x, 0.0, camera_basis.x.z)
+			if right_candidate.length_squared() > 0.001:
+				right_xz = right_candidate.normalized()
+
+		# Screen space: Up = -Y, Down = +Y, Left = -X, Right = +X.
+		var move_dir := (right_xz * normalized_input.x + forward_xz * (-normalized_input.y)).normalized()
+		var target_vel := move_dir * (move_speed * input_strength)
+
 		velocity = velocity.move_toward(target_vel, acceleration * delta)
-		
+
 		# 8-Way visual mesh facing direction
 		if mesh_pivot:
 			var target_angle := atan2(-move_dir.x, -move_dir.z)
 			var snap_step: float = PI / 4.0
 			var snapped_angle: float = round(target_angle / snap_step) * snap_step
 			mesh_pivot.rotation.y = lerp_angle(mesh_pivot.rotation.y, snapped_angle, delta * 15.0)
-			
+
 		# Procedural running stride animation
 		_anim_time += delta * velocity.length() * 2.2
 		var leg_swing: float = sin(_anim_time) * 0.55
 		var arm_swing: float = sin(_anim_time) * 0.45
-		
+
 		if left_leg: left_leg.rotation.x = leg_swing
 		if right_leg: right_leg.rotation.x = -leg_swing
 		if left_arm: left_arm.rotation.x = -arm_swing
 		if right_arm: right_arm.rotation.x = arm_swing
 		if torso_node: torso_node.position.y = 1.15 + abs(sin(_anim_time * 2.0)) * 0.04
 		if head_node: head_node.position.y = 1.62 + abs(sin(_anim_time * 2.0)) * 0.03
-			
+
 		# Trigger footstep audio event periodically
 		_step_timer += delta * velocity.length()
 		if _step_timer > 3.0:
@@ -95,7 +106,7 @@ func _physics_process(delta: float) -> void:
 		velocity = velocity.move_toward(Vector3.ZERO, friction * delta)
 		_step_timer = 0.0
 		_reset_standing_pose()
-		
+
 	move_and_slide()
 
 func set_joystick_input(vec: Vector2) -> void:
@@ -105,7 +116,7 @@ func set_mounted_posture(mounted: bool) -> void:
 	is_mounted = mounted
 	if not mesh_pivot:
 		return
-		
+
 	if mounted:
 		# Riding motorcycle posture: seated, forward crouch, hands reaching forward to grips
 		if torso_node:

--- a/godot/tests/dynamic_camera_follow_test.gd
+++ b/godot/tests/dynamic_camera_follow_test.gd
@@ -1,0 +1,138 @@
+extends SceneTree
+
+# Combined #29 + #30 regression: latest desktop controls must remain camera-relative
+# while the camera follows on-foot movement and vehicle heading without snaps.
+var _scene_under_test: Node = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _finish(exit_code: int) -> void:
+	_release_key(KEY_W)
+	if is_instance_valid(_scene_under_test):
+		_scene_under_test.queue_free()
+		await process_frame
+		await process_frame
+	quit(exit_code)
+
+func _fail(message: String) -> void:
+	push_error("[DYNAMIC_CAMERA_AB] %s" % message)
+	await _finish(1)
+
+func _key_event(key: Key, pressed: bool) -> InputEventKey:
+	var event := InputEventKey.new()
+	event.physical_keycode = key
+	event.keycode = key
+	event.pressed = pressed
+	return event
+
+func _inject_key(key: Key, pressed: bool) -> void:
+	Input.parse_input_event(_key_event(key, pressed))
+	Input.flush_buffered_events()
+
+func _release_key(key: Key) -> void:
+	_inject_key(key, false)
+
+func _yaw_error(actual: float, expected: float) -> float:
+	return abs(wrapf(actual - expected, -PI, PI))
+
+func _run() -> void:
+	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
+	if packed == null:
+		await _fail("Could not load scrap_test_block.tscn")
+		return
+
+	_scene_under_test = packed.instantiate()
+	root.add_child(_scene_under_test)
+	await process_frame
+	await physics_frame
+
+	var camera := _scene_under_test.get_node_or_null("ChinatownCamera3D")
+	var player := _scene_under_test.get_node_or_null("Runner")
+	var courier_bike := _scene_under_test.get_node_or_null("CourierBike")
+	var scrap_hauler := _scene_under_test.get_node_or_null("ScrapHauler")
+	if camera == null or player == null or courier_bike == null or scrap_hauler == null:
+		await _fail("Main scene is missing camera/player/Bike/Hauler integration nodes")
+		return
+
+	# RED on fixed-camera #29 baseline: combined candidate must explicitly expose dynamic yaw.
+	if camera.get("dynamic_yaw_enabled") == null or camera.get("_current_yaw_rad") == null:
+		await _fail("Dynamic heading-follow camera capability is absent")
+		return
+	camera.set("dynamic_yaw_enabled", true)
+
+	# 1. CourierBike uses the strong vehicle-heading follow path.
+	camera.call("reset_camera_instant", courier_bike)
+	courier_bike.rotation.y = deg_to_rad(90.0)
+	courier_bike.current_speed = 8.0
+	courier_bike.velocity = Vector3(-8.0, 0.0, 0.0)
+	for _i in range(90):
+		camera.call("_process", 0.016)
+	var bike_fwd: Vector3 = -courier_bike.global_transform.basis.z
+	var bike_expected := wrapf(atan2(bike_fwd.x, bike_fwd.z) + PI, -PI, PI)
+	if _yaw_error(float(camera.get("_current_yaw_rad")), bike_expected) >= 0.35:
+		await _fail("CourierBike camera yaw did not converge to vehicle heading")
+		return
+
+	# 2. ScrapHauler must have exact vehicle-heading parity.
+	camera.call("reset_camera_instant", scrap_hauler)
+	scrap_hauler.rotation.y = deg_to_rad(-90.0)
+	scrap_hauler.current_speed = 6.0
+	scrap_hauler.velocity = Vector3(6.0, 0.0, 0.0)
+	for _i in range(90):
+		camera.call("_process", 0.016)
+	var hauler_fwd: Vector3 = -scrap_hauler.global_transform.basis.z
+	var hauler_expected := wrapf(atan2(hauler_fwd.x, hauler_fwd.z) + PI, -PI, PI)
+	if _yaw_error(float(camera.get("_current_yaw_rad")), hauler_expected) >= 0.35:
+		await _fail("ScrapHauler did not use the vehicle-heading follow path")
+		return
+
+	# 3. On-foot sustained movement rotates the camera toward movement direction.
+	camera.call("reset_camera_instant", player)
+	player.velocity = Vector3(0.0, 0.0, 3.5)
+	for _i in range(90):
+		camera.call("_process", 0.016)
+	var foot_expected := wrapf(PI, -PI, PI)
+	if _yaw_error(float(camera.get("_current_yaw_rad")), foot_expected) >= 0.40:
+		await _fail("On-foot camera yaw did not follow sustained movement")
+		return
+
+	# 4. Desktop W remains screen-forward after the camera yaw is materially rotated.
+	camera.set("dynamic_yaw_enabled", false)
+	camera.set("_current_yaw_rad", PI / 2.0)
+	camera.call("set_target", player)
+	camera.call("_process", 0.016)
+	player.set_joystick_input(Vector2.ZERO)
+	player.velocity = Vector3.ZERO
+	_inject_key(KEY_W, true)
+	player._physics_process(0.1)
+	_release_key(KEY_W)
+	var cam_basis: Basis = camera.global_transform.basis
+	var cam_fwd_xz := Vector3(-cam_basis.z.x, 0.0, -cam_basis.z.z).normalized()
+	var player_dir := Vector3(player.velocity.x, 0.0, player.velocity.z).normalized()
+	if player_dir.length_squared() < 0.5 or player_dir.dot(cam_fwd_xz) <= 0.95:
+		await _fail("Physical W is not live-camera-relative after camera rotation")
+		return
+	camera.set("dynamic_yaw_enabled", true)
+
+	# 5. Interaction mode freezes yaw; exit resumes within the configured slew cap.
+	camera.call("reset_camera_instant", player)
+	var before_interaction := float(camera.get("_current_yaw_rad"))
+	camera.call("set_interaction_mode", true, player)
+	player.velocity = Vector3(10.0, 0.0, 10.0)
+	for _i in range(30):
+		camera.call("_process", 0.016)
+	if _yaw_error(float(camera.get("_current_yaw_rad")), before_interaction) > 0.001:
+		await _fail("Camera yaw moved during interaction mode")
+		return
+	camera.call("set_interaction_mode", false)
+	var before_resume := float(camera.get("_current_yaw_rad"))
+	camera.call("_process", 0.016)
+	var resume_step := _yaw_error(float(camera.get("_current_yaw_rad")), before_resume)
+	var max_yaw_speed := float(camera.get("max_yaw_speed"))
+	if resume_step > max_yaw_speed * 0.016 + 0.001:
+		await _fail("Camera snapped when leaving interaction mode")
+		return
+
+	print("[DYNAMIC_CAMERA_AB] PASS")
+	await _finish(0)


### PR DESCRIPTION
Historical stacked A/B evidence PR for #30.

Superseded after #29 merged by PR #42 (`chatgpt/camera-feel-30` -> `main`), which restacks the owner-selected `RETAIN_DYNAMIC_YAW` behavior directly on merged `main@ff8865c117732bd93c7e4714c9f27732c20701b8` and carries fresh verification.

Do not merge this PR. Preserve it only as historical A/B/TDD evidence for exact candidate `e02affc122931052f3c9e3d9de410db1839551d9`.