### PR TITLE
Mission/Narrative 02 — Civic Repossession

### DIFF
--- a/godot/scenes/prototype/scrap_test_block.tscn
+++ b/godot/scenes/prototype/scrap_test_block.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=3 uid="uid://c_scrap_test_block_001"]
+[gd_scene load_steps=27 format=3 uid="uid://c_scrap_test_block_001"]
 
 [ext_resource type="Script" path="res://scripts/prototype/scrap_test_block.gd" id="1_root"]
 
@@ -16,6 +16,7 @@
 [ext_resource type="PackedScene" uid="uid://vfx_dust_drift_001" path="res://scenes/vfx/dust_drift_particles.tscn" id="8_dust"]
 [ext_resource type="Script" path="res://scripts/audio/ui_audio_identity_layer.gd" id="9_ui_audio"]
 [ext_resource type="Script" path="res://scripts/missions/scrap_job_mission_runtime.gd" id="10_mission_runtime"]
+[ext_resource type="Script" path="res://scripts/missions/civic_repossession_runtime.gd" id="11_civic_runtime"]
 
 [sub_resource type="Environment" id="Environment_1"]
 background_mode = 1
@@ -213,6 +214,9 @@ script = ExtResource("9_ui_audio")
 
 [node name="MissionScrapJobRuntime" type="Node" parent="."]
 script = ExtResource("10_mission_runtime")
+
+[node name="CivicRepossessionRuntime" type="Node" parent="."]
+script = ExtResource("11_civic_runtime")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 

--- a/godot/scripts/missions/civic_repossession_mission.gd
+++ b/godot/scripts/missions/civic_repossession_mission.gd
@@ -1,0 +1,103 @@
+extends RefCounted
+
+## Mission / Narrative 02 — Civic Repossession
+##
+## A deliberately authored follow-on job. This remains a small product slice,
+## not a generalized mission/quest framework.
+
+enum Phase {
+	LOCKED,
+	GET_HAULER,
+	ESCAPE,
+	DELIVERY,
+	FAILED,
+	COMPLETE,
+}
+
+enum RouteChoice {
+	UNDECIDED,
+	SIGNAL_GATE,
+	LONG_ROAD,
+}
+
+const PAYOFF_CREDITS := 450
+const REQUIRED_VEHICLE_NAME := "ScrapHauler"
+
+var phase: Phase = Phase.LOCKED
+var route_choice: RouteChoice = RouteChoice.UNDECIDED
+var objective: String = ""
+var contact_line: String = ""
+var reward_credits: int = 0
+var failure_count: int = 0
+
+func unlock_after_scrap_job() -> bool:
+	if phase != Phase.LOCKED:
+		return false
+	phase = Phase.GET_HAULER
+	objective = "OBJECTIVE // TAKE THE SCRAP HAULER"
+	contact_line = "MAYOR BURN // City repossessed its own salvage truck. Very efficient. Bring me the paperwork with wheels."
+	return true
+
+func on_vehicle_mounted(vehicle_name: String) -> bool:
+	if phase != Phase.GET_HAULER or vehicle_name != REQUIRED_VEHICLE_NAME:
+		return false
+	phase = Phase.ESCAPE
+	objective = "OBJECTIVE // LOSE THE PURSUER // SIGNAL GATE OR LONG ROAD"
+	contact_line = "MAYOR BURN // Excellent. You are now driving a municipal accounting error. Try not to itemize yourself."
+	return true
+
+func on_gate_triggered() -> bool:
+	if phase != Phase.ESCAPE:
+		return false
+	route_choice = RouteChoice.SIGNAL_GATE
+	objective = "OBJECTIVE // BREAK CONTACT // SIGNAL GATE COMMITTED"
+	contact_line = "MAYOR BURN // Shortcut approved retroactively. That's how infrastructure works."
+	return true
+
+func on_intercepted() -> bool:
+	if phase != Phase.ESCAPE:
+		return false
+	failure_count += 1
+	reward_credits = 0
+	phase = Phase.FAILED
+	objective = "JOB BURNED // RETRY PURSUIT"
+	contact_line = "MAYOR BURN // They recovered the public asset. Disgusting display of municipal competence."
+	return true
+
+func on_retry_started() -> bool:
+	if phase != Phase.FAILED:
+		return false
+	route_choice = RouteChoice.UNDECIDED
+	phase = Phase.ESCAPE
+	objective = "OBJECTIVE // LOSE THE PURSUER // SIGNAL GATE OR LONG ROAD"
+	contact_line = "MAYOR BURN // Same truck, same debt, fewer introductions. Move."
+	return true
+
+func on_evasion_complete() -> bool:
+	if phase != Phase.ESCAPE:
+		return false
+	if route_choice == RouteChoice.UNDECIDED:
+		route_choice = RouteChoice.LONG_ROAD
+	phase = Phase.DELIVERY
+	objective = "OBJECTIVE // RETURN THE SCRAP HAULER TO BURN'S GARAGE"
+	contact_line = "MAYOR BURN // Heat is off. Garage is open. I filed the truck as 'temporarily democratic.'"
+	return true
+
+func on_return_zone_entered() -> bool:
+	if phase != Phase.DELIVERY:
+		return false
+	phase = Phase.COMPLETE
+	reward_credits = PAYOFF_CREDITS
+	objective = "CIVIC REPOSSESSION COMPLETE // %d SCRAP CREDITS CLEARED" % PAYOFF_CREDITS
+	contact_line = "MAYOR BURN // Municipal property restored to its natural owner: whoever got there first."
+	return true
+
+func snapshot() -> Dictionary:
+	return {
+		"phase": phase,
+		"route_choice": route_choice,
+		"objective": objective,
+		"contact_line": contact_line,
+		"reward_credits": reward_credits,
+		"failure_count": failure_count,
+	}

--- a/godot/scripts/missions/civic_repossession_runtime.gd
+++ b/godot/scripts/missions/civic_repossession_runtime.gd
@@ -1,0 +1,161 @@
+extends Node
+
+## Thin authored adapter for Mission/Narrative 02. Existing production systems
+## retain authority over vehicles, pursuit, Signal Gate, camera, radio and replay.
+
+const MissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
+const ScrapJobMissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
+const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
+const RETURN_ZONE_POSITION := Vector3(7.0, 0.08, 8.0)
+const RETURN_ZONE_RADIUS := 2.6
+
+var mission = MissionScript.new()
+var _root_controller: Node = null
+var _mission_one_runtime = null
+var _scrap_hauler = null
+var _signal_gate = null
+var _bound: bool = false
+
+var _return_zone: MeshInstance3D = null
+var _mission_title: Label = null
+var _objective_label: Label = null
+var _contact_label: Label = null
+
+func _ready() -> void:
+	_root_controller = get_parent()
+	call_deferred("_try_bind_runtime")
+
+func _process(_delta: float) -> void:
+	if not _bound:
+		_try_bind_runtime()
+		return
+
+	var mission_one_complete := _mission_one_runtime != null \
+	and _mission_one_runtime.mission.phase == ScrapJobMissionScript.Phase.COMPLETE
+
+	if mission.phase == MissionScript.Phase.LOCKED and mission_one_complete:
+		if mission.unlock_after_scrap_job():
+			_refresh_hud()
+	elif mission.phase != MissionScript.Phase.LOCKED and not mission_one_complete:
+		_reset_for_full_replay()
+		return
+
+	var root_pursuit_state := int(_root_controller.get("current_pursuit_state"))
+	var changed := false
+	if mission.phase == MissionScript.Phase.ESCAPE \
+	and root_pursuit_state == int(ScrapTestBlockScript.PursuitState.INTERCEPTED):
+		changed = mission.on_intercepted() or changed
+	elif mission.phase == MissionScript.Phase.FAILED \
+	and root_pursuit_state == int(ScrapTestBlockScript.PursuitState.PURSUIT_ACTIVE):
+		changed = mission.on_retry_started() or changed
+	elif mission.phase == MissionScript.Phase.ESCAPE \
+	and root_pursuit_state == int(ScrapTestBlockScript.PursuitState.EVADED):
+		if mission.on_evasion_complete():
+			changed = true
+			_set_return_zone_visible(true)
+
+	if mission.phase == MissionScript.Phase.DELIVERY \
+	and _return_zone != null \
+	and _scrap_hauler != null \
+	and _scrap_hauler.global_position.distance_to(_return_zone.global_position) <= RETURN_ZONE_RADIUS:
+		if mission.on_return_zone_entered():
+			changed = true
+			_set_return_zone_visible(false)
+
+	if changed:
+		_refresh_hud()
+
+func _try_bind_runtime() -> void:
+	if _bound or _root_controller == null:
+		return
+
+	_mission_one_runtime = _root_controller.get_node_or_null("MissionScrapJobRuntime")
+	_scrap_hauler = _root_controller.get("scrap_hauler")
+	_signal_gate = _root_controller.get("signal_gate")
+	var mission_hud := _root_controller.get_node_or_null("CanvasLayer/TouchControlsUI/SafeAreaRoot/MissionHUD")
+	if _mission_one_runtime == null or _scrap_hauler == null or _signal_gate == null or mission_hud == null:
+		return
+
+	_mission_title = mission_hud.find_child("MissionTitle", true, false) as Label
+	_objective_label = mission_hud.find_child("ObjectiveLabel", true, false) as Label
+	_contact_label = mission_hud.find_child("ContactLabel", true, false) as Label
+	if _mission_title == null or _objective_label == null or _contact_label == null:
+		return
+
+	_scrap_hauler.mounted.connect(_on_hauler_mounted)
+	_signal_gate.gate_triggered.connect(_on_signal_gate_triggered)
+	_create_return_zone()
+	_bound = true
+	print("[MISSION_NARRATIVE_02] Runtime bound to retained Scrap Hauler/pursuit systems")
+
+func _on_hauler_mounted(_player) -> void:
+	if not _bound:
+		return
+	if not mission.on_vehicle_mounted(_scrap_hauler.name):
+		return
+	_refresh_hud()
+	# Pursuit remains controller-owned. This only asks the existing disturbance
+	# authority to begin from its canonical CALM state.
+	if _root_controller.has_method("trigger_disturbance_alert"):
+		_root_controller.trigger_disturbance_alert()
+
+func _on_signal_gate_triggered() -> void:
+	if mission.on_gate_triggered():
+		_refresh_hud()
+
+func _create_return_zone() -> void:
+	if _return_zone != null:
+		return
+	_return_zone = MeshInstance3D.new()
+	_return_zone.name = "CivicRepossessionReturnZone"
+	_return_zone.position = RETURN_ZONE_POSITION
+	_return_zone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+
+	var zone_mesh := CylinderMesh.new()
+	zone_mesh.top_radius = RETURN_ZONE_RADIUS
+	zone_mesh.bottom_radius = RETURN_ZONE_RADIUS
+	zone_mesh.height = 0.08
+	zone_mesh.radial_segments = 32
+	_return_zone.mesh = zone_mesh
+
+	var zone_material := StandardMaterial3D.new()
+	zone_material.transparency = BaseMaterial3D.TRANSPARENCY_ALPHA
+	zone_material.albedo_color = Color(0.9, 0.72, 0.2, 0.35)
+	zone_material.emission_enabled = true
+	zone_material.emission = Color(0.8, 0.5, 0.08, 1.0)
+	zone_material.emission_energy_multiplier = 1.2
+	_return_zone.material_override = zone_material
+
+	var label := Label3D.new()
+	label.text = "BURN // GARAGE"
+	label.position = Vector3(0, 0.7, 0)
+	label.font_size = 24
+	label.billboard = BaseMaterial3D.BILLBOARD_ENABLED
+	_return_zone.add_child(label)
+
+	_root_controller.add_child(_return_zone)
+	_set_return_zone_visible(false)
+
+func _set_return_zone_visible(visible_value: bool) -> void:
+	if _return_zone != null:
+		_return_zone.visible = visible_value
+
+func _refresh_hud() -> void:
+	if _mission_title == null or _objective_label == null or _contact_label == null:
+		return
+	_mission_title.text = "CIVIC REPOSSESSION // MAYOR BURN"
+	_objective_label.text = mission.objective
+	_contact_label.text = mission.contact_line
+
+func _restore_mission_one_hud() -> void:
+	if _mission_title == null or _objective_label == null or _contact_label == null or _mission_one_runtime == null:
+		return
+	_mission_title.text = "SCRAP JOB 01 // CITY PROPERTY"
+	_objective_label.text = _mission_one_runtime.mission.objective
+	_contact_label.text = _mission_one_runtime.mission.contact_line
+
+func _reset_for_full_replay() -> void:
+	mission = MissionScript.new()
+	_set_return_zone_visible(false)
+	_restore_mission_one_hud()
+	print("[MISSION_NARRATIVE_02] Full replay detected; Civic Repossession relocked")

--- a/godot/scripts/missions/civic_repossession_runtime.gd
+++ b/godot/scripts/missions/civic_repossession_runtime.gd
@@ -97,7 +97,7 @@ func _on_hauler_mounted(_player) -> void:
 	# Pursuit remains controller-owned. This only asks the existing disturbance
 	# authority to begin from its canonical CALM state.
 	if _root_controller.has_method("trigger_disturbance_alert"):
-		_root_controller.trigger_disturbance_alert()
+		_root_controller.call("trigger_disturbance_alert")
 
 func _on_signal_gate_triggered() -> void:
 	if mission.on_gate_triggered():

--- a/godot/scripts/missions/civic_repossession_runtime.gd
+++ b/godot/scripts/missions/civic_repossession_runtime.gd
@@ -40,6 +40,14 @@ func _process(_delta: float) -> void:
 		_reset_for_full_replay()
 		return
 
+	# The Hauler is retained production state and can already be occupied when
+	# Mission 01 completes. Reconcile that authoritative state so a one-shot mount
+	# signal consumed while this mission was LOCKED cannot strand GET_HAULER.
+	if mission.phase == MissionScript.Phase.GET_HAULER \
+	and _scrap_hauler != null \
+	and _scrap_hauler.get("occupant") != null:
+		_on_hauler_mounted(_scrap_hauler.get("occupant"))
+
 	var root_pursuit_state := int(_root_controller.get("current_pursuit_state"))
 	var changed := false
 	if mission.phase == MissionScript.Phase.ESCAPE \

--- a/godot/scripts/missions/civic_repossession_runtime.gd
+++ b/godot/scripts/missions/civic_repossession_runtime.gd
@@ -30,7 +30,7 @@ func _process(_delta: float) -> void:
 		_try_bind_runtime()
 		return
 
-	var mission_one_complete := _mission_one_runtime != null \
+	var mission_one_complete: bool = _mission_one_runtime != null \
 	and _mission_one_runtime.mission.phase == ScrapJobMissionScript.Phase.COMPLETE
 
 	if mission.phase == MissionScript.Phase.LOCKED and mission_one_complete:

--- a/godot/tests/civic_repossession_mission_contract_test.gd
+++ b/godot/tests/civic_repossession_mission_contract_test.gd
@@ -1,0 +1,93 @@
+extends RefCounted
+
+const MissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
+
+static func verify() -> String:
+	var mission = MissionScript.new()
+	if mission.phase != MissionScript.Phase.LOCKED:
+		return "Fresh Civic Repossession mission did not begin LOCKED"
+	if mission.on_vehicle_mounted("ScrapHauler"):
+		return "Locked mission accepted Hauler mount before Mission 01 completion"
+	if mission.on_return_zone_entered():
+		return "Locked mission accepted return-zone completion"
+
+	if not mission.unlock_after_scrap_job():
+		return "Mission 01 completion did not unlock Civic Repossession"
+	if mission.phase != MissionScript.Phase.GET_HAULER:
+		return "Unlock did not enter GET_HAULER"
+	if "SCRAP HAULER" not in mission.objective:
+		return "Unlock objective does not identify the Scrap Hauler"
+	if not mission.contact_line.begins_with("MAYOR BURN //"):
+		return "Mayor Burn does not own the Civic Repossession briefing"
+
+	var phase_before_wrong_vehicle = mission.phase
+	if mission.on_vehicle_mounted("CourierBike"):
+		return "Courier Bike incorrectly satisfied the Hauler acquisition objective"
+	if mission.phase != phase_before_wrong_vehicle:
+		return "Wrong vehicle mutated Civic Repossession phase"
+	if mission.on_return_zone_entered():
+		return "Return zone completed before Hauler theft/escape"
+
+	if not mission.on_vehicle_mounted("ScrapHauler"):
+		return "Scrap Hauler mount did not start the escape"
+	if mission.phase != MissionScript.Phase.ESCAPE:
+		return "Scrap Hauler mount did not enter ESCAPE"
+	if "SIGNAL GATE" not in mission.objective or "LONG ROAD" not in mission.objective:
+		return "Escape objective does not expose retained route choice"
+
+	if not mission.on_gate_triggered():
+		return "Signal Gate did not record Civic Repossession shortcut"
+	if mission.route_choice != MissionScript.RouteChoice.SIGNAL_GATE:
+		return "Signal Gate route choice was not recorded"
+
+	if not mission.on_intercepted():
+		return "Controller interception did not fail Civic Repossession"
+	if mission.phase != MissionScript.Phase.FAILED:
+		return "Interception did not enter FAILED"
+	if "RETRY PURSUIT" not in mission.objective:
+		return "Failure objective does not expose retained fast retry"
+	if mission.reward_credits != 0:
+		return "Failed mission retained payoff"
+	if not mission.on_retry_started():
+		return "Fast retry did not resume Civic Repossession"
+	if mission.phase != MissionScript.Phase.ESCAPE:
+		return "Fast retry did not resume the escape phase"
+	if mission.route_choice != MissionScript.RouteChoice.UNDECIDED:
+		return "Fast retry did not reset route decision"
+	if mission.failure_count != 1:
+		return "Failure accounting is incorrect"
+
+	if not mission.on_evasion_complete():
+		return "Successful evasion did not advance to delivery"
+	if mission.phase != MissionScript.Phase.DELIVERY:
+		return "Evasion did not enter DELIVERY"
+	if mission.route_choice != MissionScript.RouteChoice.LONG_ROAD:
+		return "Ungated retry escape did not record LONG_ROAD"
+	if "RETURN" not in mission.objective or "HAULER" not in mission.objective:
+		return "Delivery objective does not identify the Hauler return"
+	if not mission.on_return_zone_entered():
+		return "Return zone did not complete Civic Repossession"
+	if mission.phase != MissionScript.Phase.COMPLETE:
+		return "Delivery did not reach COMPLETE"
+	if mission.reward_credits != MissionScript.PAYOFF_CREDITS:
+		return "Completion did not award configured payoff"
+	if str(MissionScript.PAYOFF_CREDITS) not in mission.objective:
+		return "Completion objective does not expose payoff"
+	if "municipal" not in mission.contact_line.to_lower():
+		return "Aftermath line does not preserve Civic Repossession satire"
+
+	var shortcut = MissionScript.new()
+	if not shortcut.unlock_after_scrap_job():
+		return "Shortcut fixture did not unlock"
+	if not shortcut.on_vehicle_mounted("ScrapHauler"):
+		return "Shortcut fixture did not accept Hauler"
+	if not shortcut.on_gate_triggered():
+		return "Shortcut fixture did not accept Signal Gate"
+	if not shortcut.on_evasion_complete():
+		return "Shortcut fixture did not advance after evasion"
+	if shortcut.route_choice != MissionScript.RouteChoice.SIGNAL_GATE:
+		return "Shortcut choice was lost during evasion"
+	if not shortcut.on_return_zone_entered():
+		return "Shortcut fixture did not complete delivery"
+
+	return ""

--- a/godot/tests/civic_repossession_mission_contract_test.gd
+++ b/godot/tests/civic_repossession_mission_contract_test.gd
@@ -1,10 +1,14 @@
 extends RefCounted
 
-const MissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
+const MISSION_PATH := "res://scripts/missions/civic_repossession_mission.gd"
 
 static func verify() -> String:
-	var mission = MissionScript.new()
-	if mission.phase != MissionScript.Phase.LOCKED:
+	var mission_script = load(MISSION_PATH)
+	if mission_script == null:
+		return "Civic Repossession mission script is missing"
+
+	var mission = mission_script.new()
+	if mission.phase != mission_script.Phase.LOCKED:
 		return "Fresh Civic Repossession mission did not begin LOCKED"
 	if mission.on_vehicle_mounted("ScrapHauler"):
 		return "Locked mission accepted Hauler mount before Mission 01 completion"
@@ -13,7 +17,7 @@ static func verify() -> String:
 
 	if not mission.unlock_after_scrap_job():
 		return "Mission 01 completion did not unlock Civic Repossession"
-	if mission.phase != MissionScript.Phase.GET_HAULER:
+	if mission.phase != mission_script.Phase.GET_HAULER:
 		return "Unlock did not enter GET_HAULER"
 	if "SCRAP HAULER" not in mission.objective:
 		return "Unlock objective does not identify the Scrap Hauler"
@@ -30,19 +34,19 @@ static func verify() -> String:
 
 	if not mission.on_vehicle_mounted("ScrapHauler"):
 		return "Scrap Hauler mount did not start the escape"
-	if mission.phase != MissionScript.Phase.ESCAPE:
+	if mission.phase != mission_script.Phase.ESCAPE:
 		return "Scrap Hauler mount did not enter ESCAPE"
 	if "SIGNAL GATE" not in mission.objective or "LONG ROAD" not in mission.objective:
 		return "Escape objective does not expose retained route choice"
 
 	if not mission.on_gate_triggered():
 		return "Signal Gate did not record Civic Repossession shortcut"
-	if mission.route_choice != MissionScript.RouteChoice.SIGNAL_GATE:
+	if mission.route_choice != mission_script.RouteChoice.SIGNAL_GATE:
 		return "Signal Gate route choice was not recorded"
 
 	if not mission.on_intercepted():
 		return "Controller interception did not fail Civic Repossession"
-	if mission.phase != MissionScript.Phase.FAILED:
+	if mission.phase != mission_script.Phase.FAILED:
 		return "Interception did not enter FAILED"
 	if "RETRY PURSUIT" not in mission.objective:
 		return "Failure objective does not expose retained fast retry"
@@ -50,33 +54,33 @@ static func verify() -> String:
 		return "Failed mission retained payoff"
 	if not mission.on_retry_started():
 		return "Fast retry did not resume Civic Repossession"
-	if mission.phase != MissionScript.Phase.ESCAPE:
+	if mission.phase != mission_script.Phase.ESCAPE:
 		return "Fast retry did not resume the escape phase"
-	if mission.route_choice != MissionScript.RouteChoice.UNDECIDED:
+	if mission.route_choice != mission_script.RouteChoice.UNDECIDED:
 		return "Fast retry did not reset route decision"
 	if mission.failure_count != 1:
 		return "Failure accounting is incorrect"
 
 	if not mission.on_evasion_complete():
 		return "Successful evasion did not advance to delivery"
-	if mission.phase != MissionScript.Phase.DELIVERY:
+	if mission.phase != mission_script.Phase.DELIVERY:
 		return "Evasion did not enter DELIVERY"
-	if mission.route_choice != MissionScript.RouteChoice.LONG_ROAD:
+	if mission.route_choice != mission_script.RouteChoice.LONG_ROAD:
 		return "Ungated retry escape did not record LONG_ROAD"
 	if "RETURN" not in mission.objective or "HAULER" not in mission.objective:
 		return "Delivery objective does not identify the Hauler return"
 	if not mission.on_return_zone_entered():
 		return "Return zone did not complete Civic Repossession"
-	if mission.phase != MissionScript.Phase.COMPLETE:
+	if mission.phase != mission_script.Phase.COMPLETE:
 		return "Delivery did not reach COMPLETE"
-	if mission.reward_credits != MissionScript.PAYOFF_CREDITS:
+	if mission.reward_credits != mission_script.PAYOFF_CREDITS:
 		return "Completion did not award configured payoff"
-	if str(MissionScript.PAYOFF_CREDITS) not in mission.objective:
+	if str(mission_script.PAYOFF_CREDITS) not in mission.objective:
 		return "Completion objective does not expose payoff"
 	if "municipal" not in mission.contact_line.to_lower():
 		return "Aftermath line does not preserve Civic Repossession satire"
 
-	var shortcut = MissionScript.new()
+	var shortcut = mission_script.new()
 	if not shortcut.unlock_after_scrap_job():
 		return "Shortcut fixture did not unlock"
 	if not shortcut.on_vehicle_mounted("ScrapHauler"):
@@ -85,7 +89,7 @@ static func verify() -> String:
 		return "Shortcut fixture did not accept Signal Gate"
 	if not shortcut.on_evasion_complete():
 		return "Shortcut fixture did not advance after evasion"
-	if shortcut.route_choice != MissionScript.RouteChoice.SIGNAL_GATE:
+	if shortcut.route_choice != mission_script.RouteChoice.SIGNAL_GATE:
 		return "Shortcut choice was lost during evasion"
 	if not shortcut.on_return_zone_entered():
 		return "Shortcut fixture did not complete delivery"

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -3,6 +3,7 @@ extends SceneTree
 # Exercises actual Viewport -> Control GUI routing, not direct method calls.
 const TouchSteeringConditioningContract = preload("res://tests/touch_steering_conditioning_contract_test.gd")
 const MissionScrapJobContract = preload("res://tests/mission_scrap_job_contract_test.gd")
+const CivicRepossessionContract = preload("res://tests/civic_repossession_mission_contract_test.gd")
 const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
 
 var _last_joystick_vector := Vector2.ZERO
@@ -31,6 +32,11 @@ func _run() -> void:
 	var mission_error: String = MissionScrapJobContract.verify()
 	if not mission_error.is_empty():
 		await _fail("Mission/Narrative 01: %s" % mission_error)
+		return
+
+	var civic_error: String = CivicRepossessionContract.verify()
+	if not civic_error.is_empty():
+		await _fail("Mission/Narrative 02: %s" % civic_error)
 		return
 
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -77,7 +77,7 @@ func _run() -> void:
 	if civic_runtime == null:
 		await _fail("Mission/Narrative 02 production runtime is missing")
 		return
-	if not bool(civic_runtime.get("_bound")):
+	if civic_runtime.get("_bound") != true:
 		await _fail("Mission/Narrative 02 runtime did not bind to retained gameplay systems")
 		return
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.LOCKED:

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -289,6 +289,43 @@ func _run() -> void:
 		await _fail("Full replay did not restore Mission 01 shared HUD ownership")
 		return
 
+	_stage = "premounted_hauler_reconcile"
+	if not runtime.mission.on_courier_bike_mounted():
+		await _fail("Pre-mounted Hauler fixture could not pass Mission 01 bike prerequisite")
+		return
+	if not runtime.mission.on_tuner_arrived():
+		await _fail("Pre-mounted Hauler fixture could not reach tuner objective")
+		return
+	if not runtime.mission.on_signal_locked():
+		await _fail("Pre-mounted Hauler fixture could not solve signal")
+		return
+	if not runtime.mission.on_core_extracted():
+		await _fail("Pre-mounted Hauler fixture could not extract core")
+		return
+	if not runtime.mission.on_pursuit_active():
+		await _fail("Pre-mounted Hauler fixture could not reach escape")
+		return
+	tuner.set("current_state", SignalTuner.TunerState.LOCKED)
+	panel.set("current_step", CorrodedPanel.Step.EXTRACTED)
+	hauler.set("occupant", player)
+	hauler.mounted.emit(player)
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.LOCKED:
+		await _fail("Hauler use before Mission 01 completion incorrectly unlocked Civic Repossession")
+		return
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.CALM)
+	if not runtime.mission.on_escape_complete():
+		await _fail("Pre-mounted Hauler fixture could not complete Mission 01")
+		return
+	runtime.call("_refresh_hud")
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
+		await _fail("Civic Repossession stranded after Mission 01 completed with the Hauler already occupied")
+		return
+	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.DISTURBANCE_ALERT):
+		await _fail("Pre-mounted Hauler reconciliation did not enter retained pursuit authority")
+		return
+
 	print("[MISSION_NARRATIVE_01] CONTRACT + RUNTIME WIRING PASS")
 	print("[MISSION_NARRATIVE_02] CONTRACT + RUNTIME WIRING PASS")
 	print("[MOBILE_TOUCH_ROUTING] PASS")

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -4,6 +4,7 @@ extends SceneTree
 const TouchSteeringConditioningContract = preload("res://tests/touch_steering_conditioning_contract_test.gd")
 const MissionScrapJobContract = preload("res://tests/mission_scrap_job_contract_test.gd")
 const CivicRepossessionContract = preload("res://tests/civic_repossession_mission_contract_test.gd")
+const CivicMissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
 const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
 
 var _last_joystick_vector := Vector2.ZERO
@@ -62,6 +63,20 @@ func _run() -> void:
 	if runtime == null or not bool(runtime.get("_bound")):
 		await _fail("Mission/Narrative 01 runtime did not bind to retained gameplay systems")
 		return
+
+	# Mission/Narrative 02 must be a real production-scene adapter over the
+	# retained Hauler/pursuit systems, not a contract-only state machine.
+	var civic_runtime := _scene_under_test.get_node_or_null("CivicRepossessionRuntime")
+	if civic_runtime == null:
+		await _fail("Mission/Narrative 02 production runtime is missing")
+		return
+	if not bool(civic_runtime.get("_bound")):
+		await _fail("Mission/Narrative 02 runtime did not bind to retained gameplay systems")
+		return
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.LOCKED:
+		await _fail("Mission/Narrative 02 did not remain LOCKED before Mission 01 completion")
+		return
+
 	var safe_root := touch_ui.get_node_or_null("SafeAreaRoot")
 	var mission_hud := safe_root.get_node_or_null("MissionHUD") if safe_root != null else null
 	if mission_hud == null:
@@ -77,14 +92,35 @@ func _run() -> void:
 		return
 	for hud_control in [mission_hud, margin, stack, title, objective, contact]:
 		if hud_control.mouse_filter != Control.MOUSE_FILTER_IGNORE:
-			await _fail("Mission/Narrative 01 HUD contains a control that can steal gameplay touch input")
+			await _fail("Mission HUD contains a control that can steal gameplay touch input")
 			return
+	if safe_root.find_children("MissionHUD", "PanelContainer", true, false).size() != 1:
+		await _fail("Mission/Narrative 02 created a parallel mission HUD instead of reusing Mission 01 UI")
+		return
 	if "COURIER BIKE" not in objective.text or not contact.text.begins_with("LIRA //"):
 		await _fail("Mission/Narrative 01 cold-start briefing is not visible in the production scene")
 		return
 	var bike = _scene_under_test.get("courier_bike")
 	if bike == null or not bike.mounted.is_connected(Callable(runtime, "_on_courier_bike_mounted")):
 		await _fail("Retained Courier Bike mounted signal is not connected to the authored mission runtime")
+		return
+	var hauler = _scene_under_test.get("scrap_hauler")
+	if hauler == null:
+		await _fail("Retained Scrap Hauler runtime reference is absent")
+		return
+	if not hauler.mounted.is_connected(Callable(civic_runtime, "_on_hauler_mounted")):
+		await _fail("Retained Scrap Hauler mounted signal is not connected to Civic Repossession")
+		return
+	var signal_gate = _scene_under_test.get("signal_gate")
+	if signal_gate == null or not signal_gate.gate_triggered.is_connected(Callable(civic_runtime, "_on_signal_gate_triggered")):
+		await _fail("Retained Signal Gate is not connected to Civic Repossession")
+		return
+	var return_zone := _scene_under_test.get_node_or_null("CivicRepossessionReturnZone")
+	if return_zone == null:
+		await _fail("Civic Repossession return-zone marker is missing from the production scene")
+		return
+	if return_zone.visible:
+		await _fail("Civic Repossession return zone is visible before delivery phase")
 		return
 
 	touch_ui.joystick_vector_updated.connect(func(vec: Vector2): _last_joystick_vector = vec)
@@ -181,6 +217,78 @@ func _run() -> void:
 		await _fail("Controller-authoritative retry pursuit did not resume the route decision")
 		return
 
+	# Complete Mission 01 and prove the second job takes over the same HUD only
+	# after that authored completion boundary.
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.CALM)
+	if not runtime.mission.on_escape_complete():
+		await _fail("Mission 01 fixture could not reach COMPLETE before Civic Repossession")
+		return
+	runtime.call("_refresh_hud")
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.GET_HAULER:
+		await _fail("Mission 01 completion did not unlock Civic Repossession in production")
+		return
+	if title.text != "CIVIC REPOSSESSION // MAYOR BURN":
+		await _fail("Civic Repossession did not take ownership of the shared mission title")
+		return
+	if "SCRAP HAULER" not in objective.text or not contact.text.begins_with("MAYOR BURN //"):
+		await _fail("Mayor Burn handoff is not visible on the shared mission HUD")
+		return
+
+	# Exercise the real Hauler signal and controller-owned pursuit state. The
+	# mission observes/reuses those authorities; it does not create a parallel chase.
+	hauler.mounted.emit(player)
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
+		await _fail("Real Scrap Hauler mounted signal did not start Civic Repossession escape")
+		return
+	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.DISTURBANCE_ALERT):
+		await _fail("Hauler theft did not enter the retained disturbance/pursuit authority")
+		return
+
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.INTERCEPTED)
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.FAILED or "RETRY PURSUIT" not in objective.text:
+		await _fail("Controller-authoritative interception did not fail Civic Repossession")
+		return
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.PURSUIT_ACTIVE)
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
+		await _fail("Controller-authoritative fast retry did not resume Civic Repossession escape")
+		return
+	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.EVADED)
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.DELIVERY:
+		await _fail("Controller-authoritative evasion did not advance Civic Repossession to delivery")
+		return
+	if not return_zone.visible:
+		await _fail("Civic Repossession return zone did not become visible for delivery")
+		return
+
+	hauler.global_position = return_zone.global_position
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.COMPLETE:
+		await _fail("Delivering the real Scrap Hauler did not complete Civic Repossession")
+		return
+	if str(CivicMissionScript.PAYOFF_CREDITS) not in objective.text:
+		await _fail("Civic Repossession payoff is not visible after delivery")
+		return
+
+	# Full Replay must restore campaign ordering and shared HUD ownership.
+	_scene_under_test.call("reset_slice")
+	await process_frame
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.LOCKED:
+		await _fail("Full replay did not relock Civic Repossession behind Mission 01")
+		return
+	if return_zone.visible:
+		await _fail("Full replay left the Civic Repossession return zone visible")
+		return
+	if title.text != "SCRAP JOB 01 // CITY PROPERTY" or "COURIER BIKE" not in objective.text:
+		await _fail("Full replay did not restore Mission 01 shared HUD ownership")
+		return
+
 	print("[MISSION_NARRATIVE_01] CONTRACT + RUNTIME WIRING PASS")
+	print("[MISSION_NARRATIVE_02] CONTRACT + RUNTIME WIRING PASS")
 	print("[MOBILE_TOUCH_ROUTING] PASS")
 	await _finish(0)

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -9,11 +9,19 @@ const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.g
 
 var _last_joystick_vector := Vector2.ZERO
 var _scene_under_test: Node = null
+var _stage: String = "init"
 
 func _init() -> void:
+	call_deferred("_watchdog")
 	call_deferred("_run")
 
+func _watchdog() -> void:
+	await create_timer(12.0).timeout
+	push_error("[MOBILE_TOUCH_ROUTING] WATCHDOG TIMEOUT stage=%s" % _stage)
+	quit(1)
+
 func _finish(exit_code: int) -> void:
+	_stage = "finish"
 	if is_instance_valid(_scene_under_test):
 		_scene_under_test.queue_free()
 		await process_frame
@@ -21,10 +29,11 @@ func _finish(exit_code: int) -> void:
 	quit(exit_code)
 
 func _fail(message: String) -> void:
-	push_error("[MOBILE_TOUCH_ROUTING] %s" % message)
+	push_error("[MOBILE_TOUCH_ROUTING] %s (stage=%s)" % [message, _stage])
 	await _finish(1)
 
 func _run() -> void:
+	_stage = "contracts"
 	var steering_error: String = TouchSteeringConditioningContract.verify()
 	if not steering_error.is_empty():
 		await _fail("CTW Feel 02: %s" % steering_error)
@@ -40,6 +49,7 @@ func _run() -> void:
 		await _fail("Mission/Narrative 02: %s" % civic_error)
 		return
 
+	_stage = "scene_instantiation"
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
 	if packed == null:
 		await _fail("Could not load scrap_test_block.tscn")
@@ -51,21 +61,18 @@ func _run() -> void:
 	await physics_frame
 	await process_frame
 
+	_stage = "runtime_bindings"
 	var touch_ui := _scene_under_test.get_node_or_null("CanvasLayer/TouchControlsUI")
 	var player := _scene_under_test.get_node_or_null("Runner")
 	if touch_ui == null or player == null:
 		await _fail("Main scene is missing TouchControlsUI or Runner")
 		return
 
-	# Mission/Narrative 01 is deliberately attached to the production scene and
-	# must share the established safe-area root instead of creating a parallel UI.
 	var runtime := _scene_under_test.get_node_or_null("MissionScrapJobRuntime")
 	if runtime == null or not bool(runtime.get("_bound")):
 		await _fail("Mission/Narrative 01 runtime did not bind to retained gameplay systems")
 		return
 
-	# Mission/Narrative 02 must be a real production-scene adapter over the
-	# retained Hauler/pursuit systems, not a contract-only state machine.
 	var civic_runtime := _scene_under_test.get_node_or_null("CivicRepossessionRuntime")
 	if civic_runtime == null:
 		await _fail("Mission/Narrative 02 production runtime is missing")
@@ -123,6 +130,7 @@ func _run() -> void:
 		await _fail("Civic Repossession return zone is visible before delivery phase")
 		return
 
+	_stage = "touch_routing"
 	touch_ui.joystick_vector_updated.connect(func(vec: Vector2): _last_joystick_vector = vec)
 	var start_position: Vector3 = player.global_position
 
@@ -133,8 +141,6 @@ func _run() -> void:
 	root.push_input(touch_down, true)
 	await process_frame
 
-	# Keep the drag inside the now-visible 120px joystick base. This verifies
-	# that the passive joystick artwork cannot steal the active touch stream.
 	var touch_drag := InputEventScreenDrag.new()
 	touch_drag.index = 7
 	touch_drag.position = Vector2(180, 390)
@@ -170,9 +176,7 @@ func _run() -> void:
 		await _fail("Joystick release did not clear PlayerRunner input")
 		return
 
-	# After the authored bike prerequisite, parking short and walking to the mast
-	# must not strand the mission in traversal. Keep the bike unoccupied here to
-	# exercise the exact edge case without disturbing retained vehicle state.
+	_stage = "mission1_tuner"
 	runtime.call("_on_courier_bike_mounted", player)
 	if bike.get("occupant") != null:
 		await _fail("Mission early-park test unexpectedly mounted the retained bike")
@@ -187,10 +191,7 @@ func _run() -> void:
 		await _fail("Walking the final meters to the tuner did not advance the authored objective")
 		return
 
-	# Reproduce the one-shot ordering hazard without re-emitting either consumed
-	# production signal: the retained world is already solved when the authored
-	# job reaches SPOOF_SIGNAL. Runtime polling must catch up from authoritative
-	# component/controller state in a single frame.
+	_stage = "mission1_reconcile"
 	var panel = _scene_under_test.get("corroded_panel")
 	if panel == null:
 		await _fail("Retained Corroded Panel runtime reference is absent")
@@ -203,9 +204,7 @@ func _run() -> void:
 		await _fail("Consumed tuner/panel state did not reconcile into the live route decision")
 		return
 
-	# Normal golden-slice interception is decided by ScrapTestBlock before the
-	# pursuer entity's own delayed signal can fire. Observe the controller state,
-	# then prove the next controller-active pursuit resumes the retained fast retry.
+	_stage = "mission1_retry"
 	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.INTERCEPTED)
 	await process_frame
 	if "JOB BURNED" not in objective.text or "RETRY PURSUIT" not in objective.text:
@@ -217,8 +216,7 @@ func _run() -> void:
 		await _fail("Controller-authoritative retry pursuit did not resume the route decision")
 		return
 
-	# Complete Mission 01 and prove the second job takes over the same HUD only
-	# after that authored completion boundary.
+	_stage = "mission2_unlock"
 	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.CALM)
 	if not runtime.mission.on_escape_complete():
 		await _fail("Mission 01 fixture could not reach COMPLETE before Civic Repossession")
@@ -235,8 +233,7 @@ func _run() -> void:
 		await _fail("Mayor Burn handoff is not visible on the shared mission HUD")
 		return
 
-	# Exercise the real Hauler signal and controller-owned pursuit state. The
-	# mission observes/reuses those authorities; it does not create a parallel chase.
+	_stage = "mission2_mount"
 	hauler.mounted.emit(player)
 	await process_frame
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
@@ -246,6 +243,7 @@ func _run() -> void:
 		await _fail("Hauler theft did not enter the retained disturbance/pursuit authority")
 		return
 
+	_stage = "mission2_intercept"
 	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.INTERCEPTED)
 	await process_frame
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.FAILED or "RETRY PURSUIT" not in objective.text:
@@ -256,6 +254,8 @@ func _run() -> void:
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
 		await _fail("Controller-authoritative fast retry did not resume Civic Repossession escape")
 		return
+
+	_stage = "mission2_evasion"
 	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.EVADED)
 	await process_frame
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.DELIVERY:
@@ -265,6 +265,7 @@ func _run() -> void:
 		await _fail("Civic Repossession return zone did not become visible for delivery")
 		return
 
+	_stage = "mission2_delivery"
 	hauler.global_position = return_zone.global_position
 	await process_frame
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.COMPLETE:
@@ -274,7 +275,7 @@ func _run() -> void:
 		await _fail("Civic Repossession payoff is not visible after delivery")
 		return
 
-	# Full Replay must restore campaign ordering and shared HUD ownership.
+	_stage = "full_replay"
 	_scene_under_test.call("reset_slice")
 	await process_frame
 	await process_frame


### PR DESCRIPTION
Closes #52

## Summary
- add authored Mission 02 state for Civic Repossession
- hand shared Mission HUD from Lira/Mission 01 to Mayor Burn after Mission 01 completion
- require the retained Scrap Hauler, then reuse controller-owned pursuit/interception, Signal Gate, fast retry, camera/radio/vehicle authority, and replay systems
- reconcile retained Hauler occupancy when Mission 01 completes so an already-mounted Hauler cannot strand the handoff
- add an authored Burn garage return marker and fixed 450-credit presentation payoff without introducing a mission framework or persistent economy
- add deterministic contract + production-scene coverage for ordering, Hauler-only progression, route choice, interception/retry, delivery/payoff, shared-HUD safety, replay reset, and the pre-mounted-Hauler handoff

## Verification
Final exact head `f291a9109db9fea183b0edb8e7a8b09b9072be0c` passed branch Web Playtest run #361. PR Web Playtest run #362 passed the literal PR-head export, synthetic merge export, and exact-head canonical 29-suite compatibility matrix.

## Review
Frozen Standards+Spec review found one important retained-state edge case (Mission 01 completing while the Hauler was already occupied). It was reproduced RED in the production-scene regression and fixed with a narrow retained-occupancy reconciliation; the final head is GREEN across all merge gates. No remaining critical/important findings.

## Scope
No generalized quest framework, new vehicle physics, camera rewrite, radio architecture, combat, economy persistence, or wanted-system rewrite.