### PR TITLE
CTW Feel 06 — bounded pursuer interception A/B

### DIFF
--- a/godot/scripts/entities/pursuer_prototype.gd
+++ b/godot/scripts/entities/pursuer_prototype.gd
@@ -2,8 +2,8 @@ class_name PursuerPrototype
 extends CharacterBody3D
 
 # Pursuer Prototype Threat Entity for Echos in the Scrap (V8 M03)
-# Direct vector pursuit steering toward active target with detour waypoint rerouting,
-# graceful de-escalation retreat, and deterministic lifecycle reset.
+# Physical pursuit steering with authored Signal Gate detours, bounded observable
+# target-velocity interception, graceful de-escalation, and deterministic reset.
 
 signal intercepted_target
 signal de_escalation_started
@@ -21,6 +21,18 @@ enum PursuerState {
 @export var acceleration: float = 14.0
 @export var steering_speed: float = 4.0
 @export var intercept_distance: float = 1.5
+
+# CTW Feel 06 — destination-only A/B. These values never retune motion authority.
+# The lead uses current observable velocity only and collapses toward the direct
+# chase baseline at low target speed / close range.
+@export var bounded_intercept_enabled: bool = true
+@export var intercept_lead_horizon_min: float = 0.15
+@export var intercept_lead_horizon_max: float = 0.45
+@export var intercept_lead_distance_cap: float = 4.0
+@export var intercept_prediction_close_range: float = 3.0
+@export var intercept_prediction_full_range: float = 15.0
+@export var intercept_prediction_min_target_speed: float = 0.75
+@export var intercept_prediction_full_target_speed: float = 10.0
 
 @onready var visual_root: Node3D = $VisualRoot
 @onready var siren_mesh: MeshInstance3D = $VisualRoot/SirenMesh
@@ -118,6 +130,53 @@ func set_detour_path(waypoints: Array[Vector3]) -> void:
 		
 	print("[PURSUER] Detour reroute path set (%d forward waypoints)..." % detour_waypoints.size())
 
+## CTW Feel 06 — pure destination candidate. It has no target input history and
+## therefore cannot preserve stale steering intent after a sharp reversal.
+func get_bounded_chase_destination(target_position: Vector3, target_velocity: Vector3) -> Vector3:
+	var flat_to_target := target_position - global_position
+	flat_to_target.y = 0.0
+	var target_distance: float = flat_to_target.length()
+
+	var flat_velocity := target_velocity
+	flat_velocity.y = 0.0
+	var target_speed: float = flat_velocity.length()
+
+	if target_distance <= intercept_prediction_close_range or target_speed <= intercept_prediction_min_target_speed:
+		return target_position
+
+	var distance_span: float = maxf(intercept_prediction_full_range - intercept_prediction_close_range, 0.001)
+	var speed_span: float = maxf(intercept_prediction_full_target_speed - intercept_prediction_min_target_speed, 0.001)
+	var distance_factor: float = clampf((target_distance - intercept_prediction_close_range) / distance_span, 0.0, 1.0)
+	var speed_factor: float = clampf((target_speed - intercept_prediction_min_target_speed) / speed_span, 0.0, 1.0)
+	var qualification: float = minf(distance_factor, speed_factor)
+	if qualification <= 0.0:
+		return target_position
+
+	var horizon: float = lerpf(intercept_lead_horizon_min, intercept_lead_horizon_max, qualification)
+	# Scaling by qualification lets lead distance approach zero smoothly while the
+	# actual horizon remains inside the specified 0.15–0.45 s experiment range.
+	var lead_vector: Vector3 = flat_velocity * horizon * qualification
+	if lead_vector.length() > intercept_lead_distance_cap:
+		lead_vector = lead_vector.normalized() * intercept_lead_distance_cap
+	return target_position + lead_vector
+
+## Single destination authority for the active chase. Authored DETOURING waypoints
+## always win; prediction only participates in direct CHASING.
+func get_navigation_destination() -> Vector3:
+	if current_detour_index >= 0 and current_detour_index < detour_waypoints.size():
+		return detour_waypoints[current_detour_index]
+	if target_node == null:
+		return global_position
+
+	var direct_destination: Vector3 = target_node.global_position
+	if not bounded_intercept_enabled:
+		return direct_destination
+
+	var target_velocity := Vector3.ZERO
+	if target_node is CharacterBody3D:
+		target_velocity = (target_node as CharacterBody3D).velocity
+	return get_bounded_chase_destination(direct_destination, target_velocity)
+
 func _physics_process(delta: float) -> void:
 	if not is_active:
 		return
@@ -164,9 +223,8 @@ func _physics_process(delta: float) -> void:
 	if not target_node:
 		return
 		
-	var destination: Vector3 = target_node.global_position
+	var destination: Vector3 = get_navigation_destination()
 	if current_detour_index >= 0 and current_detour_index < detour_waypoints.size():
-		destination = detour_waypoints[current_detour_index]
 		if global_position.distance_to(destination) < 3.0:
 			current_detour_index += 1
 			print("[PURSUER] Detour waypoint reached. Advancing to index %d..." % current_detour_index)

--- a/godot/tests/desktop_vehicle_authority_test.gd
+++ b/godot/tests/desktop_vehicle_authority_test.gd
@@ -41,11 +41,10 @@ func _mount_vehicle_direct(vehicle: Node, player: Node) -> bool:
 	return vehicle.request_mount(player)
 
 func _run() -> void:
-	# CTW Feel 06 owns a pure destination-selection A/B contract. Run it before
-	# loading the live prototype scene so it cannot perturb the vehicle-authority
-	# fixture or create teardown hangs. Retained V4/V5/M15 suites cover the live
-	# pursuit/gate/evasion/retry lifecycle separately.
-	var intercept_error: String = PursuerInterceptContract.verify()
+	# CTW Feel 06 owns a pure destination-selection A/B contract. Its synthetic
+	# nodes attach under the SceneTree root so production global transforms are
+	# valid, but it never touches the live prototype scene fixture.
+	var intercept_error: String = PursuerInterceptContract.verify(root)
 	if not intercept_error.is_empty():
 		await _fail("CTW Feel 06: %s" % intercept_error)
 		return

--- a/godot/tests/desktop_vehicle_authority_test.gd
+++ b/godot/tests/desktop_vehicle_authority_test.gd
@@ -2,6 +2,8 @@ extends SceneTree
 
 # Integration regression for #29's full authority path:
 # keyboard -> TouchControlsUI normalized intent -> ScrapTestBlock -> existing vehicle physics seam.
+const PursuerInterceptContract = preload("res://tests/pursuer_intercept_contract_test.gd")
+
 var _scene_under_test: Node = null
 
 func _init() -> void:
@@ -53,12 +55,20 @@ func _run() -> void:
 	var player := _scene_under_test.get_node_or_null("Runner")
 	var bike := _scene_under_test.get_node_or_null("CourierBike")
 	var hauler := _scene_under_test.get_node_or_null("ScrapHauler")
-	if touch_ui == null or player == null or bike == null or hauler == null:
-		await _fail("Main scene is missing TouchControlsUI, Runner, CourierBike, or ScrapHauler")
+	var pursuer := _scene_under_test.get_node_or_null("Pursuer")
+	if touch_ui == null or player == null or bike == null or hauler == null or pursuer == null:
+		await _fail("Main scene is missing TouchControlsUI, Runner, CourierBike, ScrapHauler, or Pursuer")
 		return
 
-	# CTW Feel 04 TDD seam: normalized vehicle intent must remain observable by
-	# feedback systems without mutating the existing Courier Bike handling path.
+	# CTW Feel 06 TDD: destination prediction is independently testable without
+	# changing pursuit speed/acceleration or the existing vehicle authority path.
+	var intercept_error: String = PursuerInterceptContract.verify(pursuer, bike)
+	if not intercept_error.is_empty():
+		await _fail("CTW Feel 06: %s" % intercept_error)
+		return
+
+	# CTW Feel 04 seam: normalized vehicle intent remains observable by feedback
+	# systems without mutating the existing Courier Bike handling path.
 	if not bike.has_method("get_vehicle_feedback_telemetry"):
 		await _fail("Courier Bike vehicle-feedback telemetry seam is absent")
 		return

--- a/godot/tests/desktop_vehicle_authority_test.gd
+++ b/godot/tests/desktop_vehicle_authority_test.gd
@@ -41,6 +41,15 @@ func _mount_vehicle_direct(vehicle: Node, player: Node) -> bool:
 	return vehicle.request_mount(player)
 
 func _run() -> void:
+	# CTW Feel 06 owns a pure destination-selection A/B contract. Run it before
+	# loading the live prototype scene so it cannot perturb the vehicle-authority
+	# fixture or create teardown hangs. Retained V4/V5/M15 suites cover the live
+	# pursuit/gate/evasion/retry lifecycle separately.
+	var intercept_error: String = PursuerInterceptContract.verify()
+	if not intercept_error.is_empty():
+		await _fail("CTW Feel 06: %s" % intercept_error)
+		return
+
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
 	if packed == null:
 		await _fail("Could not load scrap_test_block.tscn")
@@ -55,16 +64,8 @@ func _run() -> void:
 	var player := _scene_under_test.get_node_or_null("Runner")
 	var bike := _scene_under_test.get_node_or_null("CourierBike")
 	var hauler := _scene_under_test.get_node_or_null("ScrapHauler")
-	var pursuer = _scene_under_test.get("pursuer")
-	if touch_ui == null or player == null or bike == null or hauler == null or pursuer == null:
-		await _fail("Main scene is missing TouchControlsUI, Runner, CourierBike, ScrapHauler, or runtime PursuerPrototype")
-		return
-
-	# CTW Feel 06 TDD: destination prediction is independently testable without
-	# changing pursuit speed/acceleration or the existing vehicle authority path.
-	var intercept_error: String = PursuerInterceptContract.verify(pursuer, bike)
-	if not intercept_error.is_empty():
-		await _fail("CTW Feel 06: %s" % intercept_error)
+	if touch_ui == null or player == null or bike == null or hauler == null:
+		await _fail("Main scene is missing TouchControlsUI, Runner, CourierBike, or ScrapHauler")
 		return
 
 	# CTW Feel 04 seam: normalized vehicle intent remains observable by feedback

--- a/godot/tests/desktop_vehicle_authority_test.gd
+++ b/godot/tests/desktop_vehicle_authority_test.gd
@@ -55,9 +55,9 @@ func _run() -> void:
 	var player := _scene_under_test.get_node_or_null("Runner")
 	var bike := _scene_under_test.get_node_or_null("CourierBike")
 	var hauler := _scene_under_test.get_node_or_null("ScrapHauler")
-	var pursuer := _scene_under_test.get_node_or_null("Pursuer")
+	var pursuer = _scene_under_test.get("pursuer")
 	if touch_ui == null or player == null or bike == null or hauler == null or pursuer == null:
-		await _fail("Main scene is missing TouchControlsUI, Runner, CourierBike, ScrapHauler, or Pursuer")
+		await _fail("Main scene is missing TouchControlsUI, Runner, CourierBike, ScrapHauler, or runtime PursuerPrototype")
 		return
 
 	# CTW Feel 06 TDD: destination prediction is independently testable without

--- a/godot/tests/pursuer_intercept_contract_test.gd
+++ b/godot/tests/pursuer_intercept_contract_test.gd
@@ -28,6 +28,7 @@ static func verify(pursuer: Node, target: Node3D) -> String:
 	var original_target_node = pursuer.target_node
 	var original_detours: Array[Vector3] = pursuer.detour_waypoints.duplicate()
 	var original_detour_index := int(pursuer.current_detour_index)
+	var original_intercept_enabled := bool(pursuer.bounded_intercept_enabled)
 
 	pursuer.global_position = Vector3.ZERO
 	target.global_position = Vector3(0.0, 0.0, 18.0)
@@ -37,8 +38,20 @@ static func verify(pursuer: Node, target: Node3D) -> String:
 	pursuer.detour_waypoints.clear()
 	pursuer.current_detour_index = -1
 
-	var direct := target.global_position
-	var candidate: Vector3 = pursuer.call("get_bounded_chase_destination", direct, target.get("velocity"))
+	# A = direct world target, B = bounded observable-velocity interception.
+	# Both use the exact same live pursuer and target fixture so movement tuning,
+	# collisions, steering and target motion are held constant.
+	pursuer.bounded_intercept_enabled = false
+	var direct: Vector3 = pursuer.call("get_navigation_destination")
+	if direct.distance_to(target.global_position) > 0.001:
+		return "A baseline did not resolve to the current world target position"
+
+	pursuer.bounded_intercept_enabled = true
+	var candidate: Vector3 = pursuer.call("get_navigation_destination")
+	var helper_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", direct, target.get("velocity"))
+	if candidate.distance_to(helper_candidate) > 0.001:
+		return "B navigation destination diverged from the bounded prediction helper"
+
 	var lead := candidate - direct
 	lead.y = 0.0
 	if lead.length() <= 0.5:
@@ -49,12 +62,19 @@ static func verify(pursuer: Node, target: Node3D) -> String:
 		return "Bounded lead did not follow observable current target velocity"
 
 	# Compare against the target's short observable continuation. The candidate
-	# should reduce the heading error versus tail-following without teleporting.
+	# should reduce heading error versus tail-following without teleporting.
 	var observable_future := direct + Vector3(9.0, 0.0, 0.0) * 0.35
 	var direct_error := _heading_error(pursuer.global_position, direct, observable_future)
 	var candidate_error := _heading_error(pursuer.global_position, candidate, observable_future)
-	if candidate_error >= direct_error - deg_to_rad(3.0):
+	var improvement := direct_error - candidate_error
+	if improvement < deg_to_rad(3.0):
 		return "Bounded lead did not create a measurable cut-off heading improvement"
+	print("[CTW_FEEL_06] A/B lead_m=%.3f direct_error_deg=%.3f bounded_error_deg=%.3f improvement_deg=%.3f" % [
+		lead.length(),
+		rad_to_deg(direct_error),
+		rad_to_deg(candidate_error),
+		rad_to_deg(improvement),
+	])
 
 	# Low target speed collapses to the direct baseline.
 	var low_speed: Vector3 = pursuer.call("get_bounded_chase_destination", direct, Vector3(0.25, 0.0, 0.0))
@@ -77,7 +97,8 @@ static func verify(pursuer: Node, target: Node3D) -> String:
 
 	# Authored Signal Gate detours remain authoritative over prediction.
 	var waypoint := Vector3(6.0, 0.0, 12.0)
-	pursuer.detour_waypoints = [waypoint]
+	var detour_fixture: Array[Vector3] = [waypoint]
+	pursuer.detour_waypoints = detour_fixture
 	pursuer.current_detour_index = 0
 	pursuer.current_state = PursuerScript.PursuerState.DETOURING
 	var detour_destination: Vector3 = pursuer.call("get_navigation_destination")
@@ -98,4 +119,5 @@ static func verify(pursuer: Node, target: Node3D) -> String:
 	pursuer.target_node = original_target_node
 	pursuer.detour_waypoints = original_detours
 	pursuer.current_detour_index = original_detour_index
+	pursuer.bounded_intercept_enabled = original_intercept_enabled
 	return ""

--- a/godot/tests/pursuer_intercept_contract_test.gd
+++ b/godot/tests/pursuer_intercept_contract_test.gd
@@ -11,25 +11,30 @@ static func _heading_error(from_pos: Vector3, destination: Vector3, reference: V
 		return 0.0
 	return absf(a.normalized().angle_to(b.normalized()))
 
-static func _finish(pursuer: Node, target: Node, message: String) -> String:
-	if is_instance_valid(target):
-		target.free()
-	if is_instance_valid(pursuer):
-		pursuer.free()
+static func _finish(fixture: Node, message: String) -> String:
+	if is_instance_valid(fixture):
+		fixture.free()
 	return message
 
-static func verify() -> String:
+static func verify(tree_root: Node) -> String:
+	if tree_root == null:
+		return "Pursuer intercept contract requires a SceneTree root"
+
 	# Keep this A/B contract independent from the live prototype scene. Retained
-	# V4/V5/M15 suites already own full pursuit/gate/retry lifecycle coverage;
-	# this test owns only the new destination-selection experiment.
+	# V4/V5/M15 suites own pursuit/gate/retry lifecycle coverage. The synthetic
+	# nodes are attached only so production global_position semantics are valid.
+	var fixture := Node3D.new()
+	fixture.name = "PursuerInterceptContractFixture"
+	tree_root.add_child(fixture)
 	var pursuer := PursuerScript.new()
 	var target := CharacterBody3D.new()
-	if pursuer == null or target == null:
-		return _finish(pursuer, target, "Could not construct isolated pursuer A/B fixture")
+	fixture.add_child(pursuer)
+	fixture.add_child(target)
+
 	if not pursuer.has_method("get_bounded_chase_destination"):
-		return _finish(pursuer, target, "Pursuer bounded chase destination seam is absent")
+		return _finish(fixture, "Pursuer bounded chase destination seam is absent")
 	if not pursuer.has_method("get_navigation_destination"):
-		return _finish(pursuer, target, "Pursuer navigation destination seam is absent")
+		return _finish(fixture, "Pursuer navigation destination seam is absent")
 
 	var baseline_max_speed := float(pursuer.max_speed)
 	var baseline_acceleration := float(pursuer.acceleration)
@@ -47,29 +52,29 @@ static func verify() -> String:
 	pursuer.bounded_intercept_enabled = false
 	var direct: Vector3 = pursuer.call("get_navigation_destination")
 	if direct.distance_to(target.global_position) > 0.001:
-		return _finish(pursuer, target, "A baseline did not resolve to current target position")
+		return _finish(fixture, "A baseline did not resolve to current target position")
 
 	pursuer.bounded_intercept_enabled = true
 	var candidate: Vector3 = pursuer.call("get_navigation_destination")
 	var helper_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", direct, target.velocity)
 	if candidate.distance_to(helper_candidate) > 0.001:
-		return _finish(pursuer, target, "B navigation destination diverged from bounded helper")
+		return _finish(fixture, "B navigation destination diverged from bounded helper")
 
 	var lead := candidate - direct
 	lead.y = 0.0
 	if lead.length() <= 0.5:
-		return _finish(pursuer, target, "Qualified moving target produced no meaningful bounded lead")
+		return _finish(fixture, "Qualified moving target produced no meaningful bounded lead")
 	if lead.length() > 4.001:
-		return _finish(pursuer, target, "Bounded lead exceeded the 4 m experiment cap")
+		return _finish(fixture, "Bounded lead exceeded the 4 m experiment cap")
 	if lead.normalized().dot(Vector3.RIGHT) < 0.99:
-		return _finish(pursuer, target, "Bounded lead did not follow current observable target velocity")
+		return _finish(fixture, "Bounded lead did not follow current observable target velocity")
 
 	var observable_future := direct + target.velocity * 0.35
 	var direct_error := _heading_error(pursuer.global_position, direct, observable_future)
 	var candidate_error := _heading_error(pursuer.global_position, candidate, observable_future)
 	var improvement := direct_error - candidate_error
 	if improvement < deg_to_rad(3.0):
-		return _finish(pursuer, target, "Bounded lead did not create measurable cut-off heading improvement")
+		return _finish(fixture, "Bounded lead did not create measurable cut-off heading improvement")
 	print("[CTW_FEEL_06] A/B lead_m=%.3f direct_error_deg=%.3f bounded_error_deg=%.3f improvement_deg=%.3f" % [
 		lead.length(),
 		rad_to_deg(direct_error),
@@ -77,26 +82,22 @@ static func verify() -> String:
 		rad_to_deg(improvement),
 	])
 
-	# Low target speed collapses to the direct baseline.
 	var low_speed: Vector3 = pursuer.call("get_bounded_chase_destination", direct, Vector3(0.25, 0.0, 0.0))
 	if low_speed.distance_to(direct) > 0.05:
-		return _finish(pursuer, target, "Prediction did not collapse at very low target speed")
+		return _finish(fixture, "Prediction did not collapse at very low target speed")
 
-	# Close range collapses toward zero even for a fast target.
 	target.global_position = Vector3(0.0, 0.0, 2.0)
 	var close_direct := target.global_position
 	var close_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", close_direct, Vector3(9.0, 0.0, 0.0))
 	if close_candidate.distance_to(close_direct) > 0.05:
-		return _finish(pursuer, target, "Prediction did not collapse at close range")
+		return _finish(fixture, "Prediction did not collapse at close range")
 
-	# Reversal uses the current observed velocity only—no stale lead memory.
 	target.global_position = Vector3(0.0, 0.0, 18.0)
 	var right_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", target.global_position, Vector3(9.0, 0.0, 0.0))
 	var left_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", target.global_position, Vector3(-9.0, 0.0, 0.0))
 	if right_candidate.x <= target.global_position.x or left_candidate.x >= target.global_position.x:
-		return _finish(pursuer, target, "Sharp target reversal preserved stale lead direction")
+		return _finish(fixture, "Sharp target reversal preserved stale lead direction")
 
-	# Authored Signal Gate detours remain authoritative over prediction.
 	var waypoint := Vector3(6.0, 0.0, 12.0)
 	var detour_fixture: Array[Vector3] = [waypoint]
 	pursuer.detour_waypoints = detour_fixture
@@ -104,11 +105,11 @@ static func verify() -> String:
 	pursuer.current_state = PursuerScript.PursuerState.DETOURING
 	var detour_destination: Vector3 = pursuer.call("get_navigation_destination")
 	if detour_destination.distance_to(waypoint) > 0.001:
-		return _finish(pursuer, target, "DETOURING waypoint stopped being authoritative over prediction")
+		return _finish(fixture, "DETOURING waypoint stopped being authoritative over prediction")
 
 	if not is_equal_approx(float(pursuer.max_speed), baseline_max_speed):
-		return _finish(pursuer, target, "Feel 06 changed pursuer top speed during destination A/B")
+		return _finish(fixture, "Feel 06 changed pursuer top speed during destination A/B")
 	if not is_equal_approx(float(pursuer.acceleration), baseline_acceleration):
-		return _finish(pursuer, target, "Feel 06 changed pursuer acceleration during destination A/B")
+		return _finish(fixture, "Feel 06 changed pursuer acceleration during destination A/B")
 
-	return _finish(pursuer, target, "")
+	return _finish(fixture, "")

--- a/godot/tests/pursuer_intercept_contract_test.gd
+++ b/godot/tests/pursuer_intercept_contract_test.gd
@@ -11,64 +11,65 @@ static func _heading_error(from_pos: Vector3, destination: Vector3, reference: V
 		return 0.0
 	return absf(a.normalized().angle_to(b.normalized()))
 
-static func verify(pursuer: Node, target: Node3D) -> String:
+static func _finish(pursuer: Node, target: Node, message: String) -> String:
+	if is_instance_valid(target):
+		target.free()
+	if is_instance_valid(pursuer):
+		pursuer.free()
+	return message
+
+static func verify() -> String:
+	# Keep this A/B contract independent from the live prototype scene. Retained
+	# V4/V5/M15 suites already own full pursuit/gate/retry lifecycle coverage;
+	# this test owns only the new destination-selection experiment.
+	var pursuer := PursuerScript.new()
+	var target := CharacterBody3D.new()
 	if pursuer == null or target == null:
-		return "Pursuer intercept contract requires live pursuer and target nodes"
+		return _finish(pursuer, target, "Could not construct isolated pursuer A/B fixture")
 	if not pursuer.has_method("get_bounded_chase_destination"):
-		return "Pursuer bounded chase destination seam is absent"
+		return _finish(pursuer, target, "Pursuer bounded chase destination seam is absent")
 	if not pursuer.has_method("get_navigation_destination"):
-		return "Pursuer navigation destination seam is absent"
+		return _finish(pursuer, target, "Pursuer navigation destination seam is absent")
 
 	var baseline_max_speed := float(pursuer.max_speed)
 	var baseline_acceleration := float(pursuer.acceleration)
-	var original_pursuer_pos := pursuer.global_position
-	var original_target_pos := target.global_position
-	var original_target_velocity = target.get("velocity")
-	var original_state := int(pursuer.current_state)
-	var original_target_node = pursuer.target_node
-	var original_detours: Array[Vector3] = pursuer.detour_waypoints.duplicate()
-	var original_detour_index := int(pursuer.current_detour_index)
-	var original_intercept_enabled := bool(pursuer.bounded_intercept_enabled)
-
 	pursuer.global_position = Vector3.ZERO
 	target.global_position = Vector3(0.0, 0.0, 18.0)
-	target.set("velocity", Vector3(9.0, 0.0, 0.0))
+	target.velocity = Vector3(9.0, 0.0, 0.0)
 	pursuer.target_node = target
 	pursuer.current_state = PursuerScript.PursuerState.CHASING
 	pursuer.detour_waypoints.clear()
 	pursuer.current_detour_index = -1
 
 	# A = direct world target, B = bounded observable-velocity interception.
-	# Both use the exact same live pursuer and target fixture so movement tuning,
-	# collisions, steering and target motion are held constant.
+	# Same production pursuer object, target pose and motion; only the experiment
+	# flag changes the selected navigation destination.
 	pursuer.bounded_intercept_enabled = false
 	var direct: Vector3 = pursuer.call("get_navigation_destination")
 	if direct.distance_to(target.global_position) > 0.001:
-		return "A baseline did not resolve to the current world target position"
+		return _finish(pursuer, target, "A baseline did not resolve to current target position")
 
 	pursuer.bounded_intercept_enabled = true
 	var candidate: Vector3 = pursuer.call("get_navigation_destination")
-	var helper_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", direct, target.get("velocity"))
+	var helper_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", direct, target.velocity)
 	if candidate.distance_to(helper_candidate) > 0.001:
-		return "B navigation destination diverged from the bounded prediction helper"
+		return _finish(pursuer, target, "B navigation destination diverged from bounded helper")
 
 	var lead := candidate - direct
 	lead.y = 0.0
 	if lead.length() <= 0.5:
-		return "Qualified moving target produced no meaningful bounded lead"
+		return _finish(pursuer, target, "Qualified moving target produced no meaningful bounded lead")
 	if lead.length() > 4.001:
-		return "Bounded lead exceeded the 4 m experiment cap"
+		return _finish(pursuer, target, "Bounded lead exceeded the 4 m experiment cap")
 	if lead.normalized().dot(Vector3.RIGHT) < 0.99:
-		return "Bounded lead did not follow observable current target velocity"
+		return _finish(pursuer, target, "Bounded lead did not follow current observable target velocity")
 
-	# Compare against the target's short observable continuation. The candidate
-	# should reduce heading error versus tail-following without teleporting.
-	var observable_future := direct + Vector3(9.0, 0.0, 0.0) * 0.35
+	var observable_future := direct + target.velocity * 0.35
 	var direct_error := _heading_error(pursuer.global_position, direct, observable_future)
 	var candidate_error := _heading_error(pursuer.global_position, candidate, observable_future)
 	var improvement := direct_error - candidate_error
 	if improvement < deg_to_rad(3.0):
-		return "Bounded lead did not create a measurable cut-off heading improvement"
+		return _finish(pursuer, target, "Bounded lead did not create measurable cut-off heading improvement")
 	print("[CTW_FEEL_06] A/B lead_m=%.3f direct_error_deg=%.3f bounded_error_deg=%.3f improvement_deg=%.3f" % [
 		lead.length(),
 		rad_to_deg(direct_error),
@@ -79,21 +80,21 @@ static func verify(pursuer: Node, target: Node3D) -> String:
 	# Low target speed collapses to the direct baseline.
 	var low_speed: Vector3 = pursuer.call("get_bounded_chase_destination", direct, Vector3(0.25, 0.0, 0.0))
 	if low_speed.distance_to(direct) > 0.05:
-		return "Prediction did not collapse at very low target speed"
+		return _finish(pursuer, target, "Prediction did not collapse at very low target speed")
 
 	# Close range collapses toward zero even for a fast target.
 	target.global_position = Vector3(0.0, 0.0, 2.0)
 	var close_direct := target.global_position
 	var close_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", close_direct, Vector3(9.0, 0.0, 0.0))
 	if close_candidate.distance_to(close_direct) > 0.05:
-		return "Prediction did not collapse at close range"
+		return _finish(pursuer, target, "Prediction did not collapse at close range")
 
-	# Reversal must respond only to the current observable velocity—no stale lead.
+	# Reversal uses the current observed velocity only—no stale lead memory.
 	target.global_position = Vector3(0.0, 0.0, 18.0)
 	var right_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", target.global_position, Vector3(9.0, 0.0, 0.0))
 	var left_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", target.global_position, Vector3(-9.0, 0.0, 0.0))
 	if right_candidate.x <= target.global_position.x or left_candidate.x >= target.global_position.x:
-		return "Sharp target reversal preserved stale lead direction"
+		return _finish(pursuer, target, "Sharp target reversal preserved stale lead direction")
 
 	# Authored Signal Gate detours remain authoritative over prediction.
 	var waypoint := Vector3(6.0, 0.0, 12.0)
@@ -103,21 +104,11 @@ static func verify(pursuer: Node, target: Node3D) -> String:
 	pursuer.current_state = PursuerScript.PursuerState.DETOURING
 	var detour_destination: Vector3 = pursuer.call("get_navigation_destination")
 	if detour_destination.distance_to(waypoint) > 0.001:
-		return "DETOURING waypoint stopped being authoritative over prediction"
+		return _finish(pursuer, target, "DETOURING waypoint stopped being authoritative over prediction")
 
 	if not is_equal_approx(float(pursuer.max_speed), baseline_max_speed):
-		return "Feel 06 changed pursuer top speed during destination A/B"
+		return _finish(pursuer, target, "Feel 06 changed pursuer top speed during destination A/B")
 	if not is_equal_approx(float(pursuer.acceleration), baseline_acceleration):
-		return "Feel 06 changed pursuer acceleration during destination A/B"
+		return _finish(pursuer, target, "Feel 06 changed pursuer acceleration during destination A/B")
 
-	# Restore the live fixture so the existing vehicle-authority integration test
-	# continues from its canonical setup.
-	pursuer.global_position = original_pursuer_pos
-	target.global_position = original_target_pos
-	target.set("velocity", original_target_velocity)
-	pursuer.current_state = original_state
-	pursuer.target_node = original_target_node
-	pursuer.detour_waypoints = original_detours
-	pursuer.current_detour_index = original_detour_index
-	pursuer.bounded_intercept_enabled = original_intercept_enabled
-	return ""
+	return _finish(pursuer, target, "")

--- a/godot/tests/pursuer_intercept_contract_test.gd
+++ b/godot/tests/pursuer_intercept_contract_test.gd
@@ -1,0 +1,101 @@
+extends RefCounted
+
+const PursuerScript = preload("res://scripts/entities/pursuer_prototype.gd")
+
+static func _heading_error(from_pos: Vector3, destination: Vector3, reference: Vector3) -> float:
+	var a := destination - from_pos
+	var b := reference - from_pos
+	a.y = 0.0
+	b.y = 0.0
+	if a.length() <= 0.001 or b.length() <= 0.001:
+		return 0.0
+	return absf(a.normalized().angle_to(b.normalized()))
+
+static func verify(pursuer: Node, target: Node3D) -> String:
+	if pursuer == null or target == null:
+		return "Pursuer intercept contract requires live pursuer and target nodes"
+	if not pursuer.has_method("get_bounded_chase_destination"):
+		return "Pursuer bounded chase destination seam is absent"
+	if not pursuer.has_method("get_navigation_destination"):
+		return "Pursuer navigation destination seam is absent"
+
+	var baseline_max_speed := float(pursuer.max_speed)
+	var baseline_acceleration := float(pursuer.acceleration)
+	var original_pursuer_pos := pursuer.global_position
+	var original_target_pos := target.global_position
+	var original_target_velocity = target.get("velocity")
+	var original_state := int(pursuer.current_state)
+	var original_target_node = pursuer.target_node
+	var original_detours: Array[Vector3] = pursuer.detour_waypoints.duplicate()
+	var original_detour_index := int(pursuer.current_detour_index)
+
+	pursuer.global_position = Vector3.ZERO
+	target.global_position = Vector3(0.0, 0.0, 18.0)
+	target.set("velocity", Vector3(9.0, 0.0, 0.0))
+	pursuer.target_node = target
+	pursuer.current_state = PursuerScript.PursuerState.CHASING
+	pursuer.detour_waypoints.clear()
+	pursuer.current_detour_index = -1
+
+	var direct := target.global_position
+	var candidate: Vector3 = pursuer.call("get_bounded_chase_destination", direct, target.get("velocity"))
+	var lead := candidate - direct
+	lead.y = 0.0
+	if lead.length() <= 0.5:
+		return "Qualified moving target produced no meaningful bounded lead"
+	if lead.length() > 4.001:
+		return "Bounded lead exceeded the 4 m experiment cap"
+	if lead.normalized().dot(Vector3.RIGHT) < 0.99:
+		return "Bounded lead did not follow observable current target velocity"
+
+	# Compare against the target's short observable continuation. The candidate
+	# should reduce the heading error versus tail-following without teleporting.
+	var observable_future := direct + Vector3(9.0, 0.0, 0.0) * 0.35
+	var direct_error := _heading_error(pursuer.global_position, direct, observable_future)
+	var candidate_error := _heading_error(pursuer.global_position, candidate, observable_future)
+	if candidate_error >= direct_error - deg_to_rad(3.0):
+		return "Bounded lead did not create a measurable cut-off heading improvement"
+
+	# Low target speed collapses to the direct baseline.
+	var low_speed: Vector3 = pursuer.call("get_bounded_chase_destination", direct, Vector3(0.25, 0.0, 0.0))
+	if low_speed.distance_to(direct) > 0.05:
+		return "Prediction did not collapse at very low target speed"
+
+	# Close range collapses toward zero even for a fast target.
+	target.global_position = Vector3(0.0, 0.0, 2.0)
+	var close_direct := target.global_position
+	var close_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", close_direct, Vector3(9.0, 0.0, 0.0))
+	if close_candidate.distance_to(close_direct) > 0.05:
+		return "Prediction did not collapse at close range"
+
+	# Reversal must respond only to the current observable velocity—no stale lead.
+	target.global_position = Vector3(0.0, 0.0, 18.0)
+	var right_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", target.global_position, Vector3(9.0, 0.0, 0.0))
+	var left_candidate: Vector3 = pursuer.call("get_bounded_chase_destination", target.global_position, Vector3(-9.0, 0.0, 0.0))
+	if right_candidate.x <= target.global_position.x or left_candidate.x >= target.global_position.x:
+		return "Sharp target reversal preserved stale lead direction"
+
+	# Authored Signal Gate detours remain authoritative over prediction.
+	var waypoint := Vector3(6.0, 0.0, 12.0)
+	pursuer.detour_waypoints = [waypoint]
+	pursuer.current_detour_index = 0
+	pursuer.current_state = PursuerScript.PursuerState.DETOURING
+	var detour_destination: Vector3 = pursuer.call("get_navigation_destination")
+	if detour_destination.distance_to(waypoint) > 0.001:
+		return "DETOURING waypoint stopped being authoritative over prediction"
+
+	if not is_equal_approx(float(pursuer.max_speed), baseline_max_speed):
+		return "Feel 06 changed pursuer top speed during destination A/B"
+	if not is_equal_approx(float(pursuer.acceleration), baseline_acceleration):
+		return "Feel 06 changed pursuer acceleration during destination A/B"
+
+	# Restore the live fixture so the existing vehicle-authority integration test
+	# continues from its canonical setup.
+	pursuer.global_position = original_pursuer_pos
+	target.global_position = original_target_pos
+	target.set("velocity", original_target_velocity)
+	pursuer.current_state = original_state
+	pursuer.target_node = original_target_node
+	pursuer.detour_waypoints = original_detours
+	pursuer.current_detour_index = original_detour_index
+	return ""


### PR DESCRIPTION
Implements #16 from merged main `bce075dcba65f78c93ed46950c145ee590b74a0b`.

Scope:
- A/B changes direct CHASING destination selection only.
- B uses current observable CharacterBody3D velocity with a 0.15–0.45 s qualified horizon and hard 4 m lead cap.
- Prediction collapses at close range / low target speed and reacts immediately to reversal with no input history.
- Authored Signal Gate DETOURING waypoints remain authoritative.
- Pursuer max speed, acceleration, steering, collision/intercept timer, bike handling, camera, gate logic and audio ownership remain unchanged.

Verification:
- new deterministic `pursuer_intercept_contract_test.gd` is wired into the existing desktop vehicle-authority gate;
- explicit A=direct/B=bounded comparison reports lead distance and cut-off heading improvement;
- tests cover close/slow collapse, sharp reversal, detour authority, and unchanged movement tuning;
- PR compatibility matrix provides retained pursuit/gate/evasion/fast-retry/audio/camera/vehicle regression coverage.

Retention rule: keep bounded interception only if the deterministic A/B metric improves cut-off geometry and all canonical regressions remain green; otherwise restore direct-target default.