### PR TITLE
CTW Feel 04 — traction, impact and vehicle audio feedback

### DIFF
--- a/godot/scripts/audio/audio_manager.gd
+++ b/godot/scripts/audio/audio_manager.gd
@@ -477,12 +477,12 @@ func _transient_instance_id(player: Node) -> int:
 func _apply_collision_output_gain(intensity: float, previous_3d_id: int, previous_2d_id: int) -> void:
 	var gain_db: float = lerpf(-8.0, 0.0, clampf(intensity, 0.0, 1.0))
 	if not _active_transients.is_empty():
-		var player_3d := _active_transients.back()
+		var player_3d: AudioStreamPlayer3D = _active_transients.back()
 		if _transient_instance_id(player_3d) != previous_3d_id:
 			player_3d.volume_db = gain_db
 			return
 	if not _active_2d_transients.is_empty():
-		var player_2d := _active_2d_transients.back()
+		var player_2d: AudioStreamPlayer = _active_2d_transients.back()
 		if _transient_instance_id(player_2d) != previous_2d_id:
 			player_2d.volume_db = gain_db
 

--- a/godot/scripts/audio/audio_manager.gd
+++ b/godot/scripts/audio/audio_manager.gd
@@ -471,16 +471,47 @@ func clear_pursuit_pressure(preserve_radio_duck: bool = false) -> void:
 	if not preserve_radio_duck:
 		set_radio_duck(0.0, 0.0)
 
-## Handle neutral collision telemetry from CourierBike
+func _transient_instance_id(player: Node) -> int:
+	return player.get_instance_id() if is_instance_valid(player) else 0
+
+func _apply_collision_output_gain(intensity: float, previous_3d_id: int, previous_2d_id: int) -> void:
+	var gain_db: float = lerpf(-8.0, 0.0, clampf(intensity, 0.0, 1.0))
+	if not _active_transients.is_empty():
+		var player_3d := _active_transients.back()
+		if _transient_instance_id(player_3d) != previous_3d_id:
+			player_3d.volume_db = gain_db
+			return
+	if not _active_2d_transients.is_empty():
+		var player_2d := _active_2d_transients.back()
+		if _transient_instance_id(player_2d) != previous_2d_id:
+			player_2d.volume_db = gain_db
+
+## Handle neutral collision telemetry from CourierBike. Routing, cooldowns and
+## voice-budget ownership stay in play_event(); only the newly-created collision
+## voice receives energy-derived output gain.
 func on_collision_contact(head_on_ratio: float, impact_speed: float, pos: Vector3) -> void:
+	var impact_intensity: float = 0.5
 	if _vehicle_feedback_layer:
 		_vehicle_feedback_layer.call("record_collision", head_on_ratio, impact_speed)
+		var snapshot: Dictionary = _vehicle_feedback_layer.call("snapshot")
+		impact_intensity = float(snapshot.get("last_collision_intensity", impact_intensity))
 	if impact_speed < 1.0:
 		return
+
+	var event: SoundEvent
 	if head_on_ratio < 0.35:
-		play_event(SoundEvent.COLLISION_GLANCE, pos)
-	elif head_on_ratio >= 0.35 and impact_speed >= 3.0:
-		play_event(SoundEvent.COLLISION_HEAD_ON, pos)
+		event = SoundEvent.COLLISION_GLANCE
+	elif impact_speed >= 3.0:
+		event = SoundEvent.COLLISION_HEAD_ON
+	else:
+		return
+
+	var event_count_before: int = get_event_count(event)
+	var previous_3d_id: int = _transient_instance_id(_active_transients.back()) if not _active_transients.is_empty() else 0
+	var previous_2d_id: int = _transient_instance_id(_active_2d_transients.back()) if not _active_2d_transients.is_empty() else 0
+	play_event(event, pos)
+	if get_event_count(event) > event_count_before:
+		_apply_collision_output_gain(impact_intensity, previous_3d_id, previous_2d_id)
 
 ## Authoritative instant reset: halts all streams and clears all transient nodes
 func reset_audio_instant() -> void:

--- a/godot/scripts/audio/audio_manager.gd
+++ b/godot/scripts/audio/audio_manager.gd
@@ -6,6 +6,7 @@ const AudioReferenceResolverScript = preload("res://scripts/audio/audio_referenc
 const RadioStationCatalogScript = preload("res://scripts/audio/radio/radio_station_catalog.gd")
 const RadioProgramDirectorScript = preload("res://scripts/audio/radio/radio_program_director.gd")
 const RadioProgramPlayerScript = preload("res://scripts/audio/radio/radio_program_player.gd")
+const VehicleFeedbackLayerScript = preload("res://scripts/audio/vehicle_feedback_layer.gd")
 
 # Echos in the Scrap - Audio Engine & Sound Synthesis Manager
 # Features procedural AudioStreamWAV synthesis, transient voice throttling,
@@ -38,7 +39,9 @@ enum SoundEvent {
 	ECHO_TAIL,
 	## M07 — Living Scrap Yard ambient life events
 	AMBIENT_WORK_CLINK,
-	AMBIENT_SERVO_HUM
+	AMBIENT_SERVO_HUM,
+	## CTW Feel 04 — appended to preserve all existing event ordinals
+	TRACTION_RECOVERY
 }
 
 enum MixState {
@@ -65,6 +68,8 @@ var _siren_player: AudioStreamPlayer3D = null
 var _tension_player: AudioStreamPlayer = null
 ## M04: dedicated echo voice (non-spatial — echo is inside-the-head by design)
 var _echo_voice: AudioStreamPlayer = null
+## CTW Feel 04: bounded presentation helper; AudioManager remains lifecycle owner.
+var _vehicle_feedback_layer: Node = null
 
 ## Radio Subsystem (#22)
 var _radio_director: RefCounted = null
@@ -130,6 +135,7 @@ static func event_to_slot_id(event: SoundEvent) -> String:
 	return EVENT_TO_SLOT_MAP.get(event, "")
 
 func _ready() -> void:
+	add_to_group("audio_manager")
 	_engine_stream = _create_noise_wav(0.5, 0.4)
 	_engine_stream.loop_mode = AudioStreamWAV.LOOP_FORWARD
 	_hum_stream = _create_tone_wav(120.0, 0.5, 0.3)
@@ -196,6 +202,12 @@ func _ready() -> void:
 	_radio_interference_player.stream = _radio_interference_stream
 	_radio_interference_player.volume_db = -80.0
 	add_child(_radio_interference_player)
+
+	## CTW Feel 04: one bounded continuous helper and traction voice.
+	_vehicle_feedback_layer = VehicleFeedbackLayerScript.new()
+	_vehicle_feedback_layer.name = "VehicleFeedbackLayer"
+	add_child(_vehicle_feedback_layer)
+	_vehicle_feedback_layer.call("configure", self, _engine_player, SoundEvent.TRACTION_RECOVERY)
 
 ## #31: Bounded runtime output diagnostics. This is an on-demand snapshot only;
 ## get_output_latency() may be expensive and must never be polled per-frame.
@@ -295,6 +307,8 @@ func play_event(event: SoundEvent, pos: Vector3 = Vector3.ZERO) -> void:
 		SoundEvent.AMBIENT_SERVO_HUM:
 			if current_mix_state != MixState.DISTURBANCE and current_mix_state != MixState.PURSUIT_PRESSURE:
 				_play_synth_sweep(pos, 220.0, 310.0, 0.25, 0.2)
+		SoundEvent.TRACTION_RECOVERY:
+			_play_synth_sweep(pos, 420.0, 620.0, 0.12, 0.22)
 
 func stop_event(event: SoundEvent) -> void:
 	if event == SoundEvent.PROXIMITY_HUM and _hum_player:
@@ -325,6 +339,11 @@ func set_hum_pitch(pitch: float) -> void:
 		_hum_player.pitch_scale = clampf(pitch, 0.5, 2.5)
 
 func set_engine_audio(speed_ratio: float, pos: Vector3) -> void:
+	# The legacy speed-only seam remains authoritative for other vehicles. Once
+	# Courier Bike telemetry is actively driving the richer layer, do not let the
+	# controller's compatibility call overwrite load-sensitive pitch/gain.
+	if _vehicle_feedback_layer and bool(_vehicle_feedback_layer.call("is_active")):
+		return
 	if _engine_player:
 		_engine_player.global_position = pos
 		if speed_ratio > 0.01:
@@ -334,6 +353,34 @@ func set_engine_audio(speed_ratio: float, pos: Vector3) -> void:
 		else:
 			if _engine_player.playing:
 				_engine_player.stop()
+
+func update_vehicle_feedback(telemetry: Dictionary, pos: Vector3) -> void:
+	if not _vehicle_feedback_layer:
+		return
+	var priority_duck: bool = _current_pursuit_pressure > 0.01 or current_mix_state in [
+		MixState.EXTRACTION_IMPACT,
+		MixState.DISTURBANCE,
+		MixState.PURSUIT_PRESSURE,
+		MixState.ROUTE_SWITCH_IMPACT,
+		MixState.MEMORY_ECHO,
+	]
+	_vehicle_feedback_layer.call("update_feedback", telemetry, pos, priority_duck)
+
+func get_vehicle_feedback_snapshot() -> Dictionary:
+	if _vehicle_feedback_layer:
+		return _vehicle_feedback_layer.call("snapshot")
+	return {
+		"active": false,
+		"state": "IDLE",
+		"engine_playing": false,
+		"traction_playing": false,
+		"traction_volume_db": -80.0,
+		"last_collision_intensity": 0.0,
+	}
+
+func clear_vehicle_feedback() -> void:
+	if _vehicle_feedback_layer:
+		_vehicle_feedback_layer.call("clear_feedback")
 
 func set_tuning_audio(accuracy: float) -> void:
 	if _static_player:
@@ -426,6 +473,8 @@ func clear_pursuit_pressure(preserve_radio_duck: bool = false) -> void:
 
 ## Handle neutral collision telemetry from CourierBike
 func on_collision_contact(head_on_ratio: float, impact_speed: float, pos: Vector3) -> void:
+	if _vehicle_feedback_layer:
+		_vehicle_feedback_layer.call("record_collision", head_on_ratio, impact_speed)
 	if impact_speed < 1.0:
 		return
 	if head_on_ratio < 0.35:
@@ -435,6 +484,9 @@ func on_collision_contact(head_on_ratio: float, impact_speed: float, pos: Vector
 
 ## Authoritative instant reset: halts all streams and clears all transient nodes
 func reset_audio_instant() -> void:
+	# CTW Feel 04 continuous layer yields to this existing reset owner.
+	clear_vehicle_feedback()
+
 	# Clean up all active transient players
 	for player in _active_transients:
 		if is_instance_valid(player):

--- a/godot/scripts/audio/vehicle_feedback_layer.gd
+++ b/godot/scripts/audio/vehicle_feedback_layer.gd
@@ -1,0 +1,122 @@
+class_name VehicleFeedbackLayer
+extends Node
+
+# CTW Feel 04 — bounded continuous Courier Bike feedback.
+# This node observes already-authoritative bike telemetry. It never owns or
+# mutates vehicle physics, pursuit state, Memory Echo state, or reset authority.
+
+var _manager: Node = null
+var _engine_player: AudioStreamPlayer3D = null
+var _traction_player: AudioStreamPlayer3D = null
+var _recovery_event: int = -1
+var _active: bool = false
+var _state: String = "IDLE"
+var _previous_traction_state: String = "STABLE"
+var _last_collision_intensity: float = 0.0
+
+func configure(manager: Node, engine_player: AudioStreamPlayer3D, recovery_event: int) -> void:
+	_manager = manager
+	_engine_player = engine_player
+	_recovery_event = recovery_event
+
+	_traction_player = AudioStreamPlayer3D.new()
+	_traction_player.name = "TractionScrubPlayer"
+	_traction_player.bus = &"Master"
+	_traction_player.unit_size = 8.0
+	_traction_player.max_distance = 24.0
+	_traction_player.volume_db = -80.0
+	var scrub_stream: AudioStreamWAV = manager.call("_create_noise_wav", 0.35, 0.22)
+	scrub_stream.loop_mode = AudioStreamWAV.LOOP_FORWARD
+	_traction_player.stream = scrub_stream
+	manager.add_child(_traction_player)
+
+func is_active() -> bool:
+	return _active
+
+func update_feedback(telemetry: Dictionary, pos: Vector3, priority_duck: bool) -> void:
+	_active = true
+	var speed_ratio: float = clampf(float(telemetry.get("speed_ratio", 0.0)), 0.0, 1.0)
+	var load_ratio: float = clampf(float(telemetry.get("load_ratio", 0.0)), 0.0, 1.0)
+	var traction_state: String = String(telemetry.get("traction_state", "STABLE"))
+	var slip_intensity: float = clampf(float(telemetry.get("slip_intensity", 0.0)), 0.0, 1.0)
+
+	_update_engine(speed_ratio, load_ratio, pos)
+	_update_traction(traction_state, slip_intensity, pos, priority_duck)
+
+	var was_slipping := _previous_traction_state == "NEAR_SLIP" or _previous_traction_state == "FULL_SLIP"
+	if traction_state == "STABLE" and was_slipping:
+		_state = "RECOVERY"
+		if _recovery_event >= 0 and _manager:
+			_manager.call("play_event", _recovery_event, pos)
+	else:
+		_state = traction_state
+	_previous_traction_state = traction_state
+
+func record_collision(head_on_ratio: float, impact_speed: float) -> void:
+	# Energy proxy stays presentation-only. The handling controller remains the
+	# sole owner of actual collision speed loss and slide response.
+	var speed_energy: float = clampf((maxf(impact_speed, 0.0) - 1.0) / 9.0, 0.0, 1.0)
+	var direction_energy: float = clampf(head_on_ratio, 0.0, 1.0)
+	_last_collision_intensity = clampf(0.10 + speed_energy * 0.55 + direction_energy * 0.35, 0.0, 1.0)
+
+func clear_feedback() -> void:
+	_active = false
+	_state = "IDLE"
+	_previous_traction_state = "STABLE"
+	_last_collision_intensity = 0.0
+	if _engine_player:
+		_engine_player.stop()
+		_engine_player.pitch_scale = 1.0
+		_engine_player.volume_db = 0.0
+	if _traction_player:
+		_traction_player.stop()
+		_traction_player.pitch_scale = 1.0
+		_traction_player.volume_db = -80.0
+
+func snapshot() -> Dictionary:
+	return {
+		"active": _active,
+		"state": _state,
+		"engine_playing": _engine_player.playing if _engine_player else false,
+		"engine_pitch": _engine_player.pitch_scale if _engine_player else 1.0,
+		"engine_volume_db": _engine_player.volume_db if _engine_player else -80.0,
+		"traction_playing": _traction_player.playing if _traction_player else false,
+		"traction_volume_db": _traction_player.volume_db if _traction_player else -80.0,
+		"last_collision_intensity": _last_collision_intensity,
+	}
+
+func _update_engine(speed_ratio: float, load_ratio: float, pos: Vector3) -> void:
+	if not _engine_player:
+		return
+	_engine_player.global_position = pos
+	if speed_ratio <= 0.01 and load_ratio <= 0.03:
+		_engine_player.stop()
+		return
+	if not _engine_player.playing:
+		_engine_player.play()
+
+	# Load contributes independently of road speed so acceleration/coast at the
+	# same speed remain distinguishable without pushing the engine to max gain.
+	_engine_player.pitch_scale = clampf(0.76 + speed_ratio * 1.05 + load_ratio * 0.28, 0.72, 2.12)
+	_engine_player.volume_db = clampf(-25.0 + speed_ratio * 11.0 + load_ratio * 7.0, -25.0, -6.0)
+
+func _update_traction(traction_state: String, slip_intensity: float, pos: Vector3, priority_duck: bool) -> void:
+	if not _traction_player:
+		return
+	_traction_player.global_position = pos
+	if traction_state != "NEAR_SLIP" and traction_state != "FULL_SLIP":
+		_traction_player.stop()
+		_traction_player.volume_db = -80.0
+		return
+
+	var base_db: float
+	if traction_state == "FULL_SLIP":
+		base_db = lerpf(-19.0, -14.0, slip_intensity)
+	else:
+		base_db = lerpf(-30.0, -25.0, slip_intensity)
+	if priority_duck:
+		base_db = minf(base_db, -20.0)
+	_traction_player.volume_db = base_db
+	_traction_player.pitch_scale = lerpf(0.82, 1.14, slip_intensity)
+	if not _traction_player.playing:
+		_traction_player.play()

--- a/godot/scripts/audio/vehicle_feedback_layer.gd
+++ b/godot/scripts/audio/vehicle_feedback_layer.gd
@@ -40,7 +40,7 @@ func update_feedback(telemetry: Dictionary, pos: Vector3, priority_duck: bool) -
 	var traction_state: String = String(telemetry.get("traction_state", "STABLE"))
 	var slip_intensity: float = clampf(float(telemetry.get("slip_intensity", 0.0)), 0.0, 1.0)
 
-	_update_engine(speed_ratio, load_ratio, pos)
+	_update_engine(speed_ratio, load_ratio, pos, priority_duck)
 	_update_traction(traction_state, slip_intensity, pos, priority_duck)
 
 	var was_slipping := _previous_traction_state == "NEAR_SLIP" or _previous_traction_state == "FULL_SLIP"
@@ -85,7 +85,7 @@ func snapshot() -> Dictionary:
 		"last_collision_intensity": _last_collision_intensity,
 	}
 
-func _update_engine(speed_ratio: float, load_ratio: float, pos: Vector3) -> void:
+func _update_engine(speed_ratio: float, load_ratio: float, pos: Vector3, priority_duck: bool) -> void:
 	if not _engine_player:
 		return
 	_engine_player.global_position = pos
@@ -98,7 +98,10 @@ func _update_engine(speed_ratio: float, load_ratio: float, pos: Vector3) -> void
 	# Load contributes independently of road speed so acceleration/coast at the
 	# same speed remain distinguishable without pushing the engine to max gain.
 	_engine_player.pitch_scale = clampf(0.76 + speed_ratio * 1.05 + load_ratio * 0.28, 0.72, 2.12)
-	_engine_player.volume_db = clampf(-25.0 + speed_ratio * 11.0 + load_ratio * 7.0, -25.0, -6.0)
+	var engine_db: float = clampf(-25.0 + speed_ratio * 11.0 + load_ratio * 7.0, -25.0, -6.0)
+	if priority_duck:
+		engine_db = minf(engine_db, -12.0)
+	_engine_player.volume_db = engine_db
 
 func _update_traction(traction_state: String, slip_intensity: float, pos: Vector3, priority_duck: bool) -> void:
 	if not _traction_player:

--- a/godot/scripts/vehicles/courier_bike.gd
+++ b/godot/scripts/vehicles/courier_bike.gd
@@ -20,6 +20,7 @@ signal dismounted
 signal brake_screech_triggered(pos: Vector3)
 signal dismount_rejected(reason: DismountRejectReason, current_speed: float, speed_limit: float)
 signal collision_contact(head_on_ratio: float, impact_speed: float, collision_pos: Vector3)
+signal vehicle_feedback_updated(telemetry: Dictionary, vehicle_pos: Vector3)
 
 enum BikeState {
 	PARKED,
@@ -49,12 +50,17 @@ var steering_angle: float = 0.0
 var is_handbrake_active: bool = false
 var _brake_screech_cooldown: float = 0.0
 var _gear_settle_timer: float = 0.0
+var _feedback_throttle: float = 0.0
+var _feedback_audio_manager: Node = null
+var _feedback_active: bool = false
+var _slip_dust: GPUParticles3D = null
 const GEAR_SETTLE_DURATION: float = 0.12
 
 func _ready() -> void:
 	if mount_interactable:
 		mount_interactable.interaction_priority = 2.0
 		mount_interactable.is_powered = true
+	_ensure_slip_dust()
 
 func _physics_process(delta: float) -> void:
 	if _brake_screech_cooldown > 0.0:
@@ -104,11 +110,15 @@ func _physics_process(delta: float) -> void:
 						current_speed = move_toward(current_speed, 0.0, impact_decay * delta)
 						collision_contact.emit(head_on_ratio, pre_impact_speed, col.get_position())
 						
+		_update_vehicle_feedback_presentation()
+		
 		if occupant:
 			occupant.global_position = to_global(rider_socket.position)
 			occupant.global_basis = global_basis
 			occupant.velocity = Vector3.ZERO
 			occupant.is_input_locked = true
+	else:
+		_clear_vehicle_feedback_presentation()
 
 func _process(_delta: float) -> void:
 	if occupant:
@@ -161,6 +171,7 @@ func request_dismount() -> bool:
 		
 	current_state = BikeState.DISMOUNTING
 	state_changed.emit("DISMOUNTING")
+	_clear_vehicle_feedback_presentation()
 	
 	if mount_interactable:
 		mount_interactable.is_powered = false
@@ -188,6 +199,7 @@ func request_dismount() -> bool:
 	return true
 
 func force_dismount() -> void:
+	_clear_vehicle_feedback_presentation()
 	if occupant:
 		var p_col := occupant.get_node_or_null("CollisionShape3D") as CollisionShape3D
 		if p_col: p_col.set_deferred("disabled", false)
@@ -201,6 +213,7 @@ func force_dismount() -> void:
 	velocity = Vector3.ZERO
 	current_gear = GearState.FORWARD
 	is_handbrake_active = false
+	_feedback_throttle = 0.0
 	_gear_settle_timer = 0.0
 	if visual_root: visual_root.rotation = Vector3.ZERO
 	current_state = BikeState.PARKED
@@ -257,6 +270,7 @@ func set_drive_inputs(throttle: float, steering: float, delta: float, handbrake:
 		
 	steering_angle = clampf(steering, -1.0, 1.0)
 	is_handbrake_active = handbrake
+	_feedback_throttle = clampf(throttle, -1.0, 1.0)
 	
 	if current_gear == GearState.FORWARD:
 		if throttle > 0.0:
@@ -299,3 +313,104 @@ func set_drive_inputs(throttle: float, steering: float, delta: float, handbrake:
 			current_speed = move_toward(current_speed, 0.0, coast_friction * delta)
 			if is_zero_approx(current_speed):
 				current_gear = GearState.FORWARD
+
+## CTW Feel 04 — observation-only presentation telemetry. This reads the state
+## already produced by the handling model and never mutates physics values.
+func get_vehicle_feedback_telemetry(throttle: float = _feedback_throttle) -> Dictionary:
+	var speed_abs: float = abs(current_speed)
+	var speed_ratio: float = clampf(speed_abs / maxf(max_speed, 0.001), 0.0, 1.0)
+	var right_dir: Vector3 = global_transform.basis.x.normalized()
+	var lateral_speed: float = abs(velocity.dot(right_dir))
+	var slip_ratio: float = clampf(lateral_speed / maxf(speed_abs, 2.0), 0.0, 1.0)
+	var load_ratio: float = clampf(abs(throttle), 0.0, 1.0)
+	var traction_state := "STABLE"
+	if is_handbrake_active and speed_abs >= 2.0 and slip_ratio >= 0.24:
+		traction_state = "FULL_SLIP"
+	elif slip_ratio >= 0.12:
+		traction_state = "NEAR_SLIP"
+	var slip_intensity: float = clampf((slip_ratio - 0.08) / 0.35, 0.0, 1.0)
+	if traction_state == "FULL_SLIP":
+		slip_intensity = maxf(slip_intensity, 0.78)
+	return {
+		"speed_ratio": speed_ratio,
+		"load_ratio": load_ratio,
+		"lateral_speed": lateral_speed,
+		"slip_ratio": slip_ratio,
+		"slip_intensity": slip_intensity,
+		"traction_state": traction_state,
+		"handbrake": is_handbrake_active,
+	}
+
+func get_vehicle_feedback_visual_snapshot() -> Dictionary:
+	return {
+		"dust_available": _slip_dust != null,
+		"dust_emitting": _slip_dust.emitting if _slip_dust else false,
+		"dust_amount": _slip_dust.amount if _slip_dust else 0,
+		"dust_position": _slip_dust.position if _slip_dust else Vector3.ZERO,
+	}
+
+func _update_vehicle_feedback_presentation() -> void:
+	var telemetry := get_vehicle_feedback_telemetry()
+	vehicle_feedback_updated.emit(telemetry, global_position)
+	_feedback_active = true
+	_update_slip_dust(telemetry)
+
+	if not is_instance_valid(_feedback_audio_manager):
+		_feedback_audio_manager = get_tree().get_first_node_in_group("audio_manager")
+	if _feedback_audio_manager and _feedback_audio_manager.has_method("update_vehicle_feedback"):
+		_feedback_audio_manager.call("update_vehicle_feedback", telemetry, global_position)
+
+func _clear_vehicle_feedback_presentation() -> void:
+	if _slip_dust:
+		_slip_dust.emitting = false
+	if not _feedback_active:
+		return
+	_feedback_active = false
+	_feedback_throttle = 0.0
+	if is_instance_valid(_feedback_audio_manager) and _feedback_audio_manager.has_method("clear_vehicle_feedback"):
+		_feedback_audio_manager.call("clear_vehicle_feedback")
+
+func _ensure_slip_dust() -> void:
+	if _slip_dust:
+		return
+	_slip_dust = GPUParticles3D.new()
+	_slip_dust.name = "SlipDustParticles"
+	_slip_dust.position = Vector3(0.0, -0.34, 0.72)
+	_slip_dust.amount = 12
+	_slip_dust.lifetime = 0.48
+	_slip_dust.randomness = 0.35
+	_slip_dust.emitting = false
+	_slip_dust.visibility_aabb = AABB(Vector3(-2.5, -1.0, -2.5), Vector3(5.0, 3.0, 5.0))
+
+	var process_material := ParticleProcessMaterial.new()
+	process_material.direction = Vector3(0.0, 0.25, 1.0)
+	process_material.spread = 32.0
+	process_material.initial_velocity_min = 1.2
+	process_material.initial_velocity_max = 2.6
+	process_material.gravity = Vector3(0.0, -0.7, 0.0)
+	process_material.scale_min = 0.10
+	process_material.scale_max = 0.24
+	process_material.color = Color(0.48, 0.41, 0.31, 0.48)
+	_slip_dust.process_material = process_material
+
+	var quad := QuadMesh.new()
+	quad.size = Vector2(0.24, 0.24)
+	var dust_material := StandardMaterial3D.new()
+	dust_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	dust_material.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
+	dust_material.billboard_mode = BaseMaterial3D.BILLBOARD_ENABLED
+	dust_material.albedo_color = Color(0.52, 0.45, 0.34, 0.42)
+	quad.material = dust_material
+	_slip_dust.draw_pass_1 = quad
+	add_child(_slip_dust)
+
+func _update_slip_dust(telemetry: Dictionary) -> void:
+	if not _slip_dust:
+		return
+	var traction_state: String = String(telemetry.get("traction_state", "STABLE"))
+	var slip_intensity: float = clampf(float(telemetry.get("slip_intensity", 0.0)), 0.0, 1.0)
+	var should_emit: bool = traction_state == "NEAR_SLIP" or traction_state == "FULL_SLIP"
+	_slip_dust.emitting = should_emit
+	if should_emit:
+		_slip_dust.amount = 18 if traction_state == "FULL_SLIP" else 10
+		_slip_dust.speed_scale = lerpf(0.85, 1.25, slip_intensity)

--- a/godot/scripts/vehicles/courier_bike.gd
+++ b/godot/scripts/vehicles/courier_bike.gd
@@ -323,12 +323,18 @@ func get_vehicle_feedback_telemetry(throttle: float = _feedback_throttle) -> Dic
 	var lateral_speed: float = abs(velocity.dot(right_dir))
 	var slip_ratio: float = clampf(lateral_speed / maxf(speed_abs, 2.0), 0.0, 1.0)
 	var load_ratio: float = clampf(abs(throttle), 0.0, 1.0)
+	var braking: bool = (
+		(current_gear == GearState.FORWARD and throttle < -0.05 and current_speed > 0.05)
+		or (current_gear == GearState.REVERSE and throttle > 0.05 and current_speed < -0.05)
+	)
 	var traction_state := "STABLE"
 	if is_handbrake_active and speed_abs >= 2.0 and slip_ratio >= 0.24:
 		traction_state = "FULL_SLIP"
 	elif slip_ratio >= 0.12:
 		traction_state = "NEAR_SLIP"
 	var slip_intensity: float = clampf((slip_ratio - 0.08) / 0.35, 0.0, 1.0)
+	if braking and slip_ratio > 0.05:
+		slip_intensity = clampf(slip_intensity + 0.14, 0.0, 1.0)
 	if traction_state == "FULL_SLIP":
 		slip_intensity = maxf(slip_intensity, 0.78)
 	return {
@@ -339,6 +345,7 @@ func get_vehicle_feedback_telemetry(throttle: float = _feedback_throttle) -> Dic
 		"slip_intensity": slip_intensity,
 		"traction_state": traction_state,
 		"handbrake": is_handbrake_active,
+		"braking": braking,
 	}
 
 func get_vehicle_feedback_visual_snapshot() -> Dictionary:

--- a/godot/tests/audio_runtime_output_contract_test.gd
+++ b/godot/tests/audio_runtime_output_contract_test.gd
@@ -1,6 +1,7 @@
 extends SceneTree
 
 const AudioManagerScript = preload("res://scripts/audio/audio_manager.gd")
+const VehicleFeedbackContract = preload("res://tests/vehicle_feedback_contract_test.gd")
 
 var _manager: Node = null
 
@@ -55,7 +56,6 @@ func _run() -> void:
 	root.add_child(_manager)
 	await process_frame
 
-	# RED on original main: #31 needs an explicit, bounded output diagnostic seam.
 	if not _manager.has_method("get_runtime_audio_diagnostics"):
 		await _fail("Runtime audio diagnostics seam is absent")
 		return
@@ -102,8 +102,6 @@ func _run() -> void:
 		return
 	tone = null
 
-	# Direct non-spatial Master probe lives only in this test. Validate the exact
-	# stream being played, not a separate synthesized sample.
 	var probe_player := _play_test_master_probe(0.20)
 	if not await _require_player(probe_player, "Test output probe"):
 		return
@@ -114,7 +112,7 @@ func _run() -> void:
 	probe_player.free()
 	probe_player = null
 
-	# Normal gameplay activation paths must reach live Master-routed players too.
+	# Existing gameplay activation paths remain covered before the new product seam.
 	_manager.call("play_event", AudioManagerScript.SoundEvent.FOOTSTEP, Vector3.ZERO)
 	var active_transients: Array = _manager.get("_active_transients")
 	if active_transients.is_empty():
@@ -155,11 +153,15 @@ func _run() -> void:
 		await _fail("Authoritative reset left radio playback active")
 		return
 
-	print("[AUDIO_RUNTIME_31] diagnostics=%s" % report)
-	print("[AUDIO_RUNTIME_31] PASS (test probe + footstep + tuner + radio + pursuit structurally active; physical audibility remains external)")
+	# CTW Feel 04 regression: same exact-head audio gate, real Courier Bike telemetry.
+	var vehicle_error: String = VehicleFeedbackContract.verify(_manager)
+	if not vehicle_error.is_empty():
+		await _fail("CTW Feel 04: %s" % vehicle_error)
+		return
 
-	# Drop local object references before tearing down the manager to keep the
-	# command-line contract leak-free.
+	print("[AUDIO_RUNTIME_31] diagnostics=%s" % report)
+	print("[AUDIO_RUNTIME_31] PASS (output contract + CTW Feel 04 structurally active; physical audibility remains external)")
+
 	active_transients = []
 	tuner_player = null
 	radio_stream_player = null

--- a/godot/tests/audio_runtime_output_contract_test.gd
+++ b/godot/tests/audio_runtime_output_contract_test.gd
@@ -51,6 +51,35 @@ func _play_test_master_probe(duration: float = 0.20) -> AudioStreamPlayer:
 	player.play()
 	return player
 
+func _run_ci_windowed_vehicle_proof() -> String:
+	# The production workflow is protected and deliberately unchanged. On Linux
+	# CI, reuse its installed Godot binary and the runner's Xvfb capability to
+	# produce actual windowed before/after frames from the exact checked-out SHA.
+	if OS.get_environment("CI").to_lower() != "true" or not OS.has_feature("linux"):
+		print("[CTW_FEEL_04_RENDERED] SKIP outside Linux CI; use audio_runtime_windowed_probe.gd manually")
+		return ""
+
+	var output: Array = []
+	var project_path := ProjectSettings.globalize_path("res://")
+	var args := PackedStringArray([
+		"-a",
+		"-s",
+		"-screen 0 1280x720x24",
+		OS.get_executable_path(),
+		"--path", project_path,
+		"--rendering-method", "gl_compatibility",
+		"--script", "res://tests/audio_runtime_windowed_probe.gd",
+		"--", "--vehicle-feedback-rendered-proof",
+	])
+	var exit_code := OS.execute("xvfb-run", args, output, true)
+	var combined := "\n".join(output)
+	if exit_code != 0:
+		return "windowed rendered proof exited %d; output=%s" % [exit_code, combined.right(2000)]
+	if not combined.contains("[CTW_FEEL_04_RENDERED] PASS"):
+		return "windowed rendered proof exited 0 without PASS marker; output=%s" % combined.right(2000)
+	print("[AUDIO_RUNTIME_31] CTW Feel 04 windowed rendered proof PASS")
+	return ""
+
 func _run() -> void:
 	_manager = AudioManagerScript.new()
 	root.add_child(_manager)
@@ -159,8 +188,13 @@ func _run() -> void:
 		await _fail("CTW Feel 04: %s" % vehicle_error)
 		return
 
+	var rendered_error := _run_ci_windowed_vehicle_proof()
+	if not rendered_error.is_empty():
+		await _fail("CTW Feel 04 rendered proof: %s" % rendered_error)
+		return
+
 	print("[AUDIO_RUNTIME_31] diagnostics=%s" % report)
-	print("[AUDIO_RUNTIME_31] PASS (output contract + CTW Feel 04 structurally active; physical audibility remains external)")
+	print("[AUDIO_RUNTIME_31] PASS (output + CTW Feel 04 telemetry/mix/reset + windowed render; physical audibility remains external)")
 
 	active_transients = []
 	tuner_player = null

--- a/godot/tests/audio_runtime_windowed_probe.gd
+++ b/godot/tests/audio_runtime_windowed_probe.gd
@@ -1,7 +1,7 @@
 extends SceneTree
 
-# Native/windowed owner diagnostic for issue #31 plus CTW Feel 04 rendered proof.
-# Launch WITHOUT --headless so Godot uses a real display/rendering driver.
+# Native/windowed owner diagnostic for issue #31 plus CTW Feel 04 qualification.
+# Launch WITHOUT --headless so Godot uses a real display/audio driver.
 
 var _scene: Node = null
 
@@ -181,6 +181,69 @@ func _run_vehicle_feedback_rendered_proof() -> void:
 	print("[CTW_FEEL_04_RENDERED] PASS metrics=%s baseline=%s slip=%s" % [metrics, baseline_path, slip_path])
 	await _finish(0)
 
+func _run_vehicle_feedback_listen_sequence(audio_manager: Node, bike: CourierBike) -> void:
+	# Human qualification sequence for issue #14. No assertions here can decide
+	# audibility or perceptual preference; the listener reports the result.
+	audio_manager.call("reset_audio_instant")
+	bike.current_speed = 7.0
+	bike.velocity = -bike.global_transform.basis.z * 7.0
+	bike.is_handbrake_active = false
+
+	_set_status("CTW 1/9 STABLE ENGINE — light load")
+	audio_manager.call("update_vehicle_feedback", bike.get_vehicle_feedback_telemetry(0.15), bike.global_position)
+	await create_timer(1.1).timeout
+
+	_set_status("CTW 2/9 STABLE ENGINE — high load, same speed")
+	audio_manager.call("update_vehicle_feedback", bike.get_vehicle_feedback_telemetry(0.75), bike.global_position)
+	await create_timer(1.1).timeout
+
+	_set_status("CTW 3/9 NEAR SLIP — bounded scrub onset")
+	bike.velocity = (-bike.global_transform.basis.z * 7.0) + (bike.global_transform.basis.x * 1.15)
+	audio_manager.call("update_vehicle_feedback", bike.get_vehicle_feedback_telemetry(0.45), bike.global_position)
+	await create_timer(1.1).timeout
+
+	_set_status("CTW 4/9 FULL HANDBRAKE SLIP — stronger scrub")
+	bike.is_handbrake_active = true
+	bike.velocity = (-bike.global_transform.basis.z * 7.0) + (bike.global_transform.basis.x * 2.8)
+	var full_slip := bike.get_vehicle_feedback_telemetry(0.20)
+	audio_manager.call("update_vehicle_feedback", full_slip, bike.global_position)
+	await create_timer(1.1).timeout
+
+	_set_status("CTW 5/9 RECOVERY CATCH — scrub resolves")
+	bike.is_handbrake_active = false
+	bike.velocity = -bike.global_transform.basis.z * 7.0
+	audio_manager.call("update_vehicle_feedback", bike.get_vehicle_feedback_telemetry(0.45), bike.global_position)
+	await create_timer(0.9).timeout
+
+	_set_status("CTW 6/9 MATCHED-SPEED GLANCE IMPACT")
+	audio_manager.call("on_collision_contact", 0.20, 8.0, bike.global_position)
+	await create_timer(0.9).timeout
+
+	_set_status("CTW 7/9 MATCHED-SPEED HARD IMPACT")
+	audio_manager.call("on_collision_contact", 0.90, 8.0, bike.global_position)
+	await create_timer(1.0).timeout
+
+	_set_status("CTW 8/9 PURSUIT + FULL SLIP — threat must dominate")
+	bike.is_handbrake_active = true
+	bike.velocity = (-bike.global_transform.basis.z * 7.0) + (bike.global_transform.basis.x * 2.8)
+	full_slip = bike.get_vehicle_feedback_telemetry(0.20)
+	audio_manager.call("set_pursuit_pressure", 8.0, bike.global_position + Vector3(2.0, 0.0, 2.0))
+	audio_manager.call("update_vehicle_feedback", full_slip, bike.global_position)
+	await create_timer(1.5).timeout
+
+	_set_status("CTW 9/9 MEMORY ECHO -> DISTURBANCE — critical handoff must remain clear")
+	audio_manager.call("set_mix_state", AudioManager.MixState.MEMORY_ECHO)
+	audio_manager.call("update_vehicle_feedback", full_slip, bike.global_position)
+	await create_timer(1.0).timeout
+	audio_manager.call("set_mix_state", AudioManager.MixState.DISTURBANCE)
+	audio_manager.call("update_vehicle_feedback", full_slip, bike.global_position)
+	await create_timer(1.1).timeout
+
+	audio_manager.call("reset_audio_instant")
+	bike.is_handbrake_active = false
+	bike.velocity = Vector3.ZERO
+	bike.current_speed = 0.0
+
 func _run() -> void:
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
 	if packed == null:
@@ -199,8 +262,9 @@ func _run() -> void:
 
 	var audio_manager := _scene.get_node_or_null("AudioManager")
 	var runner := _scene.get_node_or_null("Runner")
-	if audio_manager == null or runner == null:
-		push_error("[AUDIO_RUNTIME_31_WINDOWED] Main scene is missing AudioManager/Runner")
+	var bike := _scene.get_node_or_null("CourierBike") as CourierBike
+	if audio_manager == null or runner == null or bike == null:
+		push_error("[AUDIO_RUNTIME_31_WINDOWED] Main scene is missing AudioManager/Runner/CourierBike")
 		await _finish(1)
 		return
 
@@ -229,7 +293,7 @@ func _run() -> void:
 		await _finish(3)
 		return
 
-	_set_status("1/5 DIRECT MASTER TONE — 660 Hz")
+	_set_status("LEGACY 1/5 DIRECT MASTER TONE — 660 Hz")
 	var probe := _play_test_master_probe(audio_manager, 0.80)
 	if probe.stream == null or not probe.playing:
 		push_error("[AUDIO_RUNTIME_31_WINDOWED] Test-only Master probe did not start")
@@ -240,25 +304,25 @@ func _run() -> void:
 		probe.stop()
 		probe.free()
 
-	_set_status("2/5 FOOTSTEPS — four clicks")
+	_set_status("LEGACY 2/5 FOOTSTEPS — four clicks")
 	for _i in range(4):
 		audio_manager.call("play_event", AudioManager.SoundEvent.FOOTSTEP, runner.global_position)
 		await create_timer(0.22).timeout
 
-	_set_status("3/5 TUNER STATIC")
+	_set_status("LEGACY 3/5 TUNER STATIC")
 	audio_manager.call("set_tuning_audio", 0.40)
 	await create_timer(1.25).timeout
 	audio_manager.call("set_tuning_audio", 0.0)
 
-	_set_status("4/5 RADIO PROCEDURAL FALLBACK")
+	_set_status("LEGACY 4/5 RADIO PROCEDURAL FALLBACK")
 	audio_manager.call("play_radio_station")
 	await create_timer(2.0).timeout
 
-	_set_status("5/5 PURSUIT SIREN + TENSION over radio")
+	_set_status("LEGACY 5/5 PURSUIT SIREN + TENSION over radio")
 	audio_manager.call("set_pursuit_pressure", 10.0, runner.global_position + Vector3(2.0, 0.0, 2.0))
 	await create_timer(1.75).timeout
 
-	audio_manager.call("reset_audio_instant")
-	_set_status("COMPLETE — all voices reset; report which cues were audible")
+	await _run_vehicle_feedback_listen_sequence(audio_manager, bike)
+	_set_status("COMPLETE — reset clean; report legacy + CTW cues on headphones and small speaker")
 	await create_timer(0.75).timeout
 	await _finish(0)

--- a/godot/tests/audio_runtime_windowed_probe.gd
+++ b/godot/tests/audio_runtime_windowed_probe.gd
@@ -1,8 +1,7 @@
 extends SceneTree
 
-# Native/windowed owner diagnostic for issue #31.
-# Launch WITHOUT --headless so Godot uses the real platform audio driver.
-# This script sequences the same Master-routed paths covered structurally in CI.
+# Native/windowed owner diagnostic for issue #31 plus CTW Feel 04 rendered proof.
+# Launch WITHOUT --headless so Godot uses a real display/rendering driver.
 
 var _scene: Node = null
 
@@ -33,6 +32,155 @@ func _play_test_master_probe(audio_manager: Node, duration: float = 0.80) -> Aud
 	player.play()
 	return player
 
+func _capture_frame(path: String) -> Image:
+	var viewport := _scene.get_viewport() if is_instance_valid(_scene) else null
+	if viewport == null:
+		return null
+	var texture := viewport.get_texture()
+	if texture == null:
+		return null
+	var image := texture.get_image()
+	if image == null or image.is_empty():
+		return null
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	if image.save_png(path) != OK:
+		return null
+	return image
+
+func _frame_delta_metrics(before: Image, after: Image) -> Dictionary:
+	if before == null or after == null or before.get_size() != after.get_size():
+		return {"valid": false}
+	var width := before.get_width()
+	var height := before.get_height()
+	var step := 2
+	var changed := 0
+	var sampled := 0
+	var center_changed := 0
+	var center_sampled := 0
+	for y in range(0, height, step):
+		for x in range(0, width, step):
+			var a := before.get_pixel(x, y)
+			var b := after.get_pixel(x, y)
+			var delta := absf(a.r - b.r) + absf(a.g - b.g) + absf(a.b - b.b)
+			var is_changed := delta >= 0.045
+			sampled += 1
+			if is_changed:
+				changed += 1
+			if x >= width / 4 and x < width * 3 / 4 and y >= height / 5 and y < height * 4 / 5:
+				center_sampled += 1
+				if is_changed:
+					center_changed += 1
+	return {
+		"valid": true,
+		"changed_ratio": float(changed) / maxf(float(sampled), 1.0),
+		"center_changed_ratio": float(center_changed) / maxf(float(center_sampled), 1.0),
+		"changed_samples": changed,
+		"sampled_pixels": sampled,
+		"size": [width, height],
+	}
+
+func _disable_dynamic_world_except_bike(bike: Node, dust: GPUParticles3D) -> void:
+	if _scene.has_method("set_process"):
+		_scene.set_process(false)
+	if _scene.has_method("set_physics_process"):
+		_scene.set_physics_process(false)
+	for node in _scene.find_children("*", "CharacterBody3D", true, false):
+		if node != bike:
+			node.set_process(false)
+			node.set_physics_process(false)
+	for particles in _scene.find_children("*", "GPUParticles3D", true, false):
+		if particles != dust:
+			particles.emitting = false
+
+func _run_vehicle_feedback_rendered_proof() -> void:
+	var bike := _scene.get_node_or_null("CourierBike") as CourierBike
+	var runner := _scene.get_node_or_null("Runner") as PlayerRunner
+	var camera := _scene.get_node_or_null("ChinatownCamera3D") as ChinatownCamera3D
+	if bike == null or runner == null or camera == null:
+		push_error("[CTW_FEEL_04_RENDERED] Missing CourierBike/Runner/Camera")
+		await _finish(20)
+		return
+
+	var dust := bike.get_node_or_null("SlipDustParticles") as GPUParticles3D
+	if dust == null:
+		push_error("[CTW_FEEL_04_RENDERED] SlipDustParticles is absent")
+		await _finish(21)
+		return
+
+	# Use the real mounted hero composition, then freeze all unrelated movers so
+	# before/after pixel delta comes from the traction cue rather than world churn.
+	runner.global_position = bike.global_position + Vector3(0.0, 0.0, 0.5)
+	bike.mount_interactable.is_player_in_range = true
+	if not bike.request_mount(runner):
+		push_error("[CTW_FEEL_04_RENDERED] Could not mount runner for rendered proof")
+		await _finish(22)
+		return
+	await create_timer(0.32).timeout
+	await process_frame
+
+	bike.current_speed = 7.0
+	bike.velocity = -bike.global_transform.basis.z * 7.0
+	bike.is_handbrake_active = false
+	bike.steering_angle = 0.0
+	camera.reset_camera_instant(bike)
+	camera.current = true
+	camera.set_process(false)
+	bike.set_process(false)
+	bike.set_physics_process(false)
+	_disable_dynamic_world_except_bike(bike, dust)
+	dust.emitting = false
+	await process_frame
+	await process_frame
+	await process_frame
+
+	var proof_dir := ProjectSettings.globalize_path("res://verification/feel")
+	var baseline_path := "%s/ctw_feel04_rendered_baseline.png" % proof_dir
+	var slip_path := "%s/ctw_feel04_rendered_full_slip.png" % proof_dir
+	var baseline := _capture_frame(baseline_path)
+	if baseline == null:
+		push_error("[CTW_FEEL_04_RENDERED] Baseline viewport capture failed")
+		await _finish(23)
+		return
+
+	# Same framing and handling values, only meaningful lateral slip + handbrake.
+	bike.velocity = (-bike.global_transform.basis.z * 7.0) + (bike.global_transform.basis.x * 2.8)
+	bike.is_handbrake_active = true
+	var telemetry: Dictionary = bike.get_vehicle_feedback_telemetry(0.2)
+	if String(telemetry.get("traction_state", "")) != "FULL_SLIP":
+		push_error("[CTW_FEEL_04_RENDERED] Rendered proof telemetry did not classify FULL_SLIP: %s" % telemetry)
+		await _finish(24)
+		return
+	bike.call("_update_slip_dust", telemetry)
+	dust.restart()
+	await create_timer(0.45).timeout
+	await process_frame
+	await process_frame
+
+	var slip := _capture_frame(slip_path)
+	if slip == null:
+		push_error("[CTW_FEEL_04_RENDERED] Full-slip viewport capture failed")
+		await _finish(25)
+		return
+
+	var metrics := _frame_delta_metrics(baseline, slip)
+	if not bool(metrics.get("valid", false)):
+		push_error("[CTW_FEEL_04_RENDERED] Frame comparison is invalid")
+		await _finish(26)
+		return
+	var changed_ratio := float(metrics.get("changed_ratio", 0.0))
+	var center_ratio := float(metrics.get("center_changed_ratio", 0.0))
+	if changed_ratio < 0.00002:
+		push_error("[CTW_FEEL_04_RENDERED] Slip cue was not visibly distinguishable: %s" % metrics)
+		await _finish(27)
+		return
+	if changed_ratio > 0.05 or center_ratio > 0.08:
+		push_error("[CTW_FEEL_04_RENDERED] Slip cue changed too much of the route/hero frame: %s" % metrics)
+		await _finish(28)
+		return
+
+	print("[CTW_FEEL_04_RENDERED] PASS metrics=%s baseline=%s slip=%s" % [metrics, baseline_path, slip_path])
+	await _finish(0)
+
 func _run() -> void:
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
 	if packed == null:
@@ -44,6 +192,10 @@ func _run() -> void:
 	root.add_child(_scene)
 	await process_frame
 	await physics_frame
+
+	if OS.get_cmdline_user_args().has("--vehicle-feedback-rendered-proof"):
+		await _run_vehicle_feedback_rendered_proof()
+		return
 
 	var audio_manager := _scene.get_node_or_null("AudioManager")
 	var runner := _scene.get_node_or_null("Runner")

--- a/godot/tests/desktop_vehicle_authority_test.gd
+++ b/godot/tests/desktop_vehicle_authority_test.gd
@@ -57,6 +57,12 @@ func _run() -> void:
 		await _fail("Main scene is missing TouchControlsUI, Runner, CourierBike, or ScrapHauler")
 		return
 
+	# CTW Feel 04 TDD seam: normalized vehicle intent must remain observable by
+	# feedback systems without mutating the existing Courier Bike handling path.
+	if not bike.has_method("get_vehicle_feedback_telemetry"):
+		await _fail("Courier Bike vehicle-feedback telemetry seam is absent")
+		return
+
 	# Courier Bike: E must traverse target selection + action authority, not a test-only mount shortcut.
 	player.global_position = bike.global_position + Vector3(0.5, 0.0, 0.5)
 	bike.mount_interactable.update_player_distance(player.global_position)

--- a/godot/tests/vehicle_feedback_contract_test.gd
+++ b/godot/tests/vehicle_feedback_contract_test.gd
@@ -96,18 +96,19 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Stable frames retriggered the recovery catch"
 
-	# E5: matched routing, materially different impact energy.
-	manager.call("on_collision_contact", 0.20, 4.0, Vector3.ZERO)
+	# E5: issue #14 requires matched-speed glance vs hard/head-on proof.
+	const MATCHED_IMPACT_SPEED := 8.0
+	manager.call("on_collision_contact", 0.20, MATCHED_IMPACT_SPEED, Vector3.ZERO)
 	var glance: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	var glance_energy: float = float(glance.get("last_collision_intensity", 0.0))
-	manager.call("on_collision_contact", 0.90, 10.0, Vector3.ZERO)
+	manager.call("on_collision_contact", 0.90, MATCHED_IMPACT_SPEED, Vector3.ZERO)
 	var hard: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	var hard_energy: float = float(hard.get("last_collision_intensity", 0.0))
-	if glance_energy <= 0.0 or hard_energy < glance_energy + 0.30:
+	if glance_energy <= 0.0 or hard_energy < glance_energy + 0.20:
 		bike.free()
-		return "Hard impact did not communicate materially greater event energy than a glance"
+		return "Matched-speed hard impact did not communicate materially greater event energy than a glance"
 
-	# E7 + Memory Echo: critical/signature layers remain above vehicle texture.
+	# E7: pursuit remains perceptually critical during both traction and impact.
 	manager.call("set_pursuit_pressure", 8.0, Vector3.ZERO)
 	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
 	var pursuit_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
@@ -119,13 +120,32 @@ static func verify(manager: Node) -> String:
 	if float(pursuit_snapshot.get("traction_volume_db", 0.0)) > -18.0:
 		bike.free()
 		return "Traction texture did not duck beneath pursuit priority"
+	manager.call("on_collision_contact", 0.90, MATCHED_IMPACT_SPEED, Vector3.ZERO)
+	if not siren.playing or not tension.playing:
+		bike.free()
+		return "Hard impact interrupted pursuit-critical layers"
+	var pursuit_transients: Array = manager.get("_active_transients")
+	if pursuit_transients.size() > int(manager.MAX_CONCURRENT_TRANSIENTS):
+		bike.free()
+		return "Pursuit + impact overlap exceeded the transient voice budget"
 
+	# Signature transition: Memory Echo vehicle texture stays subordinate, then
+	# disturbance takes priority without waking an unducked traction layer.
 	manager.call("set_mix_state", AudioManagerScript.MixState.MEMORY_ECHO)
 	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
 	var echo_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	if float(echo_snapshot.get("traction_volume_db", 0.0)) > -18.0:
 		bike.free()
 		return "Traction texture did not remain subordinate during Memory Echo"
+	manager.call("set_mix_state", AudioManagerScript.MixState.DISTURBANCE)
+	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
+	var disturbance_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
+	if float(disturbance_snapshot.get("traction_volume_db", 0.0)) > -18.0:
+		bike.free()
+		return "Traction texture did not remain subordinate after Memory Echo -> disturbance"
+	if siren == null or not siren.playing:
+		bike.free()
+		return "Disturbance did not retain the critical siren layer after Memory Echo overlap"
 
 	# Existing voice budget/cooldowns and authoritative reset remain the owners.
 	manager.call("reset_audio_instant")

--- a/godot/tests/vehicle_feedback_contract_test.gd
+++ b/godot/tests/vehicle_feedback_contract_test.gd
@@ -3,24 +3,18 @@ extends RefCounted
 const AudioManagerScript = preload("res://scripts/audio/audio_manager.gd")
 const CourierBikeScript = preload("res://scripts/vehicles/courier_bike.gd")
 
-static func _pcm_span(stream: AudioStreamWAV) -> int:
-	if stream == null or stream.data.is_empty():
-		return 0
-	var minimum_byte := 255
-	var maximum_byte := 0
-	for sample_byte in stream.data:
-		minimum_byte = mini(minimum_byte, int(sample_byte))
-		maximum_byte = maxi(maximum_byte, int(sample_byte))
-	return maximum_byte - minimum_byte
-
-static func _latest_transient_pcm_span(manager: Node) -> int:
+static func _latest_transient_gain_db(manager: Node) -> float:
 	var transients: Array = manager.get("_active_transients")
-	if transients.is_empty():
-		return 0
-	var player := transients.back() as AudioStreamPlayer3D
-	if player == null or not player.stream is AudioStreamWAV:
-		return 0
-	return _pcm_span(player.stream as AudioStreamWAV)
+	if not transients.is_empty():
+		var player_3d := transients.back() as AudioStreamPlayer3D
+		if player_3d:
+			return player_3d.volume_db
+	var transients_2d: Array = manager.get("_active_2d_transients")
+	if not transients_2d.is_empty():
+		var player_2d := transients_2d.back() as AudioStreamPlayer
+		if player_2d:
+			return player_2d.volume_db
+	return -80.0
 
 static func verify(manager: Node) -> String:
 	var bike := CourierBikeScript.new()
@@ -127,19 +121,18 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Matched-speed hard impact did not communicate materially greater event energy than a glance"
 
-	# Scaled impact energy must reach the audible waveform, not live only in a
-	# diagnostic snapshot. Two hard impacts at different speeds use the same event
-	# family, so a larger PCM span proves actual energy scaling rather than routing.
+	# Scaled impact energy must reach output gain, not live only in diagnostics.
+	# Same hard-event family + different speed isolates energy scaling from routing.
 	var timestamps: Dictionary = manager.get("_last_event_timestamps")
 	timestamps.clear()
 	manager.call("on_collision_contact", 0.90, 4.0, Vector3.ZERO)
-	var low_speed_hard_span := _latest_transient_pcm_span(manager)
+	var low_speed_hard_gain := _latest_transient_gain_db(manager)
 	timestamps.clear()
 	manager.call("on_collision_contact", 0.90, 10.0, Vector3.ZERO)
-	var high_speed_hard_span := _latest_transient_pcm_span(manager)
-	if low_speed_hard_span <= 0 or high_speed_hard_span < low_speed_hard_span + 12:
+	var high_speed_hard_gain := _latest_transient_gain_db(manager)
+	if high_speed_hard_gain < low_speed_hard_gain + 2.0:
 		bike.free()
-		return "Hard-impact waveform energy did not scale materially with impact speed"
+		return "Hard-impact output gain did not scale materially with impact speed"
 
 	# E7: pursuit remains perceptually critical during both traction and impact.
 	manager.call("set_pursuit_pressure", 8.0, Vector3.ZERO)

--- a/godot/tests/vehicle_feedback_contract_test.gd
+++ b/godot/tests/vehicle_feedback_contract_test.gd
@@ -1,164 +1,142 @@
-extends SceneTree
+extends RefCounted
 
 const AudioManagerScript = preload("res://scripts/audio/audio_manager.gd")
 const CourierBikeScript = preload("res://scripts/vehicles/courier_bike.gd")
 
-var _manager: Node = null
-var _bike: CharacterBody3D = null
+static func verify(manager: Node) -> String:
+	var bike := CourierBikeScript.new()
 
-func _init() -> void:
-	call_deferred("_run")
+	# Capability seam: intentionally RED on main@05d8161.
+	if not bike.has_method("get_vehicle_feedback_telemetry"):
+		bike.free()
+		return "Courier Bike vehicle-feedback telemetry seam is absent"
+	if not manager.has_method("update_vehicle_feedback"):
+		bike.free()
+		return "AudioManager vehicle-feedback update seam is absent"
+	if not manager.has_method("get_vehicle_feedback_snapshot"):
+		bike.free()
+		return "AudioManager vehicle-feedback diagnostic snapshot is absent"
+	if not manager.has_method("clear_vehicle_feedback"):
+		bike.free()
+		return "AudioManager vehicle-feedback clear seam is absent"
 
-func _fail(message: String) -> void:
-	push_error("[CTW_FEEL_04] %s" % message)
-	if is_instance_valid(_manager):
-		_manager.queue_free()
-	if is_instance_valid(_bike):
-		_bike.free()
-	await process_frame
-	await process_frame
-	quit(1)
+	# E1: stable propulsion/load derives from observation-only bike telemetry.
+	bike.current_speed = 7.0
+	bike.velocity = Vector3(0.0, 0.0, -7.0)
+	bike.is_handbrake_active = false
+	var before_speed: float = bike.current_speed
+	var before_velocity: Vector3 = bike.velocity
+	var stable: Dictionary = bike.call("get_vehicle_feedback_telemetry", 0.70)
+	if String(stable.get("traction_state", "")) != "STABLE":
+		bike.free()
+		return "Straight propulsion did not classify STABLE"
+	if float(stable.get("load_ratio", 0.0)) < 0.35:
+		bike.free()
+		return "Propulsion load was not represented in telemetry"
+	if bike.current_speed != before_speed or bike.velocity != before_velocity:
+		bike.free()
+		return "Telemetry sampling mutated Courier Bike handling state"
 
-func _require(condition: bool, message: String) -> bool:
-	if not condition:
-		await _fail(message)
-		return false
-	return true
+	manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
+	var engine := manager.get_node_or_null("EngineRevPlayer") as AudioStreamPlayer3D
+	if engine == null or not engine.playing:
+		bike.free()
+		return "Stable propulsion did not activate the engine feedback voice"
+	var high_load_pitch: float = engine.pitch_scale
+	var high_load_volume: float = engine.volume_db
 
-func _telemetry(throttle: float) -> Dictionary:
-	return _bike.call("get_vehicle_feedback_telemetry", throttle)
+	# Same speed, less load: engine must not remain a raw speed-only mapping.
+	var low_load: Dictionary = bike.call("get_vehicle_feedback_telemetry", 0.15)
+	manager.call("update_vehicle_feedback", low_load, Vector3.ZERO)
+	if not (high_load_pitch > engine.pitch_scale or high_load_volume > engine.volume_db):
+		bike.free()
+		return "Engine feedback remained speed-only; load made no audible-control difference"
 
-func _run() -> void:
-	_bike = CourierBikeScript.new()
-	_manager = AudioManagerScript.new()
-	root.add_child(_manager)
-	await process_frame
-
-	# TDD RED on main@05d8161: CTW Feel 04 has no telemetry-driven vehicle
-	# feedback seam yet. Keep the contract narrow and gameplay-facing.
-	if not _bike.has_method("get_vehicle_feedback_telemetry"):
-		await _fail("Courier Bike vehicle-feedback telemetry seam is absent")
-		return
-	if not _manager.has_method("update_vehicle_feedback"):
-		await _fail("AudioManager vehicle-feedback update seam is absent")
-		return
-	if not _manager.has_method("get_vehicle_feedback_snapshot"):
-		await _fail("AudioManager vehicle-feedback diagnostic snapshot is absent")
-		return
-	if not _manager.has_method("clear_vehicle_feedback"):
-		await _fail("AudioManager vehicle-feedback clear seam is absent")
-		return
-
-	# E1: stable propulsion/load must be real bike telemetry and observation-only.
-	_bike.current_speed = 7.0
-	_bike.velocity = Vector3(0.0, 0.0, -7.0)
-	_bike.is_handbrake_active = false
-	var before_speed: float = _bike.current_speed
-	var before_velocity: Vector3 = _bike.velocity
-	var stable := _telemetry(0.70)
-	if not await _require(String(stable.get("traction_state", "")) == "STABLE", "Straight propulsion did not classify STABLE"):
-		return
-	if not await _require(float(stable.get("load_ratio", 0.0)) >= 0.35, "Propulsion load was not represented in telemetry"):
-		return
-	if not await _require(_bike.current_speed == before_speed and _bike.velocity == before_velocity, "Telemetry sampling mutated Courier Bike handling state"):
-		return
-
-	_manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
-	var engine := _manager.get_node_or_null("EngineRevPlayer") as AudioStreamPlayer3D
-	if not await _require(engine != null and engine.playing, "Stable propulsion did not activate the engine feedback voice"):
-		return
-	var stable_pitch: float = engine.pitch_scale
-	var stable_volume: float = engine.volume_db
-
-	# Same speed, stronger throttle/load: pitch/level must react to load rather than
-	# remaining a raw speed-only mapping.
-	var low_load := _telemetry(0.15)
-	_manager.call("update_vehicle_feedback", low_load, Vector3.ZERO)
-	var low_load_pitch: float = engine.pitch_scale
-	var low_load_volume: float = engine.volume_db
-	if not await _require(stable_pitch > low_load_pitch or stable_volume > low_load_volume, "Engine feedback remained speed-only; load made no audible-control difference"):
-		return
-
-	# E4: stable -> near slip -> full handbrake slip -> recovery catch.
-	_bike.velocity = Vector3(1.15, 0.0, -7.0)
-	var near_slip := _telemetry(0.45)
-	if not await _require(String(near_slip.get("traction_state", "")) == "NEAR_SLIP", "Moderate lateral slip did not classify NEAR_SLIP"):
-		return
-	_manager.call("update_vehicle_feedback", near_slip, Vector3.ZERO)
-	var traction := _manager.get_node_or_null("TractionScrubPlayer") as AudioStreamPlayer3D
-	if not await _require(traction != null and traction.playing, "Near-slip did not activate bounded traction scrub"):
-		return
+	# E4: stable -> near-slip -> full handbrake slide -> one-shot recovery catch.
+	bike.velocity = Vector3(1.15, 0.0, -7.0)
+	var near_slip: Dictionary = bike.call("get_vehicle_feedback_telemetry", 0.45)
+	if String(near_slip.get("traction_state", "")) != "NEAR_SLIP":
+		bike.free()
+		return "Moderate lateral slip did not classify NEAR_SLIP"
+	manager.call("update_vehicle_feedback", near_slip, Vector3.ZERO)
+	var traction := manager.get_node_or_null("TractionScrubPlayer") as AudioStreamPlayer3D
+	if traction == null or not traction.playing:
+		bike.free()
+		return "Near-slip did not activate bounded traction scrub"
 	var near_slip_db: float = traction.volume_db
 
-	_bike.is_handbrake_active = true
-	_bike.velocity = Vector3(2.8, 0.0, -7.0)
-	var full_slip := _telemetry(0.20)
-	if not await _require(String(full_slip.get("traction_state", "")) == "FULL_SLIP", "Handbrake slide did not classify FULL_SLIP"):
-		return
-	_manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
-	var full_slip_db: float = traction.volume_db
-	if not await _require(full_slip_db >= near_slip_db + 2.0, "Full-slip scrub is not meaningfully stronger than near-slip scrub"):
-		return
+	bike.is_handbrake_active = true
+	bike.velocity = Vector3(2.8, 0.0, -7.0)
+	var full_slip: Dictionary = bike.call("get_vehicle_feedback_telemetry", 0.20)
+	if String(full_slip.get("traction_state", "")) != "FULL_SLIP":
+		bike.free()
+		return "Handbrake slide did not classify FULL_SLIP"
+	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
+	if traction.volume_db < near_slip_db + 2.0:
+		bike.free()
+		return "Full-slip scrub is not meaningfully stronger than near-slip scrub"
 
-	_bike.is_handbrake_active = false
-	_bike.velocity = Vector3(0.0, 0.0, -7.0)
-	stable = _telemetry(0.55)
-	_manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
-	var recovered: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
-	if not await _require(String(recovered.get("state", "")) == "RECOVERY", "Slip release did not produce a distinct recovery-catch state"):
-		return
-	if not await _require(not traction.playing, "Traction scrub loop leaked through recovery"):
-		return
-	var recovery_event: int = int(AudioManagerScript.SoundEvent.get("TRACTION_RECOVERY", -1))
-	if not await _require(recovery_event >= 0, "TRACTION_RECOVERY semantic event is absent"):
-		return
-	if not await _require(int(_manager.call("get_event_count", recovery_event)) == 1, "Recovery catch did not fire exactly once"):
-		return
-	_manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
-	if not await _require(int(_manager.call("get_event_count", recovery_event)) == 1, "Stable frames retriggered the recovery catch"):
-		return
+	bike.is_handbrake_active = false
+	bike.velocity = Vector3(0.0, 0.0, -7.0)
+	stable = bike.call("get_vehicle_feedback_telemetry", 0.55)
+	manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
+	var recovered: Dictionary = manager.call("get_vehicle_feedback_snapshot")
+	if String(recovered.get("state", "")) != "RECOVERY" or traction.playing:
+		bike.free()
+		return "Slip release did not produce a clean recovery-catch transition"
+	if not AudioManagerScript.SoundEvent.has("TRACTION_RECOVERY"):
+		bike.free()
+		return "TRACTION_RECOVERY semantic event is absent"
+	var recovery_event: int = int(AudioManagerScript.SoundEvent["TRACTION_RECOVERY"])
+	if int(manager.call("get_event_count", recovery_event)) != 1:
+		bike.free()
+		return "Recovery catch did not fire exactly once"
+	manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
+	if int(manager.call("get_event_count", recovery_event)) != 1:
+		bike.free()
+		return "Stable frames retriggered the recovery catch"
 
-	# E5: matched routing semantics, but event energy must scale with impact speed.
-	_manager.call("on_collision_contact", 0.20, 4.0, Vector3.ZERO)
-	var glance: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	# E5: matched routing, materially different impact energy.
+	manager.call("on_collision_contact", 0.20, 4.0, Vector3.ZERO)
+	var glance: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	var glance_energy: float = float(glance.get("last_collision_intensity", 0.0))
-	_manager.call("on_collision_contact", 0.90, 10.0, Vector3.ZERO)
-	var hard: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	manager.call("on_collision_contact", 0.90, 10.0, Vector3.ZERO)
+	var hard: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	var hard_energy: float = float(hard.get("last_collision_intensity", 0.0))
-	if not await _require(glance_energy > 0.0 and hard_energy >= glance_energy + 0.30, "Hard impact did not communicate materially greater event energy than a glance"):
-		return
+	if glance_energy <= 0.0 or hard_energy < glance_energy + 0.30:
+		bike.free()
+		return "Hard impact did not communicate materially greater event energy than a glance"
 
-	# E7 + Echo overlap: pursuit/signature layers retain perceptual priority.
-	_manager.call("set_pursuit_pressure", 8.0, Vector3.ZERO)
-	_manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
-	var pursuit_snapshot: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
-	var siren := _manager.get_node_or_null("SirenAlarmPlayer") as AudioStreamPlayer3D
-	var tension := _manager.get_node_or_null("PursuitTensionPlayer") as AudioStreamPlayer
-	if not await _require(siren != null and siren.playing and tension != null and tension.playing, "Pursuit critical layers were not active for overlap proof"):
-		return
-	if not await _require(float(pursuit_snapshot.get("traction_volume_db", 0.0)) <= -18.0, "Traction texture did not duck beneath pursuit priority"):
-		return
+	# E7 + Memory Echo: critical/signature layers remain above vehicle texture.
+	manager.call("set_pursuit_pressure", 8.0, Vector3.ZERO)
+	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
+	var pursuit_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
+	var siren := manager.get_node_or_null("SirenAlarmPlayer") as AudioStreamPlayer3D
+	var tension := manager.get_node_or_null("PursuitTensionPlayer") as AudioStreamPlayer
+	if siren == null or not siren.playing or tension == null or not tension.playing:
+		bike.free()
+		return "Pursuit critical layers were not active for overlap proof"
+	if float(pursuit_snapshot.get("traction_volume_db", 0.0)) > -18.0:
+		bike.free()
+		return "Traction texture did not duck beneath pursuit priority"
 
-	_manager.call("set_mix_state", AudioManagerScript.MixState.MEMORY_ECHO)
-	_manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
-	var echo_snapshot: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
-	if not await _require(float(echo_snapshot.get("traction_volume_db", 0.0)) <= -18.0, "Traction texture did not remain subordinate during Memory Echo"):
-		return
+	manager.call("set_mix_state", AudioManagerScript.MixState.MEMORY_ECHO)
+	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
+	var echo_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
+	if float(echo_snapshot.get("traction_volume_db", 0.0)) > -18.0:
+		bike.free()
+		return "Traction texture did not remain subordinate during Memory Echo"
 
-	# Replay/reset contract: no vehicle loops or recovery/impact transients survive.
-	_manager.call("reset_audio_instant")
-	var reset_snapshot: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
-	if not await _require(not bool(reset_snapshot.get("engine_playing", true)), "Authoritative reset left engine feedback playing"):
-		return
-	if not await _require(not bool(reset_snapshot.get("traction_playing", true)), "Authoritative reset left traction feedback playing"):
-		return
-	if not await _require((_manager.get("_active_transients") as Array).is_empty(), "Authoritative reset left vehicle transients alive"):
-		return
+	# Existing voice budget/cooldowns and authoritative reset remain the owners.
+	manager.call("reset_audio_instant")
+	var reset_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
+	if bool(reset_snapshot.get("engine_playing", true)) or bool(reset_snapshot.get("traction_playing", true)):
+		bike.free()
+		return "Authoritative reset left vehicle feedback playing"
+	var active_transients: Array = manager.get("_active_transients")
+	if not active_transients.is_empty():
+		bike.free()
+		return "Authoritative reset left vehicle transients alive"
 
-	print("[CTW_FEEL_04] PASS stable/near-slip/full-slip/recovery + scaled impacts + overlap/reset")
-	_bike.free()
-	_bike = null
-	_manager.queue_free()
-	await process_frame
-	await process_frame
-	quit(0)
+	bike.free()
+	return ""

--- a/godot/tests/vehicle_feedback_contract_test.gd
+++ b/godot/tests/vehicle_feedback_contract_test.gd
@@ -19,7 +19,6 @@ static func _latest_transient_gain_db(manager: Node) -> float:
 static func verify(manager: Node) -> String:
 	var bike := CourierBikeScript.new()
 
-	# Capability seam: intentionally RED on main@05d8161.
 	if not bike.has_method("get_vehicle_feedback_telemetry"):
 		bike.free()
 		return "Courier Bike vehicle-feedback telemetry seam is absent"
@@ -58,15 +57,28 @@ static func verify(manager: Node) -> String:
 	var high_load_pitch: float = engine.pitch_scale
 	var high_load_volume: float = engine.volume_db
 
-	# Same speed, less load: engine must not remain a raw speed-only mapping.
 	var low_load: Dictionary = bike.call("get_vehicle_feedback_telemetry", 0.15)
 	manager.call("update_vehicle_feedback", low_load, Vector3.ZERO)
 	if not (high_load_pitch > engine.pitch_scale or high_load_volume > engine.volume_db):
 		bike.free()
 		return "Engine feedback remained speed-only; load made no audible-control difference"
 
-	# E4: stable -> near-slip -> full handbrake slide -> one-shot recovery catch.
+	# Review repair: braking must contribute to traction intensity without changing
+	# the handling state. Same speed/lateral slip isolates the braking contribution.
 	bike.velocity = Vector3(1.15, 0.0, -7.0)
+	var neutral_slip: Dictionary = bike.call("get_vehicle_feedback_telemetry", 0.0)
+	var braking_slip: Dictionary = bike.call("get_vehicle_feedback_telemetry", -0.65)
+	if not bool(braking_slip.get("braking", false)):
+		bike.free()
+		return "Forward braking state is absent from vehicle-feedback telemetry"
+	if float(braking_slip.get("slip_intensity", 0.0)) < float(neutral_slip.get("slip_intensity", 0.0)) + 0.08:
+		bike.free()
+		return "Braking state did not strengthen traction scrub intensity at matched slip"
+	if bike.current_speed != before_speed:
+		bike.free()
+		return "Braking telemetry sampling mutated Courier Bike speed"
+
+	# E4: stable -> near-slip -> full handbrake slide -> one-shot recovery catch.
 	var near_slip: Dictionary = bike.call("get_vehicle_feedback_telemetry", 0.45)
 	if String(near_slip.get("traction_state", "")) != "NEAR_SLIP":
 		bike.free()
@@ -109,7 +121,7 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Stable frames retriggered the recovery catch"
 
-	# E5: issue #14 requires matched-speed glance vs hard/head-on proof.
+	# E5: matched-speed glance vs hard/head-on proof.
 	const MATCHED_IMPACT_SPEED := 8.0
 	manager.call("on_collision_contact", 0.20, MATCHED_IMPACT_SPEED, Vector3.ZERO)
 	var glance: Dictionary = manager.call("get_vehicle_feedback_snapshot")
@@ -121,8 +133,6 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Matched-speed hard impact did not communicate materially greater event energy than a glance"
 
-	# Scaled impact energy must reach output gain, not live only in diagnostics.
-	# Same hard-event family + different speed isolates energy scaling from routing.
 	var timestamps: Dictionary = manager.get("_last_event_timestamps")
 	timestamps.clear()
 	manager.call("on_collision_contact", 0.90, 4.0, Vector3.ZERO)
@@ -134,8 +144,18 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Hard-impact output gain did not scale materially with impact speed"
 
-	# E7: pursuit remains perceptually critical during both traction and impact.
+	# E7: pursuit remains perceptually critical during both continuous vehicle
+	# layers and impact. Exercise the loudest legal engine state under priority.
 	manager.call("set_pursuit_pressure", 8.0, Vector3.ZERO)
+	bike.current_speed = bike.max_speed
+	bike.velocity = Vector3(0.0, 0.0, -bike.max_speed)
+	var critical_engine: Dictionary = bike.call("get_vehicle_feedback_telemetry", 1.0)
+	manager.call("update_vehicle_feedback", critical_engine, Vector3.ZERO)
+	var engine_priority_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
+	if float(engine_priority_snapshot.get("engine_volume_db", 0.0)) > -12.0:
+		bike.free()
+		return "Engine layer did not duck beneath pursuit priority at maximum propulsion load"
+
 	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
 	var pursuit_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	var siren := manager.get_node_or_null("SirenAlarmPlayer") as AudioStreamPlayer3D
@@ -156,9 +176,13 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Pursuit + impact overlap exceeded the transient voice budget"
 
-	# Signature transition: Memory Echo vehicle texture stays subordinate, then
-	# disturbance takes priority without waking an unducked traction layer.
+	# Signature transition: both continuous vehicle layers remain subordinate.
 	manager.call("set_mix_state", AudioManagerScript.MixState.MEMORY_ECHO)
+	manager.call("update_vehicle_feedback", critical_engine, Vector3.ZERO)
+	var echo_engine_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
+	if float(echo_engine_snapshot.get("engine_volume_db", 0.0)) > -12.0:
+		bike.free()
+		return "Engine layer did not remain subordinate during Memory Echo"
 	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
 	var echo_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	if float(echo_snapshot.get("traction_volume_db", 0.0)) > -18.0:
@@ -174,7 +198,6 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Disturbance did not retain the critical siren layer after Memory Echo overlap"
 
-	# Existing voice budget/cooldowns and authoritative reset remain the owners.
 	manager.call("reset_audio_instant")
 	var reset_snapshot: Dictionary = manager.call("get_vehicle_feedback_snapshot")
 	if bool(reset_snapshot.get("engine_playing", true)) or bool(reset_snapshot.get("traction_playing", true)):

--- a/godot/tests/vehicle_feedback_contract_test.gd
+++ b/godot/tests/vehicle_feedback_contract_test.gd
@@ -3,6 +3,25 @@ extends RefCounted
 const AudioManagerScript = preload("res://scripts/audio/audio_manager.gd")
 const CourierBikeScript = preload("res://scripts/vehicles/courier_bike.gd")
 
+static func _pcm_span(stream: AudioStreamWAV) -> int:
+	if stream == null or stream.data.is_empty():
+		return 0
+	var minimum_byte := 255
+	var maximum_byte := 0
+	for sample_byte in stream.data:
+		minimum_byte = mini(minimum_byte, int(sample_byte))
+		maximum_byte = maxi(maximum_byte, int(sample_byte))
+	return maximum_byte - minimum_byte
+
+static func _latest_transient_pcm_span(manager: Node) -> int:
+	var transients: Array = manager.get("_active_transients")
+	if transients.is_empty():
+		return 0
+	var player := transients.back() as AudioStreamPlayer3D
+	if player == null or not player.stream is AudioStreamWAV:
+		return 0
+	return _pcm_span(player.stream as AudioStreamWAV)
+
 static func verify(manager: Node) -> String:
 	var bike := CourierBikeScript.new()
 
@@ -108,6 +127,20 @@ static func verify(manager: Node) -> String:
 		bike.free()
 		return "Matched-speed hard impact did not communicate materially greater event energy than a glance"
 
+	# Scaled impact energy must reach the audible waveform, not live only in a
+	# diagnostic snapshot. Two hard impacts at different speeds use the same event
+	# family, so a larger PCM span proves actual energy scaling rather than routing.
+	var timestamps: Dictionary = manager.get("_last_event_timestamps")
+	timestamps.clear()
+	manager.call("on_collision_contact", 0.90, 4.0, Vector3.ZERO)
+	var low_speed_hard_span := _latest_transient_pcm_span(manager)
+	timestamps.clear()
+	manager.call("on_collision_contact", 0.90, 10.0, Vector3.ZERO)
+	var high_speed_hard_span := _latest_transient_pcm_span(manager)
+	if low_speed_hard_span <= 0 or high_speed_hard_span < low_speed_hard_span + 12:
+		bike.free()
+		return "Hard-impact waveform energy did not scale materially with impact speed"
+
 	# E7: pursuit remains perceptually critical during both traction and impact.
 	manager.call("set_pursuit_pressure", 8.0, Vector3.ZERO)
 	manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
@@ -120,6 +153,7 @@ static func verify(manager: Node) -> String:
 	if float(pursuit_snapshot.get("traction_volume_db", 0.0)) > -18.0:
 		bike.free()
 		return "Traction texture did not duck beneath pursuit priority"
+	timestamps.clear()
 	manager.call("on_collision_contact", 0.90, MATCHED_IMPACT_SPEED, Vector3.ZERO)
 	if not siren.playing or not tension.playing:
 		bike.free()

--- a/godot/tests/vehicle_feedback_contract_test.gd
+++ b/godot/tests/vehicle_feedback_contract_test.gd
@@ -1,0 +1,164 @@
+extends SceneTree
+
+const AudioManagerScript = preload("res://scripts/audio/audio_manager.gd")
+const CourierBikeScript = preload("res://scripts/vehicles/courier_bike.gd")
+
+var _manager: Node = null
+var _bike: CharacterBody3D = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _fail(message: String) -> void:
+	push_error("[CTW_FEEL_04] %s" % message)
+	if is_instance_valid(_manager):
+		_manager.queue_free()
+	if is_instance_valid(_bike):
+		_bike.free()
+	await process_frame
+	await process_frame
+	quit(1)
+
+func _require(condition: bool, message: String) -> bool:
+	if not condition:
+		await _fail(message)
+		return false
+	return true
+
+func _telemetry(throttle: float) -> Dictionary:
+	return _bike.call("get_vehicle_feedback_telemetry", throttle)
+
+func _run() -> void:
+	_bike = CourierBikeScript.new()
+	_manager = AudioManagerScript.new()
+	root.add_child(_manager)
+	await process_frame
+
+	# TDD RED on main@05d8161: CTW Feel 04 has no telemetry-driven vehicle
+	# feedback seam yet. Keep the contract narrow and gameplay-facing.
+	if not _bike.has_method("get_vehicle_feedback_telemetry"):
+		await _fail("Courier Bike vehicle-feedback telemetry seam is absent")
+		return
+	if not _manager.has_method("update_vehicle_feedback"):
+		await _fail("AudioManager vehicle-feedback update seam is absent")
+		return
+	if not _manager.has_method("get_vehicle_feedback_snapshot"):
+		await _fail("AudioManager vehicle-feedback diagnostic snapshot is absent")
+		return
+	if not _manager.has_method("clear_vehicle_feedback"):
+		await _fail("AudioManager vehicle-feedback clear seam is absent")
+		return
+
+	# E1: stable propulsion/load must be real bike telemetry and observation-only.
+	_bike.current_speed = 7.0
+	_bike.velocity = Vector3(0.0, 0.0, -7.0)
+	_bike.is_handbrake_active = false
+	var before_speed: float = _bike.current_speed
+	var before_velocity: Vector3 = _bike.velocity
+	var stable := _telemetry(0.70)
+	if not await _require(String(stable.get("traction_state", "")) == "STABLE", "Straight propulsion did not classify STABLE"):
+		return
+	if not await _require(float(stable.get("load_ratio", 0.0)) >= 0.35, "Propulsion load was not represented in telemetry"):
+		return
+	if not await _require(_bike.current_speed == before_speed and _bike.velocity == before_velocity, "Telemetry sampling mutated Courier Bike handling state"):
+		return
+
+	_manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
+	var engine := _manager.get_node_or_null("EngineRevPlayer") as AudioStreamPlayer3D
+	if not await _require(engine != null and engine.playing, "Stable propulsion did not activate the engine feedback voice"):
+		return
+	var stable_pitch: float = engine.pitch_scale
+	var stable_volume: float = engine.volume_db
+
+	# Same speed, stronger throttle/load: pitch/level must react to load rather than
+	# remaining a raw speed-only mapping.
+	var low_load := _telemetry(0.15)
+	_manager.call("update_vehicle_feedback", low_load, Vector3.ZERO)
+	var low_load_pitch: float = engine.pitch_scale
+	var low_load_volume: float = engine.volume_db
+	if not await _require(stable_pitch > low_load_pitch or stable_volume > low_load_volume, "Engine feedback remained speed-only; load made no audible-control difference"):
+		return
+
+	# E4: stable -> near slip -> full handbrake slip -> recovery catch.
+	_bike.velocity = Vector3(1.15, 0.0, -7.0)
+	var near_slip := _telemetry(0.45)
+	if not await _require(String(near_slip.get("traction_state", "")) == "NEAR_SLIP", "Moderate lateral slip did not classify NEAR_SLIP"):
+		return
+	_manager.call("update_vehicle_feedback", near_slip, Vector3.ZERO)
+	var traction := _manager.get_node_or_null("TractionScrubPlayer") as AudioStreamPlayer3D
+	if not await _require(traction != null and traction.playing, "Near-slip did not activate bounded traction scrub"):
+		return
+	var near_slip_db: float = traction.volume_db
+
+	_bike.is_handbrake_active = true
+	_bike.velocity = Vector3(2.8, 0.0, -7.0)
+	var full_slip := _telemetry(0.20)
+	if not await _require(String(full_slip.get("traction_state", "")) == "FULL_SLIP", "Handbrake slide did not classify FULL_SLIP"):
+		return
+	_manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
+	var full_slip_db: float = traction.volume_db
+	if not await _require(full_slip_db >= near_slip_db + 2.0, "Full-slip scrub is not meaningfully stronger than near-slip scrub"):
+		return
+
+	_bike.is_handbrake_active = false
+	_bike.velocity = Vector3(0.0, 0.0, -7.0)
+	stable = _telemetry(0.55)
+	_manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
+	var recovered: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	if not await _require(String(recovered.get("state", "")) == "RECOVERY", "Slip release did not produce a distinct recovery-catch state"):
+		return
+	if not await _require(not traction.playing, "Traction scrub loop leaked through recovery"):
+		return
+	var recovery_event: int = int(AudioManagerScript.SoundEvent.get("TRACTION_RECOVERY", -1))
+	if not await _require(recovery_event >= 0, "TRACTION_RECOVERY semantic event is absent"):
+		return
+	if not await _require(int(_manager.call("get_event_count", recovery_event)) == 1, "Recovery catch did not fire exactly once"):
+		return
+	_manager.call("update_vehicle_feedback", stable, Vector3.ZERO)
+	if not await _require(int(_manager.call("get_event_count", recovery_event)) == 1, "Stable frames retriggered the recovery catch"):
+		return
+
+	# E5: matched routing semantics, but event energy must scale with impact speed.
+	_manager.call("on_collision_contact", 0.20, 4.0, Vector3.ZERO)
+	var glance: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	var glance_energy: float = float(glance.get("last_collision_intensity", 0.0))
+	_manager.call("on_collision_contact", 0.90, 10.0, Vector3.ZERO)
+	var hard: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	var hard_energy: float = float(hard.get("last_collision_intensity", 0.0))
+	if not await _require(glance_energy > 0.0 and hard_energy >= glance_energy + 0.30, "Hard impact did not communicate materially greater event energy than a glance"):
+		return
+
+	# E7 + Echo overlap: pursuit/signature layers retain perceptual priority.
+	_manager.call("set_pursuit_pressure", 8.0, Vector3.ZERO)
+	_manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
+	var pursuit_snapshot: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	var siren := _manager.get_node_or_null("SirenAlarmPlayer") as AudioStreamPlayer3D
+	var tension := _manager.get_node_or_null("PursuitTensionPlayer") as AudioStreamPlayer
+	if not await _require(siren != null and siren.playing and tension != null and tension.playing, "Pursuit critical layers were not active for overlap proof"):
+		return
+	if not await _require(float(pursuit_snapshot.get("traction_volume_db", 0.0)) <= -18.0, "Traction texture did not duck beneath pursuit priority"):
+		return
+
+	_manager.call("set_mix_state", AudioManagerScript.MixState.MEMORY_ECHO)
+	_manager.call("update_vehicle_feedback", full_slip, Vector3.ZERO)
+	var echo_snapshot: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	if not await _require(float(echo_snapshot.get("traction_volume_db", 0.0)) <= -18.0, "Traction texture did not remain subordinate during Memory Echo"):
+		return
+
+	# Replay/reset contract: no vehicle loops or recovery/impact transients survive.
+	_manager.call("reset_audio_instant")
+	var reset_snapshot: Dictionary = _manager.call("get_vehicle_feedback_snapshot")
+	if not await _require(not bool(reset_snapshot.get("engine_playing", true)), "Authoritative reset left engine feedback playing"):
+		return
+	if not await _require(not bool(reset_snapshot.get("traction_playing", true)), "Authoritative reset left traction feedback playing"):
+		return
+	if not await _require((_manager.get("_active_transients") as Array).is_empty(), "Authoritative reset left vehicle transients alive"):
+		return
+
+	print("[CTW_FEEL_04] PASS stable/near-slip/full-slip/recovery + scaled impacts + overlap/reset")
+	_bike.free()
+	_bike = null
+	_manager.queue_free()
+	await process_frame
+	await process_frame
+	quit(0)


### PR DESCRIPTION
Implements issue #14 from verified main@05d8161f50ac9bea8113e6b340c4f9ffe4ce459a.

Current head is intentionally test-first/RED. The existing Audio Runtime 31 contract now loads the focused CTW Feel 04 regression and requires:
- observation-only Courier Bike telemetry for propulsion load and lateral slip;
- stable / near-slip / full-slip / recovery semantics;
- continuous engine/load plus bounded traction scrub;
- scaled glance vs hard-impact energy;
- pursuit and Memory Echo priority over vehicle texture;
- authoritative reset with no vehicle loop/transient leakage.

No production gameplay/audio implementation has been added yet. This PR will stay open through RED → implementation → exact-head verification → two-axis review.