### PR TITLE
CTW Feel 02 — touch steering conditioning A/B

### DIFF
--- a/godot/scripts/input/touch_controls.gd
+++ b/godot/scripts/input/touch_controls.gd
@@ -29,6 +29,12 @@ enum UIMode {
 @export var max_joystick_radius: float = 80.0
 @export var debug_hud_enabled: bool = false
 
+# CTW Feel 02 — experimental touch-only static steering conditioning. The
+# validated linear baseline remains the default until real-device qualification.
+@export var vehicle_steer_conditioning_enabled: bool = false
+@export_range(0.0, 0.25, 0.005) var vehicle_steer_deadzone: float = 0.06
+@export_range(1.0, 2.5, 0.05) var vehicle_steer_response_power: float = 1.5
+
 var current_mode: UIMode = UIMode.FOOT_TRAVERSAL
 
 # SafeAreaRoot hierarchy references (with automatic fallback to direct child if not nested)
@@ -142,6 +148,24 @@ func _emit_net_throttle() -> void:
 		throttle = 1.0
 	driving_throttle_updated.emit(throttle)
 
+## CTW Feel 02 pure A/B seam. It is intentionally stateless and receives no
+## vehicle speed or delta-time input; vehicle physics keeps sole yaw authority.
+func get_conditioned_vehicle_steer(joystick_vec: Vector2) -> float:
+	var raw_x: float = clampf(joystick_vec.x, -1.0, 1.0)
+	if not vehicle_steer_conditioning_enabled:
+		return raw_x
+
+	var magnitude: float = clampf(joystick_vec.length(), 0.0, 1.0)
+	var deadzone: float = clampf(vehicle_steer_deadzone, 0.0, 0.95)
+	if magnitude <= deadzone:
+		return 0.0
+
+	var normalized_magnitude: float = clampf((magnitude - deadzone) / maxf(1.0 - deadzone, 0.001), 0.0, 1.0)
+	var response_power: float = maxf(vehicle_steer_response_power, 1.0)
+	var conditioned_magnitude: float = pow(normalized_magnitude, response_power)
+	var direction_x: float = joystick_vec.x / maxf(magnitude, 0.0001)
+	return clampf(direction_x * conditioned_magnitude, -1.0, 1.0)
+
 func _emit_net_steer() -> void:
 	var steer := 0.0
 	if current_mode == UIMode.VEHICLE_DRIVING and (_keyboard_left_pressed or _keyboard_right_pressed):
@@ -149,7 +173,7 @@ func _emit_net_steer() -> void:
 		var left_value := 1.0 if _keyboard_left_pressed else 0.0
 		steer = right_value - left_value
 	elif current_mode == UIMode.VEHICLE_DRIVING and _joystick_active:
-		steer = _current_joystick_vec.x
+		steer = get_conditioned_vehicle_steer(_current_joystick_vec)
 	driving_steer_updated.emit(steer)
 
 func _emit_net_handbrake() -> void:

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -1,6 +1,8 @@
 extends SceneTree
 
 # Exercises actual Viewport -> Control GUI routing, not direct method calls.
+const TouchSteeringConditioningContract = preload("res://tests/touch_steering_conditioning_contract_test.gd")
+
 var _last_joystick_vector := Vector2.ZERO
 var _scene_under_test: Node = null
 
@@ -19,6 +21,11 @@ func _fail(message: String) -> void:
 	await _finish(1)
 
 func _run() -> void:
+	var steering_error: String = TouchSteeringConditioningContract.verify()
+	if not steering_error.is_empty():
+		await _fail("CTW Feel 02: %s" % steering_error)
+		return
+
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
 	if packed == null:
 		await _fail("Could not load scrap_test_block.tscn")

--- a/godot/tests/touch_steering_conditioning_contract_test.gd
+++ b/godot/tests/touch_steering_conditioning_contract_test.gd
@@ -59,11 +59,35 @@ static func verify() -> String:
 			controls.free()
 			return "Candidate steering response lost left/right symmetry at %.2f" % raw_x
 
-	var full_right: float = controls.call("get_conditioned_vehicle_steer", Vector2(1.0, 0.0))
+	# E2 canonical 90-degree turn input is full lock. Candidate must preserve
+	# exact full-lock authority so downstream turn-envelope physics are unchanged.
+	var e2_baseline_full_lock := 1.0
+	var e2_candidate_full_lock: float = controls.call("get_conditioned_vehicle_steer", Vector2(1.0, 0.0))
 	var full_left: float = controls.call("get_conditioned_vehicle_steer", Vector2(-1.0, 0.0))
-	if not _approx(full_right, 1.0) or not _approx(full_left, -1.0):
+	if not _approx(e2_candidate_full_lock, e2_baseline_full_lock) or not _approx(full_left, -1.0):
 		controls.free()
 		return "Candidate no longer reaches full normalized steering lock"
+
+	# E3 canonical reversal is -1 -> +1 with no temporal smoothing. Preserve the
+	# exact 2.0 normalized reversal span and deterministic same-frame response.
+	var e3_baseline_span := 2.0
+	var e3_candidate_span := e2_candidate_full_lock - full_left
+	if not _approx(e3_candidate_span, e3_baseline_span):
+		controls.free()
+		return "Candidate changed canonical full-lock reversal span"
+
+	# E7 canonical route uses +/-0.35 correction windows. Capture the exact
+	# candidate intent attenuation so the physical-device gate can evaluate the
+	# real thumb benefit later without pretending this is already retained.
+	var e7_baseline_correction := 0.35
+	var e7_candidate_correction: float = controls.call("get_conditioned_vehicle_steer", Vector2(e7_baseline_correction, 0.0))
+	var e7_candidate_negative: float = controls.call("get_conditioned_vehicle_steer", Vector2(-e7_baseline_correction, 0.0))
+	if e7_candidate_correction <= 0.0 or e7_candidate_correction >= e7_baseline_correction:
+		controls.free()
+		return "Candidate did not soften canonical E7 correction intent"
+	if not _approx(e7_candidate_correction, -e7_candidate_negative):
+		controls.free()
+		return "Candidate E7 correction lost left/right symmetry"
 
 	var diagonal: float = controls.call("get_conditioned_vehicle_steer", Vector2(0.30, 0.40))
 	if diagonal <= 0.0 or diagonal >= 0.30:
@@ -78,6 +102,17 @@ static func verify() -> String:
 			controls.free()
 			return "Candidate introduced temporal/history-dependent steering output"
 
-	print("[CTW_FEEL_02] A/B deadzone=%.3f response_power=%.3f sample_raw=0.420 sample_conditioned=%.3f" % [deadzone, response_power, first])
+	print("[CTW_FEEL_02] A/B deadzone=%.3f response_power=%.3f E2_full_lock_A=%.3f E2_full_lock_B=%.3f E3_span_A=%.3f E3_span_B=%.3f E7_correction_A=%.3f E7_correction_B=%.3f E7_ratio=%.3f sample_raw=0.420 sample_conditioned=%.3f" % [
+		deadzone,
+		response_power,
+		e2_baseline_full_lock,
+		e2_candidate_full_lock,
+		e3_baseline_span,
+		e3_candidate_span,
+		e7_baseline_correction,
+		e7_candidate_correction,
+		e7_candidate_correction / e7_baseline_correction,
+		first,
+	])
 	controls.free()
 	return ""

--- a/godot/tests/touch_steering_conditioning_contract_test.gd
+++ b/godot/tests/touch_steering_conditioning_contract_test.gd
@@ -1,0 +1,83 @@
+extends RefCounted
+
+const TouchControlsScript = preload("res://scripts/input/touch_controls.gd")
+
+static func _approx(a: float, b: float, epsilon: float = 0.0001) -> bool:
+	return absf(a - b) <= epsilon
+
+static func verify() -> String:
+	var controls := TouchControlsScript.new()
+	if controls == null:
+		return "Could not construct TouchControlsUI steering fixture"
+	if not controls.has_method("get_conditioned_vehicle_steer"):
+		controls.free()
+		return "Touch steering conditioning seam is absent"
+
+	# A = retained baseline. Default must remain exactly linear until real-device
+	# qualification exists; desktop keyboard steering is outside this pure seam.
+	if bool(controls.get("vehicle_steer_conditioning_enabled")):
+		controls.free()
+		return "Touch steering candidate became default before physical-device qualification"
+	for raw_x in [-1.0, -0.6, -0.2, 0.0, 0.2, 0.6, 1.0]:
+		var baseline: float = controls.call("get_conditioned_vehicle_steer", Vector2(raw_x, 0.0))
+		if not _approx(baseline, raw_x):
+			controls.free()
+			return "Linear A baseline changed at raw steer %.2f" % raw_x
+
+	# B = static candidate only: radial deadzone + monotonic symmetric
+	# center-softening. No temporal history or speed input participates.
+	controls.set("vehicle_steer_conditioning_enabled", true)
+	var deadzone := float(controls.get("vehicle_steer_deadzone"))
+	var response_power := float(controls.get("vehicle_steer_response_power"))
+	if deadzone < 0.05 or deadzone > 0.08:
+		controls.free()
+		return "Candidate deadzone escaped the 0.05–0.08 search envelope"
+	if response_power < 1.4 or response_power > 1.7:
+		controls.free()
+		return "Candidate response power escaped the 1.4–1.7 search envelope"
+
+	var inside_deadzone: float = controls.call("get_conditioned_vehicle_steer", Vector2(deadzone * 0.5, deadzone * 0.25))
+	if not _approx(inside_deadzone, 0.0):
+		controls.free()
+		return "Radial deadzone did not collapse tiny touch motion to zero"
+
+	var previous := -0.001
+	for raw_x in [0.10, 0.20, 0.35, 0.55, 0.75, 1.0]:
+		var conditioned: float = controls.call("get_conditioned_vehicle_steer", Vector2(raw_x, 0.0))
+		if conditioned <= previous:
+			controls.free()
+			return "Candidate steering response is not strictly monotonic"
+		if raw_x < 0.75 and conditioned >= raw_x:
+			controls.free()
+			return "Candidate failed to soften center steering at %.2f" % raw_x
+		previous = conditioned
+
+	for raw_x in [0.12, 0.30, 0.65, 1.0]:
+		var positive: float = controls.call("get_conditioned_vehicle_steer", Vector2(raw_x, 0.0))
+		var negative: float = controls.call("get_conditioned_vehicle_steer", Vector2(-raw_x, 0.0))
+		if not _approx(positive, -negative):
+			controls.free()
+			return "Candidate steering response lost left/right symmetry at %.2f" % raw_x
+
+	var full_right: float = controls.call("get_conditioned_vehicle_steer", Vector2(1.0, 0.0))
+	var full_left: float = controls.call("get_conditioned_vehicle_steer", Vector2(-1.0, 0.0))
+	if not _approx(full_right, 1.0) or not _approx(full_left, -1.0):
+		controls.free()
+		return "Candidate no longer reaches full normalized steering lock"
+
+	var diagonal: float = controls.call("get_conditioned_vehicle_steer", Vector2(0.30, 0.40))
+	if diagonal <= 0.0 or diagonal >= 0.30:
+		controls.free()
+		return "Radial conditioning did not preserve a bounded diagonal steering contribution"
+
+	# Repeated evaluation must be stateless: same touch vector, same result.
+	var sample := Vector2(0.42, -0.18)
+	var first: float = controls.call("get_conditioned_vehicle_steer", sample)
+	for _i in range(8):
+		if not _approx(float(controls.call("get_conditioned_vehicle_steer", sample)), first):
+			controls.free()
+			return "Candidate introduced temporal/history-dependent steering output"
+
+	print("[CTW_FEEL_02] A/B deadzone=%.3f response_power=%.3f sample_raw=0.420 sample_conditioned=%.3f" % [deadzone, response_power, first])
+	controls.free()
+	return ""

--- a/godot/verification/feel/ctw_feel02_touch_steering_ab.json
+++ b/godot/verification/feel/ctw_feel02_touch_steering_ab.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "ticket": 12,
+  "base_main_sha": "3f66483805606e523434409bf2ab86e9bfa88b4c",
+  "implementation_commit": "2d05127b0b72f8d3d4c2b5ec5b0a5098cce8d35f",
+  "candidate": {
+    "default_enabled": false,
+    "deadzone": 0.06,
+    "response_power": 1.5,
+    "temporal_smoothing": false,
+    "speed_sensitive_touch_attenuation": false,
+    "ownership": "raw touch -> floating joystick geometry -> static conditioning -> normalized steer intent -> Courier Bike physics"
+  },
+  "deterministic_ab_metrics": {
+    "E2_constant_90_turn": {
+      "baseline_full_lock_intent": 1.0,
+      "candidate_full_lock_intent": 1.0,
+      "input_delta": 0.0,
+      "interpretation": "canonical full-lock turn authority remains unchanged"
+    },
+    "E3_steering_reversal": {
+      "baseline_reversal_span": 2.0,
+      "candidate_reversal_span": 2.0,
+      "temporal_history_frames": 0,
+      "interpretation": "full-lock reversal remains immediate and symmetric"
+    },
+    "E7_pursuit_route": {
+      "baseline_correction_intent": 0.35,
+      "candidate_correction_intent": 0.17135832819555988,
+      "candidate_to_baseline_ratio": 0.4895952234158854,
+      "interpretation": "candidate materially softens small route corrections; gameplay default remains linear pending physical touch qualification"
+    }
+  },
+  "verification_policy": {
+    "automated_code_gate": "required",
+    "physical_touch_gate": "not performed in implementation plane",
+    "default_change_allowed": false
+  },
+  "completion_result": "PHYSICAL_TOUCH_GATE_PENDING",
+  "retention_status": "EXPERIMENTAL_CANDIDATE_AVAILABLE__LINEAR_DEFAULT_RETAINED"
+}


### PR DESCRIPTION
Implements #12 from main `3f66483805606e523434409bf2ab86e9bfa88b4c` as an experimental/configurable path while preserving the validated linear default.

Scope:
- one touch-only static conditioning seam in `TouchControlsUI`;
- candidate parameters: radial deadzone `0.06`, response power `1.5`;
- no temporal smoothing, no speed-sensitive touch attenuation, no Courier Bike physics retune;
- desktop keyboard steering bypasses the touch conditioner;
- candidate flag defaults `false`, so linear steering remains production default pending real-device qualification.

Deterministic A/B evidence:
- E2 full-lock intent: A `1.0`, B `1.0`;
- E3 reversal span: A `2.0`, B `2.0`, zero history frames;
- E7 canonical correction: A `0.35`, B `0.1713583282` (`48.96%` of baseline);
- monotonicity, left/right symmetry, radial deadzone, diagonal bounds, repeatability/statelessness are contract-tested;
- existing touch safe-area/pointer/multitouch and full gameplay regression suites remain the compatibility gate.

Completion disposition for this implementation plane: `PHYSICAL_TOUCH_GATE_PENDING` / `EXPERIMENTAL_CANDIDATE_AVAILABLE__LINEAR_DEFAULT_RETAINED`. Per #12, no real-device proof means the candidate does not become default.