### PR TITLE
Mission/Narrative 01 — first complete scrap-job crime loop

### DIFF
--- a/contracts/mission_narrative_01_scrap_job_spec.md
+++ b/contracts/mission_narrative_01_scrap_job_spec.md
@@ -1,0 +1,43 @@
+# Mission / Narrative 01 — First Complete Scrap-Job Crime Loop
+
+**Status:** implementation target  
+**Baseline:** `7627601089f1872d906452e90da2db3dd533784f`  
+**Product intent:** turn the existing golden-slice playground into one authored, replayable crime job without introducing a general-purpose mission framework.
+
+## Player fantasy
+
+Lira sends the runner to steal a customs salvage core that the yard has already marked for municipal recycling. The runner takes the Courier Bike, crosses the yard, spoofs the tuner, pulls the core, survives the resulting pursuit, chooses whether to spend the Signal Gate shortcut, and gets a concrete payoff once contact is broken.
+
+Tone is economical crime satire: short lines, sharp contrast between criminal pragmatism and bureaucratic language, dry consequences communicated through gameplay. No imitation of a living writer.
+
+## Authored flow
+
+`briefing/contact -> get bike -> vehicle traversal -> tuner spoof -> core extraction -> pursuit complication -> route decision -> escape/failure -> payoff/aftermath`
+
+The job reuses the retained Courier Bike, Signal Tuner, Corroded Panel, Memory Echo, pursuit, Signal Gate, fast retry, radio/audio, camera and interaction systems. It must not reopen retained camera/steering/audio-foundation work.
+
+## Acceptance criteria
+
+1. A visible mission HUD identifies the job, current objective and current contact line during normal play.
+2. On cold start the player receives a concise Lira briefing and an objective to take the Courier Bike.
+3. Mounting the Courier Bike advances the objective to traverse to the tuner mast; arriving near the tuner advances it to the spoof interaction.
+4. Locking the tuner advances the objective to steal the customs core; extracting the core advances the job into escape pressure without bypassing the existing Memory Echo sequence.
+5. When the existing pursuer becomes active, the job presents a route decision: Signal Gate shortcut or long road.
+6. Triggering the Signal Gate records the shortcut route and updates the escape objective. Escaping without the gate records the long-road route.
+7. Interception puts the job in a failed/retry state and preserves the existing fast pursuit retry flow. When the retained pursuit retry restarts, the job returns to the route-decision/escape phase rather than replaying solved setup.
+8. Successful pursuit de-escalation completes the job and shows an explicit payoff plus a short aftermath line.
+9. A deterministic contract test covers the authored state machine, including shortcut completion, long-road completion, interception/retry, wrong-order rejection and objective/payoff text.
+10. The existing canonical Godot Web Playtest compatibility matrix remains green on the exact PR head.
+
+## Non-goals
+
+- No inventory, economy, mission database, quest journal, cutscene system, branching dialogue framework or general mission graph.
+- No new vehicle, pursuer, camera, steering or audio subsystem.
+- No physical-listening or owner-play perceptual gate for this code-first authored job unless a concrete perceptual defect is observed.
+- No closure of Audio Runtime #31 or the administratively open Feel/Audio tickets.
+
+## Verification
+
+- New mission-state contract test runs headlessly in CI.
+- Existing Web export + exact-head compatibility matrix remain required.
+- Interactive browser verification should be attempted only against an exact-commit public/deployed build with browser-control capability; missing browser control is reported as a coverage limitation, not converted into PASS.

--- a/godot/scenes/prototype/scrap_test_block.tscn
+++ b/godot/scenes/prototype/scrap_test_block.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://c_scrap_test_block_001"]
+[gd_scene load_steps=26 format=3 uid="uid://c_scrap_test_block_001"]
 
 [ext_resource type="Script" path="res://scripts/prototype/scrap_test_block.gd" id="1_root"]
 
@@ -15,6 +15,7 @@
 [ext_resource type="PackedScene" uid="uid://e00dress01proof" path="res://scenes/world/scrap_yard_dressing.tscn" id="7_dressing"]
 [ext_resource type="PackedScene" uid="uid://vfx_dust_drift_001" path="res://scenes/vfx/dust_drift_particles.tscn" id="8_dust"]
 [ext_resource type="Script" path="res://scripts/audio/ui_audio_identity_layer.gd" id="9_ui_audio"]
+[ext_resource type="Script" path="res://scripts/missions/scrap_job_mission_runtime.gd" id="10_mission_runtime"]
 
 [sub_resource type="Environment" id="Environment_1"]
 background_mode = 1
@@ -209,6 +210,9 @@ script = ExtResource("6_audio")
 script = ExtResource("9_ui_audio")
 
 [node name="ScrapYardDressing" parent="." instance=ExtResource("7_dressing")]
+
+[node name="MissionScrapJobRuntime" type="Node" parent="."]
+script = ExtResource("10_mission_runtime")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 

--- a/godot/scripts/missions/scrap_job_mission.gd
+++ b/godot/scripts/missions/scrap_job_mission.gd
@@ -126,6 +126,36 @@ func on_escape_complete() -> bool:
 		contact_line = "LIRA // Core received. Municipal loss report says 'routing delay.' Even the long road has paperwork."
 	return true
 
+## Reconcile one-shot retained systems after the authored prerequisites are met.
+## A player may solve the tuner/panel before taking the Courier Bike; those
+## production signals do not fire twice. The job therefore catches up from the
+## retained authoritative state without letting wrong-order events skip the
+## bike/traversal beats when they first occur.
+func reconcile_retained_progress(
+	tuner_solved: bool,
+	core_extracted: bool,
+	pursuit_active: bool,
+	intercepted: bool
+) -> bool:
+	var changed := false
+
+	if phase == Phase.SPOOF_SIGNAL and tuner_solved:
+		changed = on_signal_locked() or changed
+	if phase == Phase.EXTRACT_CORE and core_extracted:
+		changed = on_core_extracted() or changed
+
+	# Interception is stronger than active pursuit: the root controller can
+	# reset the pursuer entity immediately after declaring INTERCEPTED.
+	if intercepted:
+		changed = on_intercepted() or changed
+	elif pursuit_active:
+		if phase == Phase.FAILED:
+			changed = on_retry_started() or changed
+		elif phase == Phase.PURSUIT_COMPLICATION:
+			changed = on_pursuit_active() or changed
+
+	return changed
+
 func snapshot() -> Dictionary:
 	return {
 		"phase": phase,

--- a/godot/scripts/missions/scrap_job_mission.gd
+++ b/godot/scripts/missions/scrap_job_mission.gd
@@ -1,0 +1,137 @@
+extends RefCounted
+
+## Mission / Narrative 01
+##
+## Deliberately narrow authored state for the first complete scrap-job crime loop.
+## This is not a general mission framework: the runtime adapter translates the
+## existing golden-slice systems into these authored beats.
+
+enum Phase {
+	BRIEFING,
+	GET_BIKE,
+	TRAVERSE_TO_TUNER,
+	SPOOF_SIGNAL,
+	EXTRACT_CORE,
+	PURSUIT_COMPLICATION,
+	ROUTE_DECISION,
+	ESCAPE,
+	FAILED,
+	COMPLETE,
+}
+
+enum RouteChoice {
+	UNDECIDED,
+	SIGNAL_GATE,
+	LONG_ROAD,
+}
+
+const PAYOFF_CREDITS := 320
+
+var phase: Phase = Phase.BRIEFING
+var route_choice: RouteChoice = RouteChoice.UNDECIDED
+var objective: String = ""
+var contact_line: String = ""
+var reward_credits: int = 0
+var failure_count: int = 0
+var _started: bool = false
+
+func start() -> bool:
+	if _started or phase != Phase.BRIEFING:
+		return false
+	_started = true
+	phase = Phase.GET_BIKE
+	objective = "OBJECTIVE // GET THE COURIER BIKE"
+	contact_line = "LIRA // Yard auditors tagged a customs core for recycling. Recycling means us. Take the bike, lift the core, lose the invoice."
+	return true
+
+func on_courier_bike_mounted() -> bool:
+	if phase != Phase.GET_BIKE:
+		return false
+	phase = Phase.TRAVERSE_TO_TUNER
+	objective = "OBJECTIVE // RIDE TO THE TUNER MAST"
+	contact_line = "LIRA // Keep it ordinary. Nothing alarms a yard like someone driving responsibly."
+	return true
+
+func on_tuner_arrived() -> bool:
+	if phase != Phase.TRAVERSE_TO_TUNER:
+		return false
+	phase = Phase.SPOOF_SIGNAL
+	objective = "OBJECTIVE // DISMOUNT // SPOOF THE YARD SIGNAL"
+	contact_line = "LIRA // Their lock trusts a frequency more than a person. Be the frequency."
+	return true
+
+func on_signal_locked() -> bool:
+	if phase != Phase.SPOOF_SIGNAL:
+		return false
+	phase = Phase.EXTRACT_CORE
+	objective = "OBJECTIVE // PULL THE CUSTOMS CORE"
+	contact_line = "LIRA // Good. The city sold the same lock twice. You are paying once."
+	return true
+
+func on_core_extracted() -> bool:
+	if phase != Phase.EXTRACT_CORE:
+		return false
+	phase = Phase.PURSUIT_COMPLICATION
+	objective = "OBJECTIVE // MOVE // YARD RESPONSE INBOUND"
+	contact_line = "LIRA // Core is hot. Apparently municipal property gets sentimental after theft."
+	return true
+
+func on_pursuit_active() -> bool:
+	if phase != Phase.PURSUIT_COMPLICATION:
+		return false
+	phase = Phase.ROUTE_DECISION
+	objective = "OBJECTIVE // LOSE THE PURSUER // SIGNAL GATE OR LONG ROAD"
+	contact_line = "LIRA // Gate or long road. Pick which lie you can drive faster."
+	return true
+
+func on_gate_triggered() -> bool:
+	if phase != Phase.ROUTE_DECISION and phase != Phase.ESCAPE:
+		return false
+	route_choice = RouteChoice.SIGNAL_GATE
+	phase = Phase.ESCAPE
+	objective = "OBJECTIVE // CUT THE SHORTCUT // BREAK CONTACT"
+	contact_line = "LIRA // Gate is committed. So are you, legally speaking."
+	return true
+
+func on_intercepted() -> bool:
+	if phase not in [Phase.PURSUIT_COMPLICATION, Phase.ROUTE_DECISION, Phase.ESCAPE]:
+		return false
+	failure_count += 1
+	reward_credits = 0
+	phase = Phase.FAILED
+	objective = "JOB BURNED // RETRY PURSUIT"
+	contact_line = "LIRA // The city found its paperwork. Try not to be in it next time."
+	return true
+
+func on_retry_started() -> bool:
+	if phase != Phase.FAILED:
+		return false
+	route_choice = RouteChoice.UNDECIDED
+	phase = Phase.ROUTE_DECISION
+	objective = "OBJECTIVE // LOSE THE PURSUER // SIGNAL GATE OR LONG ROAD"
+	contact_line = "LIRA // Solved setup stays solved. Get gone."
+	return true
+
+func on_escape_complete() -> bool:
+	if phase != Phase.ROUTE_DECISION and phase != Phase.ESCAPE:
+		return false
+	if route_choice == RouteChoice.UNDECIDED:
+		route_choice = RouteChoice.LONG_ROAD
+	phase = Phase.COMPLETE
+	reward_credits = PAYOFF_CREDITS
+	objective = "JOB COMPLETE // %d SCRAP CREDITS CLEARED" % PAYOFF_CREDITS
+	if route_choice == RouteChoice.SIGNAL_GATE:
+		contact_line = "LIRA // Core received. Municipal loss report says 'weather.' Beautiful paperwork."
+	else:
+		contact_line = "LIRA // Core received. Municipal loss report says 'routing delay.' Even the long road has paperwork."
+	return true
+
+func snapshot() -> Dictionary:
+	return {
+		"phase": phase,
+		"route_choice": route_choice,
+		"objective": objective,
+		"contact_line": contact_line,
+		"reward_credits": reward_credits,
+		"failure_count": failure_count,
+	}

--- a/godot/scripts/missions/scrap_job_mission_runtime.gd
+++ b/godot/scripts/missions/scrap_job_mission_runtime.gd
@@ -1,10 +1,11 @@
 extends Node
 
 ## Thin adapter from the retained golden-slice runtime into the authored
-## Mission/Narrative 01 state. It observes existing production signals and does
-## not take ownership of vehicle, pursuit, camera, interaction or audio logic.
+## Mission/Narrative 01 state. It observes existing production signals/state and
+## does not take ownership of vehicle, pursuit, camera, interaction or audio logic.
 
 const MissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
+const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
 const TUNER_ARRIVAL_RADIUS := 5.0
 
 var mission = null
@@ -16,7 +17,6 @@ var _corroded_panel = null
 var _signal_gate = null
 var _pursuer = null
 var _bound: bool = false
-var _pursuer_was_active: bool = false
 
 var _mission_panel: PanelContainer = null
 var _objective_label: Label = null
@@ -33,6 +33,7 @@ func _process(_delta: float) -> void:
 		_try_bind_runtime()
 		return
 
+	var changed := false
 	# The bike mount is the authored prerequisite, but the player may park short
 	# of the mast and finish the approach on foot. Track the rider rather than
 	# requiring the bike to remain occupied at the arrival boundary.
@@ -40,19 +41,15 @@ func _process(_delta: float) -> void:
 	and _runner != null \
 	and _signal_tuner != null \
 	and _runner.global_position.distance_to(_signal_tuner.global_position) <= TUNER_ARRIVAL_RADIUS:
-		if mission.on_tuner_arrived():
-			_refresh_hud()
+		changed = mission.on_tuner_arrived() or changed
 
-	var pursuer_active := bool(_pursuer.get("is_active")) if _pursuer != null else false
-	if pursuer_active and not _pursuer_was_active:
-		var changed := false
-		if mission.phase == MissionScript.Phase.FAILED:
-			changed = mission.on_retry_started() or changed
-		elif mission.phase == MissionScript.Phase.PURSUIT_COMPLICATION:
-			changed = mission.on_pursuit_active() or changed
-		if changed:
-			_refresh_hud()
-	_pursuer_was_active = pursuer_active
+	# Production interactions and pursuit authority already exist outside this
+	# adapter. Reconcile their retained state every frame so one-shot signals used
+	# before the authored prerequisite cannot strand the job, and so the root
+	# controller's interception decision wins over the reset pursuer entity.
+	changed = _reconcile_retained_progress() or changed
+	if changed:
+		_refresh_hud()
 
 	_maybe_restart_after_full_slice_reset()
 
@@ -73,13 +70,28 @@ func _try_bind_runtime() -> void:
 	_signal_tuner.signal_locked.connect(_on_signal_locked)
 	_corroded_panel.extraction_completed.connect(_on_core_extracted)
 	_signal_gate.gate_triggered.connect(_on_gate_triggered)
-	_pursuer.intercepted_target.connect(_on_intercepted)
 	_pursuer.de_escalation_completed.connect(_on_escape_complete)
-	_pursuer_was_active = bool(_pursuer.get("is_active"))
 	_bound = true
 	_ensure_hud()
 	_refresh_hud()
 	print("[MISSION_NARRATIVE_01] Runtime bound to retained golden-slice systems")
+
+func _reconcile_retained_progress() -> bool:
+	if not _bound or _root_controller == null:
+		return false
+
+	var tuner_solved := int(_signal_tuner.get("current_state")) >= int(SignalTuner.TunerState.LOCKED)
+	var core_extracted := int(_corroded_panel.get("current_step")) == int(CorrodedPanel.Step.EXTRACTED)
+	var root_pursuit_state := int(_root_controller.get("current_pursuit_state"))
+	var pursuit_active := root_pursuit_state == int(ScrapTestBlockScript.PursuitState.PURSUIT_ACTIVE)
+	var intercepted := root_pursuit_state == int(ScrapTestBlockScript.PursuitState.INTERCEPTED)
+
+	return mission.reconcile_retained_progress(
+		tuner_solved,
+		core_extracted,
+		pursuit_active,
+		intercepted
+	)
 
 func _on_courier_bike_mounted(_player) -> void:
 	if mission.on_courier_bike_mounted():
@@ -97,10 +109,6 @@ func _on_gate_triggered() -> void:
 	if mission.on_gate_triggered():
 		_refresh_hud()
 
-func _on_intercepted() -> void:
-	if mission.on_intercepted():
-		_refresh_hud()
-
 func _on_escape_complete() -> void:
 	if mission.on_escape_complete():
 		_refresh_hud()
@@ -112,7 +120,8 @@ func _maybe_restart_after_full_slice_reset() -> void:
 		return
 	# Full replay resets solved tuner/panel state. Fast pursuit retry deliberately
 	# preserves the extracted panel, so this cannot accidentally replay setup.
-	if int(_signal_tuner.get("current_state")) != 0 or int(_corroded_panel.get("current_step")) != 0:
+	if int(_signal_tuner.get("current_state")) != int(SignalTuner.TunerState.DORMANT) \
+	or int(_corroded_panel.get("current_step")) != int(CorrodedPanel.Step.IDLE):
 		return
 	mission = MissionScript.new()
 	mission.start()

--- a/godot/scripts/missions/scrap_job_mission_runtime.gd
+++ b/godot/scripts/missions/scrap_job_mission_runtime.gd
@@ -9,6 +9,7 @@ const TUNER_ARRIVAL_RADIUS := 5.0
 
 var mission = null
 var _root_controller: Node = null
+var _runner: Node3D = null
 var _courier_bike = null
 var _signal_tuner = null
 var _corroded_panel = null
@@ -32,11 +33,13 @@ func _process(_delta: float) -> void:
 		_try_bind_runtime()
 		return
 
+	# The bike mount is the authored prerequisite, but the player may park short
+	# of the mast and finish the approach on foot. Track the rider rather than
+	# requiring the bike to remain occupied at the arrival boundary.
 	if mission.phase == MissionScript.Phase.TRAVERSE_TO_TUNER \
-	and _courier_bike != null \
+	and _runner != null \
 	and _signal_tuner != null \
-	and _courier_bike.get("occupant") != null \
-	and _courier_bike.global_position.distance_to(_signal_tuner.global_position) <= TUNER_ARRIVAL_RADIUS:
+	and _runner.global_position.distance_to(_signal_tuner.global_position) <= TUNER_ARRIVAL_RADIUS:
 		if mission.on_tuner_arrived():
 			_refresh_hud()
 
@@ -57,12 +60,13 @@ func _try_bind_runtime() -> void:
 	if _bound or _root_controller == null:
 		return
 
+	_runner = _root_controller.get_node_or_null("Runner") as Node3D
 	_courier_bike = _root_controller.get("courier_bike")
 	_signal_tuner = _root_controller.get("signal_tuner")
 	_corroded_panel = _root_controller.get("corroded_panel")
 	_signal_gate = _root_controller.get("signal_gate")
 	_pursuer = _root_controller.get("pursuer")
-	if _courier_bike == null or _signal_tuner == null or _corroded_panel == null or _signal_gate == null or _pursuer == null:
+	if _runner == null or _courier_bike == null or _signal_tuner == null or _corroded_panel == null or _signal_gate == null or _pursuer == null:
 		return
 
 	_courier_bike.mounted.connect(_on_courier_bike_mounted)

--- a/godot/scripts/missions/scrap_job_mission_runtime.gd
+++ b/godot/scripts/missions/scrap_job_mission_runtime.gd
@@ -127,9 +127,9 @@ func _ensure_hud() -> void:
 	_mission_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_mission_panel.z_index = 40
 	_mission_panel.offset_left = 24.0
-	_mission_panel.offset_top = 24.0
+	_mission_panel.offset_top = 78.0
 	_mission_panel.offset_right = 500.0
-	_mission_panel.offset_bottom = 138.0
+	_mission_panel.offset_bottom = 200.0
 	safe_root.add_child(_mission_panel)
 
 	var margin := MarginContainer.new()

--- a/godot/scripts/missions/scrap_job_mission_runtime.gd
+++ b/godot/scripts/missions/scrap_job_mission_runtime.gd
@@ -9,11 +9,11 @@ const TUNER_ARRIVAL_RADIUS := 5.0
 
 var mission = null
 var _root_controller: Node = null
-var _courier_bike: Node3D = null
-var _signal_tuner: Node3D = null
-var _corroded_panel: Node3D = null
-var _signal_gate: Node3D = null
-var _pursuer: Node3D = null
+var _courier_bike = null
+var _signal_tuner = null
+var _corroded_panel = null
+var _signal_gate = null
+var _pursuer = null
 var _bound: bool = false
 var _pursuer_was_active: bool = false
 
@@ -57,11 +57,11 @@ func _try_bind_runtime() -> void:
 	if _bound or _root_controller == null:
 		return
 
-	_courier_bike = _root_controller.get("courier_bike") as Node3D
-	_signal_tuner = _root_controller.get("signal_tuner") as Node3D
-	_corroded_panel = _root_controller.get("corroded_panel") as Node3D
-	_signal_gate = _root_controller.get("signal_gate") as Node3D
-	_pursuer = _root_controller.get("pursuer") as Node3D
+	_courier_bike = _root_controller.get("courier_bike")
+	_signal_tuner = _root_controller.get("signal_tuner")
+	_corroded_panel = _root_controller.get("corroded_panel")
+	_signal_gate = _root_controller.get("signal_gate")
+	_pursuer = _root_controller.get("pursuer")
 	if _courier_bike == null or _signal_tuner == null or _corroded_panel == null or _signal_gate == null or _pursuer == null:
 		return
 
@@ -133,6 +133,7 @@ func _ensure_hud() -> void:
 	safe_root.add_child(_mission_panel)
 
 	var margin := MarginContainer.new()
+	margin.name = "MissionMargin"
 	margin.add_theme_constant_override("margin_left", 12)
 	margin.add_theme_constant_override("margin_top", 8)
 	margin.add_theme_constant_override("margin_right", 12)
@@ -140,6 +141,7 @@ func _ensure_hud() -> void:
 	_mission_panel.add_child(margin)
 
 	var stack := VBoxContainer.new()
+	stack.name = "MissionStack"
 	stack.add_theme_constant_override("separation", 4)
 	margin.add_child(stack)
 

--- a/godot/scripts/missions/scrap_job_mission_runtime.gd
+++ b/godot/scripts/missions/scrap_job_mission_runtime.gd
@@ -1,0 +1,171 @@
+extends Node
+
+## Thin adapter from the retained golden-slice runtime into the authored
+## Mission/Narrative 01 state. It observes existing production signals and does
+## not take ownership of vehicle, pursuit, camera, interaction or audio logic.
+
+const MissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
+const TUNER_ARRIVAL_RADIUS := 5.0
+
+var mission = null
+var _root_controller: Node = null
+var _courier_bike: Node3D = null
+var _signal_tuner: Node3D = null
+var _corroded_panel: Node3D = null
+var _signal_gate: Node3D = null
+var _pursuer: Node3D = null
+var _bound: bool = false
+var _pursuer_was_active: bool = false
+
+var _mission_panel: PanelContainer = null
+var _objective_label: Label = null
+var _contact_label: Label = null
+
+func _ready() -> void:
+	_root_controller = get_parent()
+	mission = MissionScript.new()
+	mission.start()
+	call_deferred("_try_bind_runtime")
+
+func _process(_delta: float) -> void:
+	if not _bound:
+		_try_bind_runtime()
+		return
+
+	if mission.phase == MissionScript.Phase.TRAVERSE_TO_TUNER \
+	and _courier_bike != null \
+	and _signal_tuner != null \
+	and _courier_bike.get("occupant") != null \
+	and _courier_bike.global_position.distance_to(_signal_tuner.global_position) <= TUNER_ARRIVAL_RADIUS:
+		if mission.on_tuner_arrived():
+			_refresh_hud()
+
+	var pursuer_active := bool(_pursuer.get("is_active")) if _pursuer != null else false
+	if pursuer_active and not _pursuer_was_active:
+		var changed := false
+		if mission.phase == MissionScript.Phase.FAILED:
+			changed = mission.on_retry_started() or changed
+		elif mission.phase == MissionScript.Phase.PURSUIT_COMPLICATION:
+			changed = mission.on_pursuit_active() or changed
+		if changed:
+			_refresh_hud()
+	_pursuer_was_active = pursuer_active
+
+	_maybe_restart_after_full_slice_reset()
+
+func _try_bind_runtime() -> void:
+	if _bound or _root_controller == null:
+		return
+
+	_courier_bike = _root_controller.get("courier_bike") as Node3D
+	_signal_tuner = _root_controller.get("signal_tuner") as Node3D
+	_corroded_panel = _root_controller.get("corroded_panel") as Node3D
+	_signal_gate = _root_controller.get("signal_gate") as Node3D
+	_pursuer = _root_controller.get("pursuer") as Node3D
+	if _courier_bike == null or _signal_tuner == null or _corroded_panel == null or _signal_gate == null or _pursuer == null:
+		return
+
+	_courier_bike.mounted.connect(_on_courier_bike_mounted)
+	_signal_tuner.signal_locked.connect(_on_signal_locked)
+	_corroded_panel.extraction_completed.connect(_on_core_extracted)
+	_signal_gate.gate_triggered.connect(_on_gate_triggered)
+	_pursuer.intercepted_target.connect(_on_intercepted)
+	_pursuer.de_escalation_completed.connect(_on_escape_complete)
+	_pursuer_was_active = bool(_pursuer.get("is_active"))
+	_bound = true
+	_ensure_hud()
+	_refresh_hud()
+	print("[MISSION_NARRATIVE_01] Runtime bound to retained golden-slice systems")
+
+func _on_courier_bike_mounted(_player) -> void:
+	if mission.on_courier_bike_mounted():
+		_refresh_hud()
+
+func _on_signal_locked(_tuner) -> void:
+	if mission.on_signal_locked():
+		_refresh_hud()
+
+func _on_core_extracted() -> void:
+	if mission.on_core_extracted():
+		_refresh_hud()
+
+func _on_gate_triggered() -> void:
+	if mission.on_gate_triggered():
+		_refresh_hud()
+
+func _on_intercepted() -> void:
+	if mission.on_intercepted():
+		_refresh_hud()
+
+func _on_escape_complete() -> void:
+	if mission.on_escape_complete():
+		_refresh_hud()
+
+func _maybe_restart_after_full_slice_reset() -> void:
+	if mission.phase != MissionScript.Phase.COMPLETE and mission.phase != MissionScript.Phase.FAILED:
+		return
+	if _pursuer != null and bool(_pursuer.get("is_active")):
+		return
+	# Full replay resets solved tuner/panel state. Fast pursuit retry deliberately
+	# preserves the extracted panel, so this cannot accidentally replay setup.
+	if int(_signal_tuner.get("current_state")) != 0 or int(_corroded_panel.get("current_step")) != 0:
+		return
+	mission = MissionScript.new()
+	mission.start()
+	_refresh_hud()
+	print("[MISSION_NARRATIVE_01] Full slice reset detected; authored job restarted")
+
+func _ensure_hud() -> void:
+	if _mission_panel != null:
+		return
+	var safe_root := _root_controller.get_node_or_null("CanvasLayer/TouchControlsUI/SafeAreaRoot") as Control
+	if safe_root == null:
+		return
+
+	_mission_panel = PanelContainer.new()
+	_mission_panel.name = "MissionHUD"
+	_mission_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_mission_panel.z_index = 40
+	_mission_panel.offset_left = 24.0
+	_mission_panel.offset_top = 24.0
+	_mission_panel.offset_right = 500.0
+	_mission_panel.offset_bottom = 138.0
+	safe_root.add_child(_mission_panel)
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 12)
+	margin.add_theme_constant_override("margin_top", 8)
+	margin.add_theme_constant_override("margin_right", 12)
+	margin.add_theme_constant_override("margin_bottom", 8)
+	_mission_panel.add_child(margin)
+
+	var stack := VBoxContainer.new()
+	stack.add_theme_constant_override("separation", 4)
+	margin.add_child(stack)
+
+	var title := Label.new()
+	title.name = "MissionTitle"
+	title.text = "SCRAP JOB 01 // CITY PROPERTY"
+	title.add_theme_font_size_override("font_size", 17)
+	stack.add_child(title)
+
+	_objective_label = Label.new()
+	_objective_label.name = "ObjectiveLabel"
+	_objective_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_objective_label.custom_minimum_size = Vector2(440.0, 0.0)
+	_objective_label.add_theme_font_size_override("font_size", 15)
+	stack.add_child(_objective_label)
+
+	_contact_label = Label.new()
+	_contact_label.name = "ContactLabel"
+	_contact_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_contact_label.custom_minimum_size = Vector2(440.0, 0.0)
+	_contact_label.add_theme_font_size_override("font_size", 12)
+	stack.add_child(_contact_label)
+
+func _refresh_hud() -> void:
+	_ensure_hud()
+	if _objective_label == null or _contact_label == null:
+		return
+	_objective_label.text = mission.objective
+	_contact_label.text = mission.contact_line

--- a/godot/scripts/missions/scrap_job_mission_runtime.gd
+++ b/godot/scripts/missions/scrap_job_mission_runtime.gd
@@ -115,6 +115,9 @@ func _maybe_restart_after_full_slice_reset() -> void:
 	_refresh_hud()
 	print("[MISSION_NARRATIVE_01] Full slice reset detected; authored job restarted")
 
+func _make_input_transparent(control: Control) -> void:
+	control.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
 func _ensure_hud() -> void:
 	if _mission_panel != null:
 		return
@@ -124,7 +127,7 @@ func _ensure_hud() -> void:
 
 	_mission_panel = PanelContainer.new()
 	_mission_panel.name = "MissionHUD"
-	_mission_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_make_input_transparent(_mission_panel)
 	_mission_panel.z_index = 40
 	_mission_panel.offset_left = 24.0
 	_mission_panel.offset_top = 78.0
@@ -134,6 +137,7 @@ func _ensure_hud() -> void:
 
 	var margin := MarginContainer.new()
 	margin.name = "MissionMargin"
+	_make_input_transparent(margin)
 	margin.add_theme_constant_override("margin_left", 12)
 	margin.add_theme_constant_override("margin_top", 8)
 	margin.add_theme_constant_override("margin_right", 12)
@@ -142,17 +146,20 @@ func _ensure_hud() -> void:
 
 	var stack := VBoxContainer.new()
 	stack.name = "MissionStack"
+	_make_input_transparent(stack)
 	stack.add_theme_constant_override("separation", 4)
 	margin.add_child(stack)
 
 	var title := Label.new()
 	title.name = "MissionTitle"
+	_make_input_transparent(title)
 	title.text = "SCRAP JOB 01 // CITY PROPERTY"
 	title.add_theme_font_size_override("font_size", 17)
 	stack.add_child(title)
 
 	_objective_label = Label.new()
 	_objective_label.name = "ObjectiveLabel"
+	_make_input_transparent(_objective_label)
 	_objective_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_objective_label.custom_minimum_size = Vector2(440.0, 0.0)
 	_objective_label.add_theme_font_size_override("font_size", 15)
@@ -160,6 +167,7 @@ func _ensure_hud() -> void:
 
 	_contact_label = Label.new()
 	_contact_label.name = "ContactLabel"
+	_make_input_transparent(_contact_label)
 	_contact_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_contact_label.custom_minimum_size = Vector2(440.0, 0.0)
 	_contact_label.add_theme_font_size_override("font_size", 12)

--- a/godot/tests/mission_scrap_job_contract_test.gd
+++ b/godot/tests/mission_scrap_job_contract_test.gd
@@ -1,126 +1,114 @@
-extends SceneTree
+extends RefCounted
 
 const MissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
 
-func _init() -> void:
-	call_deferred("_run")
+static func _advance_to_route_decision(mission) -> String:
+	if not mission.start():
+		return "Mission did not start from briefing state"
+	if not mission.on_courier_bike_mounted():
+		return "Courier Bike mount did not advance traversal"
+	if not mission.on_tuner_arrived():
+		return "Tuner arrival did not advance spoof objective"
+	if not mission.on_signal_locked():
+		return "Signal lock did not advance core theft objective"
+	if not mission.on_core_extracted():
+		return "Core extraction did not enter pursuit complication"
+	if not mission.on_pursuit_active():
+		return "Pursuit activation did not expose route decision"
+	return ""
 
-func _fail(message: String) -> void:
-	push_error("[MISSION_NARRATIVE_01] %s" % message)
-	quit(1)
-
-func _expect(condition: bool, message: String) -> bool:
-	if not condition:
-		_fail(message)
-		return false
-	return true
-
-func _advance_to_route_decision(mission) -> bool:
-	if not _expect(mission.start(), "Mission did not start from briefing state"):
-		return false
-	if not _expect(mission.on_courier_bike_mounted(), "Courier Bike mount did not advance traversal"):
-		return false
-	if not _expect(mission.on_tuner_arrived(), "Tuner arrival did not advance spoof objective"):
-		return false
-	if not _expect(mission.on_signal_locked(), "Signal lock did not advance core theft objective"):
-		return false
-	if not _expect(mission.on_core_extracted(), "Core extraction did not enter pursuit complication"):
-		return false
-	if not _expect(mission.on_pursuit_active(), "Pursuit activation did not expose route decision"):
-		return false
-	return true
-
-func _run() -> void:
+static func verify() -> String:
 	var mission = MissionScript.new()
-	if not _expect(mission.phase == MissionScript.Phase.BRIEFING, "Fresh mission did not begin in BRIEFING"):
-		return
-	if not _expect(mission.start(), "Mission start was rejected"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.GET_BIKE, "Briefing did not resolve to GET_BIKE"):
-		return
-	if not _expect("COURIER BIKE" in mission.objective, "Cold-start objective does not identify the Courier Bike"):
-		return
-	if not _expect(mission.contact_line.begins_with("LIRA //"), "Cold-start contact line is not authored as Lira briefing"):
-		return
+	if mission.phase != MissionScript.Phase.BRIEFING:
+		return "Fresh mission did not begin in BRIEFING"
+	if not mission.start():
+		return "Mission start was rejected"
+	if mission.phase != MissionScript.Phase.GET_BIKE:
+		return "Briefing did not resolve to GET_BIKE"
+	if "COURIER BIKE" not in mission.objective:
+		return "Cold-start objective does not identify the Courier Bike"
+	if not mission.contact_line.begins_with("LIRA //"):
+		return "Cold-start contact line is not authored as Lira briefing"
 
 	var phase_before_wrong_order = mission.phase
-	if not _expect(not mission.on_signal_locked(), "Out-of-order signal lock mutated the mission"):
-		return
-	if not _expect(mission.phase == phase_before_wrong_order, "Wrong-order event changed mission phase"):
-		return
+	if mission.on_signal_locked():
+		return "Out-of-order signal lock mutated the mission"
+	if mission.phase != phase_before_wrong_order:
+		return "Wrong-order event changed mission phase"
 
-	if not _expect(mission.on_courier_bike_mounted(), "Courier Bike mount did not advance mission"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.TRAVERSE_TO_TUNER, "Bike mount did not enter traversal phase"):
-		return
-	if not _expect("TUNER MAST" in mission.objective, "Traversal objective does not name the tuner mast"):
-		return
-	if not _expect(mission.on_tuner_arrived(), "Tuner arrival did not advance mission"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.SPOOF_SIGNAL, "Tuner arrival did not enter spoof phase"):
-		return
-	if not _expect(mission.on_signal_locked(), "Signal lock did not advance mission"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.EXTRACT_CORE, "Signal lock did not enter extraction phase"):
-		return
-	if not _expect("CUSTOMS CORE" in mission.objective, "Extraction objective does not identify the customs core"):
-		return
-	if not _expect(mission.on_core_extracted(), "Core extraction did not advance mission"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.PURSUIT_COMPLICATION, "Core extraction bypassed pursuit complication phase"):
-		return
-	if not _expect(mission.on_pursuit_active(), "Pursuit activation did not advance mission"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.ROUTE_DECISION, "Pursuit did not expose route decision"):
-		return
-	if not _expect("SIGNAL GATE" in mission.objective and "LONG ROAD" in mission.objective, "Route objective does not expose both authored choices"):
-		return
-	if not _expect(mission.on_gate_triggered(), "Signal Gate event did not advance escape"):
-		return
-	if not _expect(mission.route_choice == MissionScript.RouteChoice.SIGNAL_GATE, "Signal Gate route was not recorded"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.ESCAPE, "Signal Gate did not enter ESCAPE"):
-		return
-	if not _expect(mission.on_escape_complete(), "Successful shortcut escape did not complete mission"):
-		return
-	if not _expect(mission.phase == MissionScript.Phase.COMPLETE, "Shortcut run did not reach COMPLETE"):
-		return
-	if not _expect(mission.reward_credits == MissionScript.PAYOFF_CREDITS, "Completed job did not award configured payoff"):
-		return
-	if not _expect(str(MissionScript.PAYOFF_CREDITS) in mission.objective, "Payoff amount is not visible in completion objective"):
-		return
-	if not _expect("Municipal" in mission.contact_line, "Completion aftermath does not carry authored crime-satire consequence"):
-		return
+	if not mission.on_courier_bike_mounted():
+		return "Courier Bike mount did not advance mission"
+	if mission.phase != MissionScript.Phase.TRAVERSE_TO_TUNER:
+		return "Bike mount did not enter traversal phase"
+	if "TUNER MAST" not in mission.objective:
+		return "Traversal objective does not name the tuner mast"
+	if not mission.on_tuner_arrived():
+		return "Tuner arrival did not advance mission"
+	if mission.phase != MissionScript.Phase.SPOOF_SIGNAL:
+		return "Tuner arrival did not enter spoof phase"
+	if not mission.on_signal_locked():
+		return "Signal lock did not advance mission"
+	if mission.phase != MissionScript.Phase.EXTRACT_CORE:
+		return "Signal lock did not enter extraction phase"
+	if "CUSTOMS CORE" not in mission.objective:
+		return "Extraction objective does not identify the customs core"
+	if not mission.on_core_extracted():
+		return "Core extraction did not advance mission"
+	if mission.phase != MissionScript.Phase.PURSUIT_COMPLICATION:
+		return "Core extraction bypassed pursuit complication phase"
+	if not mission.on_pursuit_active():
+		return "Pursuit activation did not advance mission"
+	if mission.phase != MissionScript.Phase.ROUTE_DECISION:
+		return "Pursuit did not expose route decision"
+	if "SIGNAL GATE" not in mission.objective or "LONG ROAD" not in mission.objective:
+		return "Route objective does not expose both authored choices"
+	if not mission.on_gate_triggered():
+		return "Signal Gate event did not advance escape"
+	if mission.route_choice != MissionScript.RouteChoice.SIGNAL_GATE:
+		return "Signal Gate route was not recorded"
+	if mission.phase != MissionScript.Phase.ESCAPE:
+		return "Signal Gate did not enter ESCAPE"
+	if not mission.on_escape_complete():
+		return "Successful shortcut escape did not complete mission"
+	if mission.phase != MissionScript.Phase.COMPLETE:
+		return "Shortcut run did not reach COMPLETE"
+	if mission.reward_credits != MissionScript.PAYOFF_CREDITS:
+		return "Completed job did not award configured payoff"
+	if str(MissionScript.PAYOFF_CREDITS) not in mission.objective:
+		return "Payoff amount is not visible in completion objective"
+	if "Municipal" not in mission.contact_line:
+		return "Completion aftermath does not carry authored crime-satire consequence"
 
 	var long_road = MissionScript.new()
-	if not _advance_to_route_decision(long_road):
-		return
-	if not _expect(long_road.on_escape_complete(), "Long-road evasion did not complete from route decision"):
-		return
-	if not _expect(long_road.route_choice == MissionScript.RouteChoice.LONG_ROAD, "Ungated escape did not record LONG_ROAD"):
-		return
-	if not _expect(long_road.phase == MissionScript.Phase.COMPLETE, "Long-road run did not reach COMPLETE"):
-		return
+	var long_road_setup := _advance_to_route_decision(long_road)
+	if not long_road_setup.is_empty():
+		return long_road_setup
+	if not long_road.on_escape_complete():
+		return "Long-road evasion did not complete from route decision"
+	if long_road.route_choice != MissionScript.RouteChoice.LONG_ROAD:
+		return "Ungated escape did not record LONG_ROAD"
+	if long_road.phase != MissionScript.Phase.COMPLETE:
+		return "Long-road run did not reach COMPLETE"
 
 	var retry = MissionScript.new()
-	if not _advance_to_route_decision(retry):
-		return
-	if not _expect(retry.on_intercepted(), "Interception did not fail active job"):
-		return
-	if not _expect(retry.phase == MissionScript.Phase.FAILED, "Interception did not enter FAILED"):
-		return
-	if not _expect(retry.reward_credits == 0, "Failed job incorrectly retained payoff"):
-		return
-	if not _expect("RETRY PURSUIT" in retry.objective, "Failure objective does not expose retained fast retry"):
-		return
-	if not _expect(retry.on_retry_started(), "Fast retry did not resume authored job"):
-		return
-	if not _expect(retry.phase == MissionScript.Phase.ROUTE_DECISION, "Fast retry replayed solved setup instead of route decision"):
-		return
-	if not _expect(retry.route_choice == MissionScript.RouteChoice.UNDECIDED, "Fast retry did not reset route choice"):
-		return
-	if not _expect(retry.failure_count == 1, "Failure accounting is incorrect"):
-		return
+	var retry_setup := _advance_to_route_decision(retry)
+	if not retry_setup.is_empty():
+		return retry_setup
+	if not retry.on_intercepted():
+		return "Interception did not fail active job"
+	if retry.phase != MissionScript.Phase.FAILED:
+		return "Interception did not enter FAILED"
+	if retry.reward_credits != 0:
+		return "Failed job incorrectly retained payoff"
+	if "RETRY PURSUIT" not in retry.objective:
+		return "Failure objective does not expose retained fast retry"
+	if not retry.on_retry_started():
+		return "Fast retry did not resume authored job"
+	if retry.phase != MissionScript.Phase.ROUTE_DECISION:
+		return "Fast retry replayed solved setup instead of route decision"
+	if retry.route_choice != MissionScript.RouteChoice.UNDECIDED:
+		return "Fast retry did not reset route choice"
+	if retry.failure_count != 1:
+		return "Failure accounting is incorrect"
 
-	print("[MISSION_NARRATIVE_01] PASS")
-	quit(0)
+	return ""

--- a/godot/tests/mission_scrap_job_contract_test.gd
+++ b/godot/tests/mission_scrap_job_contract_test.gd
@@ -1,0 +1,126 @@
+extends SceneTree
+
+const MissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _fail(message: String) -> void:
+	push_error("[MISSION_NARRATIVE_01] %s" % message)
+	quit(1)
+
+func _expect(condition: bool, message: String) -> bool:
+	if not condition:
+		_fail(message)
+		return false
+	return true
+
+func _advance_to_route_decision(mission) -> bool:
+	if not _expect(mission.start(), "Mission did not start from briefing state"):
+		return false
+	if not _expect(mission.on_courier_bike_mounted(), "Courier Bike mount did not advance traversal"):
+		return false
+	if not _expect(mission.on_tuner_arrived(), "Tuner arrival did not advance spoof objective"):
+		return false
+	if not _expect(mission.on_signal_locked(), "Signal lock did not advance core theft objective"):
+		return false
+	if not _expect(mission.on_core_extracted(), "Core extraction did not enter pursuit complication"):
+		return false
+	if not _expect(mission.on_pursuit_active(), "Pursuit activation did not expose route decision"):
+		return false
+	return true
+
+func _run() -> void:
+	var mission = MissionScript.new()
+	if not _expect(mission.phase == MissionScript.Phase.BRIEFING, "Fresh mission did not begin in BRIEFING"):
+		return
+	if not _expect(mission.start(), "Mission start was rejected"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.GET_BIKE, "Briefing did not resolve to GET_BIKE"):
+		return
+	if not _expect("COURIER BIKE" in mission.objective, "Cold-start objective does not identify the Courier Bike"):
+		return
+	if not _expect(mission.contact_line.begins_with("LIRA //"), "Cold-start contact line is not authored as Lira briefing"):
+		return
+
+	var phase_before_wrong_order = mission.phase
+	if not _expect(not mission.on_signal_locked(), "Out-of-order signal lock mutated the mission"):
+		return
+	if not _expect(mission.phase == phase_before_wrong_order, "Wrong-order event changed mission phase"):
+		return
+
+	if not _expect(mission.on_courier_bike_mounted(), "Courier Bike mount did not advance mission"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.TRAVERSE_TO_TUNER, "Bike mount did not enter traversal phase"):
+		return
+	if not _expect("TUNER MAST" in mission.objective, "Traversal objective does not name the tuner mast"):
+		return
+	if not _expect(mission.on_tuner_arrived(), "Tuner arrival did not advance mission"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.SPOOF_SIGNAL, "Tuner arrival did not enter spoof phase"):
+		return
+	if not _expect(mission.on_signal_locked(), "Signal lock did not advance mission"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.EXTRACT_CORE, "Signal lock did not enter extraction phase"):
+		return
+	if not _expect("CUSTOMS CORE" in mission.objective, "Extraction objective does not identify the customs core"):
+		return
+	if not _expect(mission.on_core_extracted(), "Core extraction did not advance mission"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.PURSUIT_COMPLICATION, "Core extraction bypassed pursuit complication phase"):
+		return
+	if not _expect(mission.on_pursuit_active(), "Pursuit activation did not advance mission"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.ROUTE_DECISION, "Pursuit did not expose route decision"):
+		return
+	if not _expect("SIGNAL GATE" in mission.objective and "LONG ROAD" in mission.objective, "Route objective does not expose both authored choices"):
+		return
+	if not _expect(mission.on_gate_triggered(), "Signal Gate event did not advance escape"):
+		return
+	if not _expect(mission.route_choice == MissionScript.RouteChoice.SIGNAL_GATE, "Signal Gate route was not recorded"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.ESCAPE, "Signal Gate did not enter ESCAPE"):
+		return
+	if not _expect(mission.on_escape_complete(), "Successful shortcut escape did not complete mission"):
+		return
+	if not _expect(mission.phase == MissionScript.Phase.COMPLETE, "Shortcut run did not reach COMPLETE"):
+		return
+	if not _expect(mission.reward_credits == MissionScript.PAYOFF_CREDITS, "Completed job did not award configured payoff"):
+		return
+	if not _expect(str(MissionScript.PAYOFF_CREDITS) in mission.objective, "Payoff amount is not visible in completion objective"):
+		return
+	if not _expect("Municipal" in mission.contact_line, "Completion aftermath does not carry authored crime-satire consequence"):
+		return
+
+	var long_road = MissionScript.new()
+	if not _advance_to_route_decision(long_road):
+		return
+	if not _expect(long_road.on_escape_complete(), "Long-road evasion did not complete from route decision"):
+		return
+	if not _expect(long_road.route_choice == MissionScript.RouteChoice.LONG_ROAD, "Ungated escape did not record LONG_ROAD"):
+		return
+	if not _expect(long_road.phase == MissionScript.Phase.COMPLETE, "Long-road run did not reach COMPLETE"):
+		return
+
+	var retry = MissionScript.new()
+	if not _advance_to_route_decision(retry):
+		return
+	if not _expect(retry.on_intercepted(), "Interception did not fail active job"):
+		return
+	if not _expect(retry.phase == MissionScript.Phase.FAILED, "Interception did not enter FAILED"):
+		return
+	if not _expect(retry.reward_credits == 0, "Failed job incorrectly retained payoff"):
+		return
+	if not _expect("RETRY PURSUIT" in retry.objective, "Failure objective does not expose retained fast retry"):
+		return
+	if not _expect(retry.on_retry_started(), "Fast retry did not resume authored job"):
+		return
+	if not _expect(retry.phase == MissionScript.Phase.ROUTE_DECISION, "Fast retry replayed solved setup instead of route decision"):
+		return
+	if not _expect(retry.route_choice == MissionScript.RouteChoice.UNDECIDED, "Fast retry did not reset route choice"):
+		return
+	if not _expect(retry.failure_count == 1, "Failure accounting is incorrect"):
+		return
+
+	print("[MISSION_NARRATIVE_01] PASS")
+	quit(0)

--- a/godot/tests/mission_scrap_job_contract_test.gd
+++ b/godot/tests/mission_scrap_job_contract_test.gd
@@ -111,4 +111,37 @@ static func verify() -> String:
 	if retry.failure_count != 1:
 		return "Failure accounting is incorrect"
 
+	# Production tuner/panel signals are one-shot. Wrong-order use stays rejected
+	# until the authored bike/traversal prerequisite is met, then retained world
+	# state must catch the mission up rather than requiring a full replay.
+	var consumed_one_shots = MissionScript.new()
+	if not consumed_one_shots.start():
+		return "One-shot reconciliation fixture did not start"
+	if consumed_one_shots.reconcile_retained_progress(true, true, true, false):
+		return "Retained one-shot state skipped the Courier Bike prerequisite"
+	if consumed_one_shots.phase != MissionScript.Phase.GET_BIKE:
+		return "Retained one-shot state mutated GET_BIKE"
+	if not consumed_one_shots.on_courier_bike_mounted():
+		return "One-shot reconciliation fixture did not accept bike mount"
+	if not consumed_one_shots.on_tuner_arrived():
+		return "One-shot reconciliation fixture did not accept tuner arrival"
+	if not consumed_one_shots.reconcile_retained_progress(true, true, true, false):
+		return "Solved tuner/panel/pursuit state did not reconcile after prerequisites"
+	if consumed_one_shots.phase != MissionScript.Phase.ROUTE_DECISION:
+		return "One-shot reconciliation did not catch up through route decision"
+
+	# The golden-slice root controller owns interception and resets the pursuer
+	# entity immediately. Controller-authoritative INTERCEPTED must fail the job;
+	# the next controller-authoritative active pursuit must resume fast retry.
+	if not consumed_one_shots.reconcile_retained_progress(true, true, false, true):
+		return "Controller-authoritative interception did not fail the authored job"
+	if consumed_one_shots.phase != MissionScript.Phase.FAILED:
+		return "Controller-authoritative interception did not enter FAILED"
+	if not consumed_one_shots.reconcile_retained_progress(true, true, true, false):
+		return "Controller-authoritative retry pursuit did not resume the authored job"
+	if consumed_one_shots.phase != MissionScript.Phase.ROUTE_DECISION:
+		return "Controller-authoritative retry did not return to route decision"
+	if consumed_one_shots.failure_count != 1:
+		return "Controller-authoritative failure accounting is incorrect"
+
 	return ""

--- a/godot/tests/mission_scrap_job_runtime_test.gd
+++ b/godot/tests/mission_scrap_job_runtime_test.gd
@@ -1,0 +1,72 @@
+extends SceneTree
+
+var _scene_under_test: Node = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _finish(exit_code: int) -> void:
+	if is_instance_valid(_scene_under_test):
+		_scene_under_test.queue_free()
+		await process_frame
+		await process_frame
+	quit(exit_code)
+
+func _fail(message: String) -> void:
+	push_error("[MISSION_NARRATIVE_01_RUNTIME] %s" % message)
+	await _finish(1)
+
+func _run() -> void:
+	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
+	if packed == null:
+		await _fail("Could not load the production scrap_test_block scene")
+		return
+
+	_scene_under_test = packed.instantiate()
+	root.add_child(_scene_under_test)
+	await process_frame
+	await physics_frame
+	await process_frame
+
+	var runtime := _scene_under_test.get_node_or_null("MissionScrapJobRuntime")
+	if runtime == null:
+		await _fail("Production scene does not contain MissionScrapJobRuntime")
+		return
+	if not bool(runtime.get("_bound")):
+		await _fail("Mission runtime did not bind to the retained gameplay systems")
+		return
+
+	var safe_root := _scene_under_test.get_node_or_null("CanvasLayer/TouchControlsUI/SafeAreaRoot")
+	var mission_hud := safe_root.get_node_or_null("MissionHUD") if safe_root != null else null
+	if mission_hud == null:
+		await _fail("Mission HUD was not created inside SafeAreaRoot")
+		return
+
+	var title := mission_hud.find_child("MissionTitle", true, false) as Label
+	var objective := mission_hud.find_child("ObjectiveLabel", true, false) as Label
+	var contact := mission_hud.find_child("ContactLabel", true, false) as Label
+	if title == null or objective == null or contact == null:
+		await _fail("Mission HUD is missing title/objective/contact labels")
+		return
+	if title.text != "SCRAP JOB 01 // CITY PROPERTY":
+		await _fail("Mission title does not identify the authored job")
+		return
+	if "COURIER BIKE" not in objective.text:
+		await _fail("Cold-start runtime objective does not point to the Courier Bike")
+		return
+	if not contact.text.begins_with("LIRA //"):
+		await _fail("Cold-start runtime contact line is not the Lira briefing")
+		return
+
+	var bike = _scene_under_test.get("courier_bike")
+	if bike == null:
+		await _fail("Retained Courier Bike runtime reference is absent")
+		return
+	bike.mounted.emit(_scene_under_test.get_node("Runner"))
+	await process_frame
+	if "TUNER MAST" not in objective.text:
+		await _fail("Actual Courier Bike mounted signal did not advance the mission HUD")
+		return
+
+	print("[MISSION_NARRATIVE_01_RUNTIME] PASS")
+	await _finish(0)

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -2,6 +2,7 @@ extends SceneTree
 
 # Exercises actual Viewport -> Control GUI routing, not direct method calls.
 const TouchSteeringConditioningContract = preload("res://tests/touch_steering_conditioning_contract_test.gd")
+const MissionScrapJobContract = preload("res://tests/mission_scrap_job_contract_test.gd")
 
 var _last_joystick_vector := Vector2.ZERO
 var _scene_under_test: Node = null
@@ -26,6 +27,11 @@ func _run() -> void:
 		await _fail("CTW Feel 02: %s" % steering_error)
 		return
 
+	var mission_error: String = MissionScrapJobContract.verify()
+	if not mission_error.is_empty():
+		await _fail("Mission/Narrative 01: %s" % mission_error)
+		return
+
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
 	if packed == null:
 		await _fail("Could not load scrap_test_block.tscn")
@@ -35,11 +41,36 @@ func _run() -> void:
 	root.add_child(_scene_under_test)
 	await process_frame
 	await physics_frame
+	await process_frame
 
 	var touch_ui := _scene_under_test.get_node_or_null("CanvasLayer/TouchControlsUI")
 	var player := _scene_under_test.get_node_or_null("Runner")
 	if touch_ui == null or player == null:
 		await _fail("Main scene is missing TouchControlsUI or Runner")
+		return
+
+	# Mission/Narrative 01 is deliberately attached to the production scene and
+	# must share the established safe-area root instead of creating a parallel UI.
+	var runtime := _scene_under_test.get_node_or_null("MissionScrapJobRuntime")
+	if runtime == null or not bool(runtime.get("_bound")):
+		await _fail("Mission/Narrative 01 runtime did not bind to retained gameplay systems")
+		return
+	var safe_root := touch_ui.get_node_or_null("SafeAreaRoot")
+	var mission_hud := safe_root.get_node_or_null("MissionHUD") if safe_root != null else null
+	if mission_hud == null:
+		await _fail("Mission/Narrative 01 HUD is not rooted inside the established safe area")
+		return
+	var objective := mission_hud.find_child("ObjectiveLabel", true, false) as Label
+	var contact := mission_hud.find_child("ContactLabel", true, false) as Label
+	if objective == null or contact == null:
+		await _fail("Mission/Narrative 01 HUD is missing objective/contact text")
+		return
+	if "COURIER BIKE" not in objective.text or not contact.text.begins_with("LIRA //"):
+		await _fail("Mission/Narrative 01 cold-start briefing is not visible in the production scene")
+		return
+	var bike = _scene_under_test.get("courier_bike")
+	if bike == null or not bike.mounted.is_connected(Callable(runtime, "_on_courier_bike_mounted")):
+		await _fail("Retained Courier Bike mounted signal is not connected to the authored mission runtime")
 		return
 
 	touch_ui.joystick_vector_updated.connect(func(vec: Vector2): _last_joystick_vector = vec)
@@ -89,5 +120,6 @@ func _run() -> void:
 		await _fail("Joystick release did not clear PlayerRunner input")
 		return
 
+	print("[MISSION_NARRATIVE_01] CONTRACT + RUNTIME WIRING PASS")
 	print("[MOBILE_TOUCH_ROUTING] PASS")
 	await _finish(0)

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -60,11 +60,18 @@ func _run() -> void:
 	if mission_hud == null:
 		await _fail("Mission/Narrative 01 HUD is not rooted inside the established safe area")
 		return
+	var margin := mission_hud.find_child("MissionMargin", true, false) as Control
+	var stack := mission_hud.find_child("MissionStack", true, false) as Control
+	var title := mission_hud.find_child("MissionTitle", true, false) as Label
 	var objective := mission_hud.find_child("ObjectiveLabel", true, false) as Label
 	var contact := mission_hud.find_child("ContactLabel", true, false) as Label
-	if objective == null or contact == null:
-		await _fail("Mission/Narrative 01 HUD is missing objective/contact text")
+	if margin == null or stack == null or title == null or objective == null or contact == null:
+		await _fail("Mission/Narrative 01 HUD is missing required authored controls")
 		return
+	for hud_control in [mission_hud, margin, stack, title, objective, contact]:
+		if hud_control.mouse_filter != Control.MOUSE_FILTER_IGNORE:
+			await _fail("Mission/Narrative 01 HUD contains a control that can steal gameplay touch input")
+			return
 	if "COURIER BIKE" not in objective.text or not contact.text.begins_with("LIRA //"):
 		await _fail("Mission/Narrative 01 cold-start briefing is not visible in the production scene")
 		return

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -3,6 +3,7 @@ extends SceneTree
 # Exercises actual Viewport -> Control GUI routing, not direct method calls.
 const TouchSteeringConditioningContract = preload("res://tests/touch_steering_conditioning_contract_test.gd")
 const MissionScrapJobContract = preload("res://tests/mission_scrap_job_contract_test.gd")
+const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
 
 var _last_joystick_vector := Vector2.ZERO
 var _scene_under_test: Node = null
@@ -142,6 +143,36 @@ func _run() -> void:
 	await process_frame
 	if "SPOOF THE YARD SIGNAL" not in objective.text:
 		await _fail("Walking the final meters to the tuner did not advance the authored objective")
+		return
+
+	# Reproduce the one-shot ordering hazard without re-emitting either consumed
+	# production signal: the retained world is already solved when the authored
+	# job reaches SPOOF_SIGNAL. Runtime polling must catch up from authoritative
+	# component/controller state in a single frame.
+	var panel = _scene_under_test.get("corroded_panel")
+	if panel == null:
+		await _fail("Retained Corroded Panel runtime reference is absent")
+		return
+	tuner.set("current_state", SignalTuner.TunerState.LOCKED)
+	panel.set("current_step", CorrodedPanel.Step.EXTRACTED)
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.PURSUIT_ACTIVE)
+	await process_frame
+	if "SIGNAL GATE OR LONG ROAD" not in objective.text:
+		await _fail("Consumed tuner/panel state did not reconcile into the live route decision")
+		return
+
+	# Normal golden-slice interception is decided by ScrapTestBlock before the
+	# pursuer entity's own delayed signal can fire. Observe the controller state,
+	# then prove the next controller-active pursuit resumes the retained fast retry.
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.INTERCEPTED)
+	await process_frame
+	if "JOB BURNED" not in objective.text or "RETRY PURSUIT" not in objective.text:
+		await _fail("Controller-authoritative INTERCEPTED state did not fail the authored job")
+		return
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.PURSUIT_ACTIVE)
+	await process_frame
+	if "SIGNAL GATE OR LONG ROAD" not in objective.text:
+		await _fail("Controller-authoritative retry pursuit did not resume the route decision")
 		return
 
 	print("[MISSION_NARRATIVE_01] CONTRACT + RUNTIME WIRING PASS")

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -127,6 +127,23 @@ func _run() -> void:
 		await _fail("Joystick release did not clear PlayerRunner input")
 		return
 
+	# After the authored bike prerequisite, parking short and walking to the mast
+	# must not strand the mission in traversal. Keep the bike unoccupied here to
+	# exercise the exact edge case without disturbing retained vehicle state.
+	runtime.call("_on_courier_bike_mounted", player)
+	if bike.get("occupant") != null:
+		await _fail("Mission early-park test unexpectedly mounted the retained bike")
+		return
+	var tuner = _scene_under_test.get("signal_tuner")
+	if tuner == null:
+		await _fail("Retained Signal Tuner runtime reference is absent")
+		return
+	player.global_position = tuner.global_position
+	await process_frame
+	if "SPOOF THE YARD SIGNAL" not in objective.text:
+		await _fail("Walking the final meters to the tuner did not advance the authored objective")
+		return
+
 	print("[MISSION_NARRATIVE_01] CONTRACT + RUNTIME WIRING PASS")
 	print("[MOBILE_TOUCH_ROUTING] PASS")
 	await _finish(0)


### PR DESCRIPTION
## Product increment
Turns the retained golden-slice systems into one compact authored crime job without adding a general mission framework.

Flow: Lira briefing → Courier Bike → tuner spoof → customs-core extraction → pursuit complication → Signal Gate vs long-road route decision → interception/fast retry or escape → explicit payoff/aftermath.

## Scope discipline
- Reuses Courier Bike, tuner, Corroded Panel, pursuit, Signal Gate, fast retry, Memory Echo and existing safe-area UI.
- Does not reopen retained camera, steering or audio foundation work.
- Keeps mission state intentionally authored/specific rather than introducing inventory/economy/quest abstractions.

## Verification
- Deterministic Mission/Narrative 01 contract is invoked from the existing mobile routing regression already run by Godot Web Playtest.
- Production-scene binding, safe-area HUD and Courier Bike signal connection are checked through that same CI route.
- Existing exact-head Web export and canonical compatibility matrix remain required.

Spec: `contracts/mission_narrative_01_scrap_job_spec.md`