### PR TITLE
Visual Direction — approve Gears humanoid bot family

### DIFF
--- a/docs/visual_direction/GEARS_DISTRICT_HUMANOID_BOT_IMPLEMENTATION_NOTE.md
+++ b/docs/visual_direction/GEARS_DISTRICT_HUMANOID_BOT_IMPLEMENTATION_NOTE.md
@@ -1,0 +1,12 @@
+# Humanoid Bot Implementation Note
+
+**Status:** `APPROVED_VISUAL_FAMILY__NOT_REQUIRED_FOR_01A`
+
+Humanoid bots are approved visual canon via `GEARS_DISTRICT_HUMANOID_BOT_VISUAL_FAMILY_APPROVAL.md`.
+
+For Open World Expansion 01A / Issue #60:
+
+- do not expand the ticket merely to add a humanoid bot;
+- a Municipal Maintenance or Salvage Labor humanoid may substitute for the ordinary worker/small utility bot proof only if it is the smallest maintainable path;
+- otherwise keep Issue #60 unchanged and defer humanoid production to the first justified post-proof slice;
+- no humanoid bot mechanics, combat role, sentience, narrative agency or population simulation is implied by the visual approval.

--- a/docs/visual_direction/GEARS_DISTRICT_HUMANOID_BOT_VISUAL_FAMILY_APPROVAL.md
+++ b/docs/visual_direction/GEARS_DISTRICT_HUMANOID_BOT_VISUAL_FAMILY_APPROVAL.md
@@ -1,0 +1,207 @@
+# Gears District Humanoid Bot Visual Family — Owner Approval
+
+**Milestone:** Visual Direction / Concept Art  
+**Decision:** `APPROVED`  
+**Parent direction:** **Civic Salvage Palimpsest / Industrial Cel-Shaded Near Future**  
+**Parent approval:** `GEARS_DISTRICT_VISUAL_DIRECTION_APPROVAL.md`  
+**Approval evidence:** owner review and approval, 2026-08-25.
+
+This document adds humanoid bots as an approved supporting visual family for Gears District. It does not replace the existing robot rules; it narrows how human-shaped machines fit the world without turning the setting into generic android/cyberpunk fiction.
+
+## Core rule
+
+Humanoid bots are humanoid because the city, tools, stairs, doors, counters and workstations were designed for human bodies — **not** because manufacturers were trying to imitate people.
+
+Normal humanoid bots should therefore remain visibly mechanical: replaceable panels, exposed or legible joints, occupational equipment, asset/serial identification, maintenance history and non-human sensor/head architecture.
+
+## Population hierarchy
+
+Humanoid units are a minority of autonomous machines.
+
+Target world balance, to be tuned by production needs rather than treated as an exact simulation rule:
+
+- compact utility/service bots: dominant everyday machine population;
+- specialized non-humanoid machinery: common industrial layer;
+- humanoid bots: selective supporting population, roughly 10–20% of visible autonomous machines where appropriate.
+
+This protects FB-13/HS-7 identity and prevents the setting from becoming an android society.
+
+## Approved families
+
+### 1. Municipal Maintenance Humanoid
+
+**Role:** street repair, inspection, meters, electrical cabinets, signage, sanitation and civic field maintenance.
+
+Visual rules:
+- broad rectangular torso;
+- stable mechanical feet and work posture;
+- utility backpack/tool spine or clear occupational attachment;
+- sensor housing rather than human face;
+- worn off-white, municipal teal, faded amber and charcoal family;
+- large asset ID, inspection stickers and replaceable forearm/tool modules;
+- standardized base form with visible replacement parts from different service cycles.
+
+Behavioral character may emphasize procedural civic absurdity, but gameplay-critical behavior remains an implementation/narrative decision.
+
+### 2. Salvage / Yard Labor Humanoid
+
+**Role:** sorting, lifting, cutting, hauling and dangerous industrial work.
+
+Visual rules:
+- heavier shoulders/arms;
+- wider stance and lower center of gravity;
+- protected/recessed sensor head;
+- clamps, heavy hands or tool interfaces;
+- visible hydraulic/mechanical structure;
+- faded yellow, dirty green, steel and mismatched repaired panels;
+- stronger kitbash/reclaimed-part language than municipal units.
+
+### 3. Civic Service Humanoid
+
+**Role:** permit counters, information desks, transit/public-service assistance and building service.
+
+Visual rules:
+- upright, cleaner silhouette;
+- simpler limbs and friendlier proportions without synthetic-human anatomy;
+- screen/sensor interface rather than flesh face;
+- integrated document/receipt/scanner functions where useful;
+- older units may retain obsolete civic UI, slogans or terminology.
+
+### 4. Municipal Enforcement Support Unit
+
+**Role:** roadblock, scanning, evidence handling, traffic control, barricade/heavy-door work, pursuit telemetry and other support functions.
+
+Visual rules:
+- institutional first, threatening second;
+- rigid posture and standardized symmetrical base construction;
+- protected sensor head and stronger torso block;
+- high-visibility agency markings and readable unit IDs;
+- equipment communicates compliance/support role before combat capability;
+- avoid default RoboCop/Terminator/military-mech language.
+
+Human enforcement remains visually and narratively distinct; these units do not silently replace it.
+
+### 5. Echotel Humanoid Service Unit
+
+**Role:** facility service, archival handling, communications support and legacy hospitality/technical operations.
+
+Visual rules:
+- cleaner ivory shell family with restrained oxblood details;
+- quieter, more integrated mechanisms;
+- smoother motion and older premium industrial design;
+- age shown through yellowing, mismatched service panels and obsolete terminology rather than heavy scrapyard damage;
+- should imply an earlier, better-funded technological era without becoming sleek contemporary sci-fi.
+
+### 6. Obsolete / Reclaimed Humanoid
+
+**Role:** privately owned, rebuilt, repurposed or gray-market former civic/corporate/industrial units.
+
+Visual rules:
+- visible previous-life markings or ghost livery;
+- mismatched modules and changed occupational equipment;
+- strongest personalization/repair history of the family;
+- local businesses, garages, scavengers and neighborhood uses may create highly characterful variants while retaining mechanical readability.
+
+## Special narrative humanoids
+
+Humanoid units linked to Echotel history, Silent Core, HS-7 or memory suppression should remain rare and authored.
+
+They do not need to look more futuristic than ordinary units. Older, quieter, unusually well-maintained machines with missing/removed asset identification may be more effective than overt spectacle.
+
+Mystery-specific behavior, sentience, memory status or narrative authority is **not established by visual design alone**.
+
+## Shared construction grammar
+
+A normal humanoid bot should use at least four of the following as visible design cues:
+
+1. replaceable body panels;
+2. exposed or clearly articulated mechanical joints;
+3. serial/asset identification;
+4. occupational equipment;
+5. non-human head/sensor architecture;
+6. visible maintenance/reassignment history.
+
+### Face rule
+
+Default humanoid bots do **not** use realistic human faces or synthetic skin.
+
+Preferred interfaces include:
+- camera/sensor clusters;
+- recessed lenses;
+- simple displays;
+- optical apertures;
+- grille/speaker assemblies;
+- helmet-like sensor shells.
+
+Simple graphical expressions are allowed on service-oriented units when they read as interface design rather than artificial flesh.
+
+## Silhouette families
+
+At retained elevated 3/4 gameplay distance, major families should separate before texture detail:
+
+- municipal maintenance: upright/broad standardized work silhouette;
+- salvage labor: heavy shoulders/arms, wide stance;
+- civic service: narrower/cleaner friendly silhouette;
+- enforcement support: rigid reinforced torso and institutional stance;
+- Echotel: cleaner integrated proportions;
+- reclaimed: visibly modified silhouette while preserving readable mechanical anatomy.
+
+The player should be able to distinguish **human worker vs maintenance bot vs salvage bot vs enforcement-support bot** through upper-body mass, head geometry and gait rather than tiny labels.
+
+## Motion language
+
+Animation should reinforce family identity when implemented:
+
+- municipal: precise, economical, procedural;
+- salvage: heavy acceleration/deceleration and obvious machine weight;
+- civic service: deliberate gestures designed for human interaction;
+- enforcement support: fast sensor acquisition and stable purposeful locomotion;
+- Echotel: unusually smooth for its apparent age;
+- reclaimed: allowed mismatched timing, servo lag or improvised gait where readable and performant.
+
+## Keep
+
+- construction-machine anatomy;
+- cassette-future housings;
+- modular limbs;
+- kitbashed/repaired variants;
+- industrial labeling;
+- protective shells;
+- chunky hands/feet where occupationally justified;
+- visible job-specific attachments;
+- anime/mecha silhouette discipline;
+- strong readability from the retained camera.
+
+## Avoid
+
+- realistic synthetic human skin as the normal robot language;
+- chrome human replicas;
+- generic Terminator skeletons;
+- sexualized android design as default;
+- universal combat capability;
+- everyday military-mech armor;
+- decorative glowing circuitry;
+- greeble density that collapses at gameplay distance;
+- pristine symmetrical sci-fi plating across the population;
+- humanoid machines visually overwhelming FB-13/HS-7 identity.
+
+## Production sequencing
+
+Humanoid bots are approved for Gears production, but **Issue #60 / Open World Expansion 01A remains bounded**.
+
+For the current in-engine style proof, a municipal maintenance humanoid or salvage labor humanoid may substitute for the ordinary worker/small-bot proof only when doing so is the smallest useful experiment and does not materially expand implementation scope.
+
+Recommended later production order after the style proof passes:
+
+1. Municipal Maintenance Humanoid;
+2. Salvage / Yard Labor Humanoid;
+3. Reclaimed local variant;
+4. Civic Service Humanoid;
+5. Municipal Enforcement Support Unit;
+6. Echotel and other authored legacy/special units as narrative need justifies.
+
+## Status
+
+`APPROVED__SUPPORTING_VISUAL_FAMILY`
+
+This approval expands visual canon. It does not establish bot population counts as hard simulation rules, AI behavior, sentience, combat mechanics, narrative agency, mission roles or full district production scope.


### PR DESCRIPTION
## State

Docs-only visual canon update.

## Decision

Owner-approved humanoid bots as a supporting Gears District visual family.

The new family keeps robots visibly mechanical and occupational rather than synthetic-human, with six approved lanes: municipal maintenance, salvage labor, civic service, enforcement support, Echotel service, and obsolete/reclaimed units.

## Scope guard

Issue #60 / Open World Expansion 01A remains bounded. A humanoid bot may substitute for the worker/small-bot proof only if it is the smallest useful implementation path; otherwise humanoid production waits for the first justified post-proof slice.

No bot sentience, combat mechanics, narrative agency, simulation population rules, or full district production is canonized by this PR.