### PR TITLE
CTW Feel 03 — camera occlusion readability slice

### DIFF
--- a/.github/workflows/camera-occlusion-13.yml
+++ b/.github/workflows/camera-occlusion-13.yml
@@ -9,6 +9,7 @@ on:
       - "godot/scripts/camera/**"
       - "godot/scenes/props/**"
       - "godot/tests/camera_occlusion_readability_test.gd"
+      - "godot/tests/camera_occluder_authoring_test.gd"
       - ".github/workflows/camera-occlusion-13.yml"
 
 permissions:
@@ -61,7 +62,7 @@ jobs:
           set -euo pipefail
           "$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path godot --quit
 
-      - name: Run camera occlusion contract
+      - name: Run camera occlusion behavior contract
         shell: bash
         run: |
           set -euo pipefail
@@ -70,3 +71,13 @@ jobs:
             --rendering-method gl_compatibility \
             --path godot \
             --script res://tests/camera_occlusion_readability_test.gd
+
+      - name: Run camera occluder authoring contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/camera_occluder_authoring_test.gd

--- a/.github/workflows/camera-occlusion-13.yml
+++ b/.github/workflows/camera-occlusion-13.yml
@@ -10,6 +10,7 @@ on:
       - "godot/scenes/props/**"
       - "godot/tests/camera_occlusion_readability_test.gd"
       - "godot/tests/camera_occluder_authoring_test.gd"
+      - "godot/tests/camera_occlusion_render_evidence.gd"
       - ".github/workflows/camera-occlusion-13.yml"
 
 permissions:
@@ -81,3 +82,28 @@ jobs:
             --rendering-method gl_compatibility \
             --path godot \
             --script res://tests/camera_occluder_authoring_test.gd
+
+      - name: Capture rendered occlusion evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf godot/verification/feel/camera_occlusion_13_runtime
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/camera_occlusion_render_evidence.gd
+          test -s godot/verification/feel/camera_occlusion_13_runtime/01_clear_baseline.png
+          test -s godot/verification/feel/camera_occlusion_13_runtime/02_occluded_without_cutaway.png
+          test -s godot/verification/feel/camera_occlusion_13_runtime/03_cutaway_enabled.png
+          test -s godot/verification/feel/camera_occlusion_13_runtime/04_restored_after_clear.png
+          test -s godot/verification/feel/camera_occlusion_13_runtime/metrics.json
+
+      - name: Upload rendered occlusion evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: camera-occlusion-13-evidence-${{ env.SOURCE_SHA }}
+          path: godot/verification/feel/camera_occlusion_13_runtime
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/camera-occlusion-13.yml
+++ b/.github/workflows/camera-occlusion-13.yml
@@ -1,0 +1,72 @@
+name: Camera Occlusion 13
+
+on:
+  push:
+    branches:
+      - "chatgpt/camera-occlusion-13"
+  pull_request:
+    paths:
+      - "godot/scripts/camera/**"
+      - "godot/scenes/props/**"
+      - "godot/tests/camera_occlusion_readability_test.gd"
+      - ".github/workflows/camera-occlusion-13.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  occlusion-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GODOT_RELEASE: "4.7.1-stable"
+      GODOT_BIN: "${{ github.workspace }}/.godot-bin/Godot_v4.7.1-stable_linux.x86_64"
+      SOURCE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+
+      - name: Verify exact source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+
+      - name: Cache Godot editor
+        id: godot-cache
+        uses: actions/cache@v4
+        with:
+          path: .godot-bin
+          key: godot-4.7.1-linux-editor-v1
+
+      - name: Install Godot 4.7.1 editor
+        if: steps.godot-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            --output godot.zip \
+            https://github.com/godotengine/godot/releases/download/${GODOT_RELEASE}/Godot_v${GODOT_RELEASE}_linux.x86_64.zip
+          echo "c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba  godot.zip" | sha256sum --check --strict
+          mkdir -p .godot-bin
+          unzip -q godot.zip -d .godot-bin
+          chmod +x "$GODOT_BIN"
+
+      - name: Prime Godot metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path godot --quit
+
+      - name: Run camera occlusion contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/camera_occlusion_readability_test.gd

--- a/.github/workflows/camera-occlusion-13.yml
+++ b/.github/workflows/camera-occlusion-13.yml
@@ -87,9 +87,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          command -v xvfb-run
           rm -rf godot/verification/feel/camera_occlusion_13_runtime
-          "$GODOT_BIN" \
-            --headless \
+          xvfb-run -a "$GODOT_BIN" \
+            --audio-driver Dummy \
             --rendering-method gl_compatibility \
             --path godot \
             --script res://tests/camera_occlusion_render_evidence.gd

--- a/godot/scenes/props/corrugated_fence.tscn
+++ b/godot/scenes/props/corrugated_fence.tscn
@@ -15,7 +15,10 @@ size = Vector3(3.0, 1.8, 0.06)
 material = ExtResource("2_rust")
 size = Vector3(3.1, 0.1, 0.1)
 
-[node name="CorrugatedFence" type="Node3D"]
+[sub_resource type="BoxShape3D" id="BoxShape3D_camera_occlusion"]
+size = Vector3(3.2, 2.2, 0.3)
+
+[node name="CorrugatedFence" type="Node3D" groups=["camera_occluder"]]
 
 [node name="PostL" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.5, 1.1, 0)
@@ -32,3 +35,13 @@ mesh = SubResource("BoxMesh_sheet")
 [node name="TopCap" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.95, 0)
 mesh = SubResource("BoxMesh_top_bar")
+
+[node name="CameraOcclusionProxy" type="Area3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.1, 0)
+collision_layer = 1073741824
+collision_mask = 0
+monitoring = false
+monitorable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="CameraOcclusionProxy"]
+shape = SubResource("BoxShape3D_camera_occlusion")

--- a/godot/scenes/props/pipe_rack_modular.tscn
+++ b/godot/scenes/props/pipe_rack_modular.tscn
@@ -19,7 +19,10 @@ height = 6.0
 radial_segments = 8
 rings = 1
 
-[node name="PipeRackModular" type="Node3D"]
+[sub_resource type="BoxShape3D" id="BoxShape3D_camera_occlusion"]
+size = Vector3(2.5, 3.4, 6.2)
+
+[node name="PipeRackModular" type="Node3D" groups=["camera_occluder"]]
 
 [node name="StanchionL" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.0, 1.6, 0)
@@ -40,3 +43,13 @@ mesh = SubResource("CylinderMesh_pipe")
 [node name="LowerPipe" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0.4, 2.8, 0)
 mesh = SubResource("CylinderMesh_pipe")
+
+[node name="CameraOcclusionProxy" type="Area3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.7, 0)
+collision_layer = 1073741824
+collision_mask = 0
+monitoring = false
+monitorable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="CameraOcclusionProxy"]
+shape = SubResource("BoxShape3D_camera_occlusion")

--- a/godot/scenes/props/salvage_container.tscn
+++ b/godot/scenes/props/salvage_container.tscn
@@ -15,7 +15,10 @@ size = Vector3(2.5, 2.3, 0.25)
 material = ExtResource("2_rust")
 size = Vector3(0.2, 0.2, 4.8)
 
-[node name="SalvageContainer" type="Node3D"]
+[sub_resource type="BoxShape3D" id="BoxShape3D_camera_occlusion"]
+size = Vector3(2.5, 2.4, 4.9)
+
+[node name="SalvageContainer" type="Node3D" groups=["camera_occluder"]]
 
 [node name="ContainerBody" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.1, 0)
@@ -36,3 +39,13 @@ mesh = SubResource("BoxMesh_roof_rail")
 [node name="RoofRailR" type="MeshInstance3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.15, 2.2, 0)
 mesh = SubResource("BoxMesh_roof_rail")
+
+[node name="CameraOcclusionProxy" type="Area3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.15, 0)
+collision_layer = 1073741824
+collision_mask = 0
+monitoring = false
+monitorable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="CameraOcclusionProxy"]
+shape = SubResource("BoxShape3D_camera_occlusion")

--- a/godot/scripts/camera/camera_3d.gd
+++ b/godot/scripts/camera/camera_3d.gd
@@ -16,8 +16,17 @@ extends Camera3D
 @export var foot_yaw_rate: float = 1.5 # s⁻¹
 @export var max_yaw_speed: float = 2.5 # rad/s max slew
 
+# Camera readability (#13): explicit, visual-only cutaway for tagged occluders.
+# The dedicated physics layer is detection-only; gameplay collision remains untouched.
+@export var occlusion_enabled: bool = true
+@export_flags_3d_physics var occlusion_collision_mask: int = 1 << 30
+@export_range(1, 8, 1) var max_occluders: int = 3
+@export_range(0.0, 1.0, 0.01) var occluder_restore_delay: float = 0.25
+
 const RIG_GROUND_RADIUS: float = 16.9705627 # sqrt(12^2 + 12^2)
 const RIG_ELEVATION_HEIGHT: float = 18.0
+const CAMERA_OCCLUDER_GROUP: StringName = &"camera_occluder"
+const MAX_OCCLUSION_SCAN_HITS: int = 8
 
 var _current_yaw_rad: float = PI / 4.0
 var _interaction_target: Node3D = null
@@ -29,6 +38,9 @@ var _smoothed_focus_pos: Vector3 = Vector3.ZERO
 var _smoothed_look_ahead: Vector3 = Vector3.ZERO
 var _is_initialized: bool = false
 
+# #13 cutaway state: instance id -> root, cached visuals/original visibility, clear timer.
+var _active_occluders: Dictionary = {}
+
 # Telemetry
 var last_follow_error: float = 0.0
 
@@ -36,6 +48,9 @@ func _ready() -> void:
 	fov = default_fov
 	if target_node:
 		reset_camera_instant(target_node)
+
+func _exit_tree() -> void:
+	_restore_all_occluders()
 
 func set_target(new_target: Node3D) -> void:
 	target_node = new_target
@@ -46,7 +61,11 @@ func set_interaction_mode(active: bool, focus_node: Node3D = null) -> void:
 	_is_interaction_mode = active
 	_interaction_target = focus_node
 
+func get_active_occluder_count() -> int:
+	return _active_occluders.size()
+
 func reset_camera_instant(target: Node3D) -> void:
+	_restore_all_occluders()
 	target_node = target
 	_is_interaction_mode = false
 	_interaction_target = null
@@ -154,6 +173,11 @@ func _process(delta: float) -> void:
 	look_at(framing_center + _focus_height_offset)
 
 	# -------------------------------------------------------------------------
+	# STAGE 5: Explicit bounded occlusion cutaway (visual state only)
+	# -------------------------------------------------------------------------
+	_update_occlusion_cutaway(framing_center + _focus_height_offset, delta)
+
+	# -------------------------------------------------------------------------
 	# FOV: Contextual & Speed Breathing
 	# -------------------------------------------------------------------------
 	var target_fov: float = default_fov
@@ -167,3 +191,122 @@ func _process(delta: float) -> void:
 
 	var fov_factor: float = 1.0 - exp(-fov_rate * delta)
 	fov = lerpf(fov, target_fov, fov_factor)
+
+func _update_occlusion_cutaway(focus_point: Vector3, delta: float) -> void:
+	if not occlusion_enabled or not is_inside_tree():
+		_restore_all_occluders()
+		return
+
+	var world := get_world_3d()
+	if world == null:
+		return
+
+	var seen: Dictionary = {}
+	var excluded: Array[RID] = []
+	var accepted: int = 0
+	var space_state := world.direct_space_state
+
+	for _scan_index in range(MAX_OCCLUSION_SCAN_HITS):
+		if accepted >= max_occluders:
+			break
+
+		var query := PhysicsRayQueryParameters3D.create(
+			global_position,
+			focus_point,
+			occlusion_collision_mask,
+			excluded
+		)
+		query.collide_with_areas = true
+		query.collide_with_bodies = false
+		var hit: Dictionary = space_state.intersect_ray(query)
+		if hit.is_empty():
+			break
+
+		var collider := hit.get("collider")
+		if collider is CollisionObject3D:
+			excluded.append((collider as CollisionObject3D).get_rid())
+		else:
+			break
+
+		var occluder_root := _find_occluder_root(collider as Node)
+		if occluder_root == null:
+			continue
+
+		var instance_id := occluder_root.get_instance_id()
+		if seen.has(instance_id):
+			continue
+		seen[instance_id] = true
+		accepted += 1
+		_cutaway_occluder(occluder_root)
+
+	for instance_id in _active_occluders.keys():
+		var entry: Dictionary = _active_occluders[instance_id]
+		var occluder_root: Node = entry.get("root")
+		if not is_instance_valid(occluder_root):
+			_active_occluders.erase(instance_id)
+			continue
+
+		if seen.has(instance_id):
+			entry["clear_elapsed"] = 0.0
+			_active_occluders[instance_id] = entry
+			continue
+
+		var clear_elapsed: float = float(entry.get("clear_elapsed", 0.0)) + delta
+		if clear_elapsed + 0.0001 >= occluder_restore_delay:
+			_restore_occluder(instance_id)
+		else:
+			entry["clear_elapsed"] = clear_elapsed
+			_active_occluders[instance_id] = entry
+
+func _find_occluder_root(collider: Node) -> Node3D:
+	var cursor: Node = collider
+	while cursor != null:
+		if cursor.is_in_group(CAMERA_OCCLUDER_GROUP) and cursor is Node3D:
+			return cursor as Node3D
+		cursor = cursor.get_parent()
+	return null
+
+func _cutaway_occluder(occluder_root: Node3D) -> void:
+	var instance_id := occluder_root.get_instance_id()
+	if _active_occluders.has(instance_id):
+		var existing: Dictionary = _active_occluders[instance_id]
+		existing["clear_elapsed"] = 0.0
+		_active_occluders[instance_id] = existing
+		return
+
+	var visuals: Array[GeometryInstance3D] = []
+	_collect_occluder_visuals(occluder_root, visuals)
+	var original_visibility: Array[bool] = []
+	for visual in visuals:
+		original_visibility.append(visual.visible)
+		visual.visible = false
+
+	_active_occluders[instance_id] = {
+		"root": occluder_root,
+		"visuals": visuals,
+		"original_visibility": original_visibility,
+		"clear_elapsed": 0.0,
+	}
+
+func _collect_occluder_visuals(node: Node, output: Array[GeometryInstance3D]) -> void:
+	if node is GeometryInstance3D:
+		output.append(node as GeometryInstance3D)
+	for child in node.get_children():
+		_collect_occluder_visuals(child, output)
+
+func _restore_occluder(instance_id: int) -> void:
+	if not _active_occluders.has(instance_id):
+		return
+	var entry: Dictionary = _active_occluders[instance_id]
+	var visuals: Array = entry.get("visuals", [])
+	var original_visibility: Array = entry.get("original_visibility", [])
+	for i in range(mini(visuals.size(), original_visibility.size())):
+		var visual = visuals[i]
+		if is_instance_valid(visual):
+			visual.visible = bool(original_visibility[i])
+	_active_occluders.erase(instance_id)
+
+func _restore_all_occluders() -> void:
+	for instance_id in _active_occluders.keys():
+		_restore_occluder(instance_id)
+	_active_occluders.clear()

--- a/godot/scripts/camera/camera_3d.gd
+++ b/godot/scripts/camera/camera_3d.gd
@@ -197,20 +197,20 @@ func _update_occlusion_cutaway(focus_point: Vector3, delta: float) -> void:
 		_restore_all_occluders()
 		return
 
-	var world := get_world_3d()
+	var world: World3D = get_world_3d()
 	if world == null:
 		return
 
 	var seen: Dictionary = {}
 	var excluded: Array[RID] = []
 	var accepted: int = 0
-	var space_state := world.direct_space_state
+	var space_state: PhysicsDirectSpaceState3D = world.direct_space_state
 
 	for _scan_index in range(MAX_OCCLUSION_SCAN_HITS):
 		if accepted >= max_occluders:
 			break
 
-		var query := PhysicsRayQueryParameters3D.create(
+		var query: PhysicsRayQueryParameters3D = PhysicsRayQueryParameters3D.create(
 			global_position,
 			focus_point,
 			occlusion_collision_mask,
@@ -222,17 +222,17 @@ func _update_occlusion_cutaway(focus_point: Vector3, delta: float) -> void:
 		if hit.is_empty():
 			break
 
-		var collider := hit.get("collider")
+		var collider: Object = hit.get("collider") as Object
 		if collider is CollisionObject3D:
 			excluded.append((collider as CollisionObject3D).get_rid())
 		else:
 			break
 
-		var occluder_root := _find_occluder_root(collider as Node)
+		var occluder_root: Node3D = _find_occluder_root(collider as Node)
 		if occluder_root == null:
 			continue
 
-		var instance_id := occluder_root.get_instance_id()
+		var instance_id: int = occluder_root.get_instance_id()
 		if seen.has(instance_id):
 			continue
 		seen[instance_id] = true
@@ -241,7 +241,7 @@ func _update_occlusion_cutaway(focus_point: Vector3, delta: float) -> void:
 
 	for instance_id in _active_occluders.keys():
 		var entry: Dictionary = _active_occluders[instance_id]
-		var occluder_root: Node = entry.get("root")
+		var occluder_root: Node = entry.get("root") as Node
 		if not is_instance_valid(occluder_root):
 			_active_occluders.erase(instance_id)
 			continue
@@ -253,7 +253,7 @@ func _update_occlusion_cutaway(focus_point: Vector3, delta: float) -> void:
 
 		var clear_elapsed: float = float(entry.get("clear_elapsed", 0.0)) + delta
 		if clear_elapsed + 0.0001 >= occluder_restore_delay:
-			_restore_occluder(instance_id)
+			_restore_occluder(int(instance_id))
 		else:
 			entry["clear_elapsed"] = clear_elapsed
 			_active_occluders[instance_id] = entry
@@ -267,7 +267,7 @@ func _find_occluder_root(collider: Node) -> Node3D:
 	return null
 
 func _cutaway_occluder(occluder_root: Node3D) -> void:
-	var instance_id := occluder_root.get_instance_id()
+	var instance_id: int = occluder_root.get_instance_id()
 	if _active_occluders.has(instance_id):
 		var existing: Dictionary = _active_occluders[instance_id]
 		existing["clear_elapsed"] = 0.0
@@ -301,12 +301,12 @@ func _restore_occluder(instance_id: int) -> void:
 	var visuals: Array = entry.get("visuals", [])
 	var original_visibility: Array = entry.get("original_visibility", [])
 	for i in range(mini(visuals.size(), original_visibility.size())):
-		var visual = visuals[i]
+		var visual: GeometryInstance3D = visuals[i] as GeometryInstance3D
 		if is_instance_valid(visual):
 			visual.visible = bool(original_visibility[i])
 	_active_occluders.erase(instance_id)
 
 func _restore_all_occluders() -> void:
 	for instance_id in _active_occluders.keys():
-		_restore_occluder(instance_id)
+		_restore_occluder(int(instance_id))
 	_active_occluders.clear()

--- a/godot/tests/camera_occluder_authoring_test.gd
+++ b/godot/tests/camera_occluder_authoring_test.gd
@@ -1,0 +1,93 @@
+extends SceneTree
+
+# Issue #13 world-authoring contract: only intentionally selected prop families
+# participate in camera cutaway, via detection-only Area3D proxies.
+
+const OCCLUSION_LAYER: int = 1 << 30
+const SELECTED_SCENES: Array[String] = [
+	"res://scenes/props/salvage_container.tscn",
+	"res://scenes/props/corrugated_fence.tscn",
+	"res://scenes/props/pipe_rack_modular.tscn",
+]
+const NON_SELECTED_SCENE: String = "res://scenes/props/scrap_pile_a.tscn"
+
+var _instances: Array[Node] = []
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _finish(exit_code: int) -> void:
+	for instance in _instances:
+		if is_instance_valid(instance):
+			instance.queue_free()
+	await process_frame
+	await process_frame
+	quit(exit_code)
+
+func _fail(message: String) -> void:
+	push_error("[CAMERA_OCCLUDER_AUTHORING_13] %s" % message)
+	await _finish(1)
+
+func _instantiate(path: String) -> Node:
+	var packed: PackedScene = load(path) as PackedScene
+	if packed == null:
+		return null
+	var instance: Node = packed.instantiate()
+	root.add_child(instance)
+	_instances.append(instance)
+	return instance
+
+func _count_geometry(node: Node) -> int:
+	var count: int = 1 if node is GeometryInstance3D else 0
+	for child in node.get_children():
+		count += _count_geometry(child)
+	return count
+
+func _run() -> void:
+	for path in SELECTED_SCENES:
+		var instance: Node = _instantiate(path)
+		if instance == null:
+			await _fail("Could not instantiate selected prop: %s" % path)
+			return
+		if not instance.is_in_group("camera_occluder"):
+			await _fail("Selected prop is not explicitly tagged camera_occluder: %s" % path)
+			return
+		if _count_geometry(instance) <= 0:
+			await _fail("Selected prop has no visual geometry: %s" % path)
+			return
+
+		var proxy := instance.get_node_or_null("CameraOcclusionProxy") as Area3D
+		if proxy == null:
+			await _fail("Selected prop has no CameraOcclusionProxy: %s" % path)
+			return
+		if proxy.collision_layer != OCCLUSION_LAYER:
+			await _fail("Selected prop proxy is not on dedicated occlusion layer: %s" % path)
+			return
+		if proxy.collision_mask != 0:
+			await _fail("Selected prop proxy unexpectedly queries gameplay collision: %s" % path)
+			return
+		if proxy.monitoring:
+			await _fail("Selected prop proxy should not monitor overlaps: %s" % path)
+			return
+
+		var shape_node := proxy.get_node_or_null("CollisionShape3D") as CollisionShape3D
+		if shape_node == null or shape_node.shape == null:
+			await _fail("Selected prop proxy has no valid collision shape: %s" % path)
+			return
+		if shape_node.disabled:
+			await _fail("Selected prop proxy collision shape is disabled: %s" % path)
+			return
+
+	var non_selected: Node = _instantiate(NON_SELECTED_SCENE)
+	if non_selected == null:
+		await _fail("Could not instantiate non-selected control prop")
+		return
+	if non_selected.is_in_group("camera_occluder"):
+		await _fail("Non-selected scrap pile was globally opted into camera occlusion")
+		return
+	if non_selected.get_node_or_null("CameraOcclusionProxy") != null:
+		await _fail("Non-selected scrap pile unexpectedly has an occlusion proxy")
+		return
+
+	print("[CAMERA_OCCLUDER_AUTHORING_13] PASS")
+	await _finish(0)

--- a/godot/tests/camera_occlusion_readability_test.gd
+++ b/godot/tests/camera_occlusion_readability_test.gd
@@ -27,7 +27,7 @@ func _fail(message: String) -> void:
 func _make_occluder(name: String, position: Vector3, tagged: bool = true) -> Dictionary:
 	var root_node := Node3D.new()
 	root_node.name = name
-	root_node.global_position = position
+	root_node.position = position
 	if tagged:
 		root_node.add_to_group("camera_occluder")
 	_fixture_root.add_child(root_node)
@@ -76,7 +76,7 @@ func _run() -> void:
 
 	_target = Node3D.new()
 	_target.name = "Target"
-	_target.global_position = Vector3.ZERO
+	_target.position = Vector3.ZERO
 	_fixture_root.add_child(_target)
 
 	_camera = CameraScript.new()

--- a/godot/tests/camera_occlusion_readability_test.gd
+++ b/godot/tests/camera_occlusion_readability_test.gd
@@ -1,0 +1,207 @@
+extends SceneTree
+
+# Issue #13 RED-first contract: explicit camera occluders may be visually cut away
+# without changing the retained dynamic camera/control frame or gameplay collision.
+
+const CameraScript = preload("res://scripts/camera/camera_3d.gd")
+const OCCLUSION_LAYER: int = 1 << 30
+
+var _fixture_root: Node3D = null
+var _camera: Camera3D = null
+var _target: Node3D = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _finish(exit_code: int) -> void:
+	if is_instance_valid(_fixture_root):
+		_fixture_root.queue_free()
+	await process_frame
+	await process_frame
+	quit(exit_code)
+
+func _fail(message: String) -> void:
+	push_error("[CAMERA_OCCLUSION_13] %s" % message)
+	await _finish(1)
+
+func _make_occluder(name: String, position: Vector3, tagged: bool = true) -> Dictionary:
+	var root_node := Node3D.new()
+	root_node.name = name
+	root_node.global_position = position
+	if tagged:
+		root_node.add_to_group("camera_occluder")
+	_fixture_root.add_child(root_node)
+
+	var mesh_instance := MeshInstance3D.new()
+	mesh_instance.name = "Visual"
+	var mesh := BoxMesh.new()
+	mesh.size = Vector3(1.5, 1.5, 1.5)
+	mesh_instance.mesh = mesh
+	root_node.add_child(mesh_instance)
+
+	var area := Area3D.new()
+	area.name = "CameraOcclusionProxy"
+	area.collision_layer = OCCLUSION_LAYER
+	area.collision_mask = 0
+	area.monitoring = false
+	area.monitorable = true
+	root_node.add_child(area)
+
+	var collision := CollisionShape3D.new()
+	var shape := BoxShape3D.new()
+	shape.size = Vector3(1.5, 1.5, 1.5)
+	collision.shape = shape
+	area.add_child(collision)
+
+	return {
+		"root": root_node,
+		"visual": mesh_instance,
+		"area": area,
+		"collision": collision,
+		"initial_layer": area.collision_layer,
+		"initial_mask": area.collision_mask,
+		"initial_disabled": collision.disabled,
+	}
+
+func _property_exists(object: Object, property_name: StringName) -> bool:
+	for property in object.get_property_list():
+		if StringName(property.get("name", "")) == property_name:
+			return true
+	return false
+
+func _run() -> void:
+	_fixture_root = Node3D.new()
+	_fixture_root.name = "CameraOcclusionFixture"
+	root.add_child(_fixture_root)
+
+	_target = Node3D.new()
+	_target.name = "Target"
+	_target.global_position = Vector3.ZERO
+	_fixture_root.add_child(_target)
+
+	_camera = CameraScript.new()
+	_camera.name = "Camera"
+	_fixture_root.add_child(_camera)
+	_camera.call("reset_camera_instant", _target)
+	await process_frame
+	await physics_frame
+
+	# RED on current main: #13 has no explicit occlusion capability yet.
+	if not _camera.has_method("get_active_occluder_count"):
+		await _fail("Camera occlusion capability is absent")
+		return
+	if not _property_exists(_camera, &"occlusion_enabled") or not _property_exists(_camera, &"occlusion_collision_mask"):
+		await _fail("Camera occlusion configuration is not exposed")
+		return
+	if not _property_exists(_camera, &"max_occluders") or not _property_exists(_camera, &"occluder_restore_delay"):
+		await _fail("Camera occlusion bounds are not exposed")
+		return
+
+	_camera.set("occlusion_enabled", true)
+	_camera.set("occlusion_collision_mask", OCCLUSION_LAYER)
+	_camera.set("max_occluders", 3)
+	_camera.set("occluder_restore_delay", 0.25)
+
+	var focus_point: Vector3 = _target.global_position + Vector3(0.0, 0.5, 0.0)
+	var camera_point: Vector3 = _camera.global_position
+
+	# A malformed proxy on the same layer but without the semantic group must be ignored
+	# and must not prevent farther valid tagged occluders from being discovered.
+	var untagged := _make_occluder("UntaggedProxy", camera_point.lerp(focus_point, 0.10), false)
+	var occluders: Array[Dictionary] = []
+	for i in range(4):
+		occluders.append(_make_occluder(
+			"Occluder%d" % (i + 1),
+			camera_point.lerp(focus_point, 0.25 + float(i) * 0.18),
+			true
+		))
+
+	await physics_frame
+	await physics_frame
+
+	var yaw_before := float(_camera.get("_current_yaw_rad"))
+	var focus_before: Vector3 = _camera.get("_smoothed_focus_pos")
+	var look_ahead_before: Vector3 = _camera.get("_smoothed_look_ahead")
+	var fov_before := _camera.fov
+
+	_camera.call("_process", 0.016)
+
+	if int(_camera.call("get_active_occluder_count")) != 3:
+		await _fail("Camera did not enforce the three-occluder cutaway cap")
+		return
+	if not bool(untagged["visual"].visible):
+		await _fail("Untagged geometry was visually modified")
+		return
+	for i in range(3):
+		if bool(occluders[i]["visual"].visible):
+			await _fail("Tagged occluder %d was not cut away" % (i + 1))
+			return
+	if not bool(occluders[3]["visual"].visible):
+		await _fail("Occluder cap was exceeded")
+		return
+
+	# The detection proxy/collider contract must be unchanged by visual cutaway.
+	for entry in occluders:
+		var area: Area3D = entry["area"]
+		var collision: CollisionShape3D = entry["collision"]
+		if area.collision_layer != int(entry["initial_layer"]) or area.collision_mask != int(entry["initial_mask"]):
+			await _fail("Occlusion cutaway mutated collision routing")
+			return
+		if collision.disabled != bool(entry["initial_disabled"]):
+			await _fail("Occlusion cutaway disabled a collision shape")
+			return
+
+	# Static-target occlusion must not perturb retained camera state.
+	if abs(wrapf(float(_camera.get("_current_yaw_rad")) - yaw_before, -PI, PI)) > 0.0001:
+		await _fail("Occlusion changed retained dynamic camera yaw")
+		return
+	if (_camera.get("_smoothed_focus_pos") as Vector3).distance_to(focus_before) > 0.0001:
+		await _fail("Occlusion changed authoritative focus state")
+		return
+	if (_camera.get("_smoothed_look_ahead") as Vector3).distance_to(look_ahead_before) > 0.0001:
+		await _fail("Occlusion changed look-ahead state")
+		return
+	if abs(_camera.fov - fov_before) > 0.0001:
+		await _fail("Occlusion changed FOV for a static target")
+		return
+
+	# Clear the ray. Cutaways remain briefly hidden, then restore together.
+	for entry in occluders:
+		var node: Node3D = entry["root"]
+		node.global_position += Vector3(100.0, 0.0, 0.0)
+	await physics_frame
+	await physics_frame
+
+	for _i in range(4):
+		_camera.call("_process", 0.05)
+	for i in range(3):
+		if bool(occluders[i]["visual"].visible):
+			await _fail("Occluder restored before the configured clear delay")
+			return
+
+	for _i in range(2):
+		_camera.call("_process", 0.05)
+	if int(_camera.call("get_active_occluder_count")) != 0:
+		await _fail("Cleared occluders did not leave active cutaway state")
+		return
+	for i in range(3):
+		if not bool(occluders[i]["visual"].visible):
+			await _fail("Cleared occluder %d did not restore" % (i + 1))
+			return
+
+	# Reset/replay must never leave world art hidden.
+	var reset_entry: Dictionary = occluders[0]
+	(reset_entry["root"] as Node3D).global_position = camera_point.lerp(focus_point, 0.40)
+	await physics_frame
+	await physics_frame
+	_camera.call("_process", 0.016)
+	if bool(reset_entry["visual"].visible):
+		await _fail("Reset fixture occluder was not cut away before reset")
+		return
+	_camera.call("reset_camera_instant", _target)
+	if not bool(reset_entry["visual"].visible) or int(_camera.call("get_active_occluder_count")) != 0:
+		await _fail("Camera reset did not restore all cutaway visuals")
+		return
+
+	print("[CAMERA_OCCLUSION_13] PASS")
+	await _finish(0)

--- a/godot/tests/camera_occlusion_render_evidence.gd
+++ b/godot/tests/camera_occlusion_render_evidence.gd
@@ -1,0 +1,208 @@
+extends SceneTree
+
+# Issue #13 deterministic rendered evidence. Uses the retained camera implementation
+# plus the real authored salvage-container occluder at the project's 960x540 viewport.
+
+const CameraScript = preload("res://scripts/camera/camera_3d.gd")
+const OUTPUT_DIR: String = "res://verification/feel/camera_occlusion_13_runtime"
+const SAMPLE_COUNT: int = 400
+
+var _fixture: Node3D = null
+var _camera: Camera3D = null
+var _target: Node3D = null
+var _container: Node3D = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _finish(exit_code: int) -> void:
+	if is_instance_valid(_fixture):
+		_fixture.queue_free()
+	await process_frame
+	await process_frame
+	quit(exit_code)
+
+func _fail(message: String) -> void:
+	push_error("[CAMERA_OCCLUSION_RENDER_13] %s" % message)
+	await _finish(1)
+
+func _make_material(color: Color, emission_strength: float = 0.0) -> StandardMaterial3D:
+	var material := StandardMaterial3D.new()
+	material.albedo_color = color
+	material.roughness = 0.75
+	if emission_strength > 0.0:
+		material.emission_enabled = true
+		material.emission = color
+		material.emission_energy_multiplier = emission_strength
+	return material
+
+func _capture(filename: String) -> bool:
+	await RenderingServer.frame_post_draw
+	var image: Image = root.get_texture().get_image()
+	if image == null or image.is_empty():
+		return false
+	var absolute_path: String = ProjectSettings.globalize_path("%s/%s" % [OUTPUT_DIR, filename])
+	return image.save_png(absolute_path) == OK
+
+func _bench_process(iterations: int) -> float:
+	var started: int = Time.get_ticks_usec()
+	for _i in range(iterations):
+		_camera.call("_process", 0.016)
+	var elapsed: int = Time.get_ticks_usec() - started
+	return float(elapsed) / float(iterations)
+
+func _run() -> void:
+	var output_absolute: String = ProjectSettings.globalize_path(OUTPUT_DIR)
+	var mkdir_error: Error = DirAccess.make_dir_recursive_absolute(output_absolute)
+	if mkdir_error != OK and mkdir_error != ERR_ALREADY_EXISTS:
+		await _fail("Could not create evidence directory: %s" % mkdir_error)
+		return
+
+	_fixture = Node3D.new()
+	_fixture.name = "CameraOcclusionRenderFixture"
+	root.add_child(_fixture)
+
+	var world_environment := WorldEnvironment.new()
+	var environment := Environment.new()
+	environment.background_mode = Environment.BG_COLOR
+	environment.background_color = Color(0.045, 0.055, 0.075, 1.0)
+	environment.ambient_light_source = Environment.AMBIENT_SOURCE_COLOR
+	environment.ambient_light_color = Color(0.42, 0.48, 0.58, 1.0)
+	environment.ambient_light_energy = 1.0
+	world_environment.environment = environment
+	_fixture.add_child(world_environment)
+
+	var light := DirectionalLight3D.new()
+	light.rotation_degrees = Vector3(-55.0, -35.0, 0.0)
+	light.light_color = Color(1.0, 0.90, 0.78, 1.0)
+	light.light_energy = 1.4
+	light.shadow_enabled = true
+	_fixture.add_child(light)
+
+	var floor := MeshInstance3D.new()
+	var floor_mesh := PlaneMesh.new()
+	floor_mesh.size = Vector2(28.0, 28.0)
+	floor.mesh = floor_mesh
+	floor.material_override = _make_material(Color(0.13, 0.12, 0.11, 1.0))
+	_fixture.add_child(floor)
+
+	_target = Node3D.new()
+	_target.name = "ReadabilityTarget"
+	_fixture.add_child(_target)
+	var target_visual := MeshInstance3D.new()
+	var target_mesh := CapsuleMesh.new()
+	target_mesh.radius = 0.55
+	target_mesh.height = 2.0
+	target_visual.mesh = target_mesh
+	target_visual.position = Vector3(0.0, 1.0, 0.0)
+	target_visual.material_override = _make_material(Color(0.95, 0.24, 0.62, 1.0), 0.35)
+	_target.add_child(target_visual)
+
+	_camera = CameraScript.new()
+	_camera.name = "EvidenceCamera"
+	_camera.current = true
+	_fixture.add_child(_camera)
+	_camera.call("reset_camera_instant", _target)
+
+	var packed_container: PackedScene = load("res://scenes/props/salvage_container.tscn") as PackedScene
+	if packed_container == null:
+		await _fail("Could not load authored salvage container")
+		return
+	_container = packed_container.instantiate() as Node3D
+	if _container == null:
+		await _fail("Could not instantiate authored salvage container")
+		return
+	_fixture.add_child(_container)
+
+	await process_frame
+	await physics_frame
+	await physics_frame
+
+	# Clear baseline.
+	_camera.set("occlusion_enabled", false)
+	_container.position = Vector3(8.0, 0.0, 0.0)
+	_camera.call("_process", 0.016)
+	await process_frame
+	if not await _capture("01_clear_baseline.png"):
+		await _fail("Could not capture clear baseline")
+		return
+
+	# Place the real container where its authored proxy intersects the retained
+	# camera-to-target readability ray, but keep cutaway disabled for baseline.
+	var focus_point: Vector3 = _target.global_position + Vector3(0.0, 0.5, 0.0)
+	var ray_point: Vector3 = _camera.global_position.lerp(focus_point, 0.90)
+	_container.position = Vector3(ray_point.x, 0.0, ray_point.z)
+	await physics_frame
+	await physics_frame
+	_camera.call("_process", 0.016)
+	await process_frame
+	if not await _capture("02_occluded_without_cutaway.png"):
+		await _fail("Could not capture occluded baseline")
+		return
+
+	# Candidate cutaway: same camera, target, prop and collider; visual state only changes.
+	_camera.set("occlusion_enabled", true)
+	var detection_started: int = Time.get_ticks_usec()
+	_camera.call("_process", 0.016)
+	var detection_usec: int = Time.get_ticks_usec() - detection_started
+	if int(_camera.call("get_active_occluder_count")) != 1:
+		await _fail("Real authored container was not detected as one active occluder")
+		return
+	await process_frame
+	if not await _capture("03_cutaway_enabled.png"):
+		await _fail("Could not capture active cutaway")
+		return
+
+	# Same-route CPU comparison. This reports script/query cost, not GPU frame time.
+	_camera.set("occlusion_enabled", false)
+	var disabled_usec: float = _bench_process(SAMPLE_COUNT)
+	_camera.set("occlusion_enabled", true)
+	_container.position = Vector3(8.0, 0.0, 0.0)
+	await physics_frame
+	await physics_frame
+	var enabled_clear_usec: float = _bench_process(SAMPLE_COUNT)
+	_container.position = Vector3(ray_point.x, 0.0, ray_point.z)
+	await physics_frame
+	await physics_frame
+	var enabled_blocked_usec: float = _bench_process(SAMPLE_COUNT)
+
+	# Clear and prove the configured gentler restore delay before final screenshot.
+	_container.position = Vector3(8.0, 0.0, 0.0)
+	await physics_frame
+	await physics_frame
+	var restore_elapsed: float = 0.0
+	while int(_camera.call("get_active_occluder_count")) > 0 and restore_elapsed < 1.0:
+		_camera.call("_process", 0.05)
+		restore_elapsed += 0.05
+	if int(_camera.call("get_active_occluder_count")) != 0:
+		await _fail("Authored container did not restore after ray cleared")
+		return
+	await process_frame
+	if not await _capture("04_restored_after_clear.png"):
+		await _fail("Could not capture restored state")
+		return
+
+	var metrics := {
+		"source_contract": "camera_occlusion_13",
+		"viewport": [root.size.x, root.size.y],
+		"detection_budget_frames": 1,
+		"detection_cpu_usec_single": detection_usec,
+		"restore_elapsed_sec": restore_elapsed,
+		"configured_restore_delay_sec": float(_camera.get("occluder_restore_delay")),
+		"max_occluders": int(_camera.get("max_occluders")),
+		"sample_count": SAMPLE_COUNT,
+		"camera_process_cpu_usec_avg_disabled": disabled_usec,
+		"camera_process_cpu_usec_avg_enabled_clear": enabled_clear_usec,
+		"camera_process_cpu_usec_avg_enabled_one_blocker": enabled_blocked_usec,
+		"performance_scope": "CPU script/query timing in deterministic CI fixture; not target-mobile GPU proof",
+	}
+	var metrics_file := FileAccess.open("%s/metrics.json" % OUTPUT_DIR, FileAccess.WRITE)
+	if metrics_file == null:
+		await _fail("Could not open metrics evidence file")
+		return
+	metrics_file.store_string(JSON.stringify(metrics, "  "))
+	metrics_file.close()
+
+	print("[CAMERA_OCCLUSION_RENDER_13] metrics=%s" % metrics)
+	print("[CAMERA_OCCLUSION_RENDER_13] PASS")
+	await _finish(0)


### PR DESCRIPTION
Implements #13 from verified `main@05d8161f50ac9bea8113e6b340c4f9ffe4ce459a`.

Scope reconciliation:
- #11 is closed; its immutable baseline is available.
- #13's old fixed-camera wording is historical. Current retained camera behavior is the dynamic heading-follow/control-frame implementation from #30 and is a compatibility boundary.
- This PR changes occlusion only: explicit `camera_occluder` participation, bounded visual cutaway, no camera push-in, no yaw/focus/look-ahead/FOV retune, no gameplay collision mutation.

TDD state:
- Current head is intentionally RED/test-only.
- `godot/tests/camera_occlusion_readability_test.gd` requires explicit tagging, a max-three cutaway cap, ignored untagged proxies, unchanged collision routing/shapes, retained camera state, delayed restore, and reset cleanup.
- Expected RED: `Camera occlusion capability is absent`.

Planned minimal implementation after RED is observed:
- dedicated non-gameplay Area3D proxy layer for camera occlusion queries;
- immediate visibility cutaway of cached visual descendants;
- ~250 ms clear-delay restore instead of per-frame transparent material duplication;
- selected container/fence/pipe-rack prop families only;
- exact-head camera/regression/Web verification and rendered evidence before merge.