### PR TITLE
docs(visual): add visual direction wayfinder and reference atlas

### DIFF
--- a/docs/visual_direction/README.md
+++ b/docs/visual_direction/README.md
@@ -1,0 +1,153 @@
+# Visual Direction Wayfinder
+
+**START HERE for visual-direction work.**
+
+This file routes humans and coding agents to the current visual canon without duplicating the detailed specs. If a linked source conflicts with another source, use the precedence rules below rather than inventing a compromise.
+
+## Current state
+
+- **Approved direction:** Civic Salvage Palimpsest / Industrial Cel-Shaded Near Future
+- **Current canon head when this wayfinder was created:** `9686f8d88a7e926de8cfd544afe392378ca917bf`
+- **Current implementation gate:** Open World Expansion 01A — Gears in-engine visual style proof, issue `#60`
+- **Large-scale Gears production:** wait for the bounded in-engine proof to pass
+- **Gameplay foundations:** preserve existing camera, controls, vehicles, pursuit, mission HUD, retry/reset and other retained systems unless visual proof exposes a concrete readability problem
+
+## One-paragraph visual thesis
+
+Gears District is a dense, functioning municipal-industrial place built from repurposed advanced technology, salvage economics, small businesses, civic bureaucracy and buried infrastructure. The world is stylized and graphic rather than photoreal: broad cel-shaded value groups, selective contours, anime/mecha design discipline for people/robots/vehicles, strong physical signage and GTA-family gameplay readability without copying GTA assets, branding, characters, locations, UI, writing or map layouts. Technology is ordinary infrastructure: bought, serviced, patched, stolen, relabeled, regulated and misunderstood. The setting must not collapse into generic neon cyberpunk, glossy sci-fi futurism or post-apocalyptic ruin.
+
+## Authority / precedence
+
+Use the freshest directly approved source for the category being changed.
+
+1. `GEARS_DISTRICT_VISUAL_DIRECTION_APPROVAL.md` — overall approved visual canon and production gate.
+2. `GEARS_DISTRICT_HUMANOID_BOT_VISUAL_FAMILY_APPROVAL.md` — approved humanoid-bot family; wins for humanoid-bot questions.
+3. `GEARS_DISTRICT_VISUAL_DIRECTION_V2_CONVERGENCE.md` — detailed converged rendering/category rules. Where v1 and v2 differ, v2 wins.
+4. `GEARS_DISTRICT_VISUAL_DIRECTION_V1.md` — broader exploratory/detail source where not superseded.
+5. `GEARS_DISTRICT_CONCEPT_BOARD_01_BRIEF.md` — concept-board composition/communication brief; not an authority over later approvals.
+6. `REFERENCE_ATLAS.md` — provenance and extracted-reference logic. Reference material does **not** override approved canon.
+7. Implementation notes/tickets — define current execution scope; they do not silently rewrite visual canon.
+
+Proposed department, business and location names in earlier documents remain **PROPOSED** unless separately approved as narrative canon.
+
+## Category map
+
+| Category | Current direction | Authoritative detail |
+|---|---|---|
+| Rendering | Industrial cel-shaded; broad value bands; selective contours; matte/satin baseline | Approval + v2 |
+| Architecture | stacked 2–5 storey mixed-use industrial/commercial/residential; bolt-on utilities; landmark infrastructure | Approval + v2 |
+| District readability | elevated 3/4 camera; clear routes, shortcuts, silhouettes and orientation anchors | Approval + v1/v2 |
+| Humans | anime-influenced faces/proportions; practical occupational clothing and gear; class/job/neighborhood drive silhouette | Approval + v2 |
+| Compact robots | functional, characterful, repaired, serial-numbered; personality through proportion/gait/history | Approval + v2 |
+| Humanoid bots | supporting family; visibly mechanical and occupational, not synthetic-human | Humanoid-bot approval |
+| Civilian vehicles | retro-utility near-future; compact/boxy or strongly role-driven; modular panels/cargo/sensors | Approval + v2 |
+| Courier Bike | compact modular hero bike; oversized practical tires; low center; strong cargo/signal and top silhouette | Approval + v2 |
+| Enforcement | bureaucratic pursuit fleet; institutional first, threatening second; strong civic livery | Approval + v2 |
+| Signage/branding | municipal, commercial, aftermarket/subculture, criminal/gray-market spoof families | Approval + v2 |
+| Props/street furniture | obvious function + chunky silhouette + replaceable panels + serial/inspection graphics | v2 |
+| Lighting | practical light first; warm/amber civic/industrial, restrained cool utilities; neon/emissive punctuation only | Approval + v1/v2 |
+| Silent Core / Sister Kael | obsolete advanced infrastructure with ritual seriousness; sparse signal cyan; no fantasy shrine language | Approval + v2 |
+| HUD relationship | retain functional HUD; physical bureaucracy and HUD share underlying graphic logic without replacing HUD contract | v1/v2 |
+
+## Approved visual invariants
+
+- **Readability before detail.** Hero assets should read in 3–5 major value/color masses at gameplay distance.
+- **Silhouette before texture.** Player, Courier Bike, pursuit vehicle, robots and landmark anchors cannot depend on tiny details.
+- **Saturation is information.** Bright color marks identity, hazard, brand, enforcement, mission or signal/memory meaning.
+- **Wear follows use.** Repairs, grime, chipping and rust belong at plausible contact, drainage, impact and replacement zones.
+- **Function before futurism.** Vehicles, robots, props and architecture must visibly explain what they do.
+- **Practical light before neon.** Night should remain a working district, not a neon wallpaper.
+- **Systems satire over random jokes.** Civic graphics and world copy target institutions, procurement, compliance and bureaucracy.
+- **Mystery is rare.** HS-7/Silent Core visual phenomena stay scarce enough to reorganize the frame when they appear.
+- **Humanoid bots stay mechanical.** Human-shaped because the built environment is human-shaped; not because they imitate humans.
+- **GTA-family influence is experiential, not derivative.** Use clarity, immediacy, memorable silhouettes/businesses/vehicles and crime-world satire; do not copy protected visual assets or layouts.
+
+## Avoid / drift checks
+
+Stop and reassess if work starts trending toward any of these without explicit approval:
+
+- neon-everywhere cyberpunk;
+- glossy pristine future-city design;
+- generic post-apocalyptic rust wash;
+- photoreal surface detail that destroys the graphic read;
+- anime characters pasted into an unrelated realistic environment;
+- every civilian/robot/vehicle becoming a hero design;
+- realistic synthetic-human androids as ordinary population;
+- military-mech language as the default for enforcement;
+- tiny typography or greeble density carrying gameplay-critical information;
+- fantasy/cathedral/crystal visual language for Silent Core;
+- wholesale HUD/camera/gameplay redesign justified only by art preference.
+
+## Humanoid-bot quick router
+
+Approved lanes:
+
+1. municipal maintenance;
+2. salvage / yard labor;
+3. civic service;
+4. municipal enforcement support;
+5. Echotel service;
+6. obsolete / reclaimed.
+
+Normal units should expose occupational function, mechanical joints/panels, asset IDs and repair/reassignment history. Realistic human faces/skin are not the baseline. Special narrative units may break normal patterns only when authored and approved.
+
+## Current implementation gate — Issue #60
+
+Open World Expansion 01A should prove the approved style in the real Godot runtime at the retained elevated 3/4 camera before full district production.
+
+Minimum proof themes:
+
+- cel-shaded value grouping / selective contours;
+- representative stacked Gears structure;
+- primary route + alternate/shortcut;
+- municipal silhouette anchor;
+- storefront/signage treatment;
+- ordinary resident/worker treatment;
+- Courier Bike;
+- civilian/utility vehicle;
+- pursuit vehicle;
+- utility robot or a humanoid maintenance/salvage substitute if that is genuinely the smaller proof;
+- distant infrastructure/Silent Core-adjacent cue;
+- restrained practical lighting;
+- runtime captures + code verification + telemetry.
+
+Do not expand Issue #60 into full district production.
+
+## How to use this during implementation
+
+For Codex or another repo-aware agent:
+
+1. Verify repo, branch/worktree, `main`, dirty state and relevant runtime before changing anything.
+2. Read this file.
+3. Read only the category authority linked above that affects the task.
+4. Read the current issue/ticket scope.
+5. Inspect the actual Godot/runtime implementation before assuming docs match code.
+6. Make the smallest reversible implementation that proves the desired player-facing result.
+7. Verify gameplay/readability/performance relevant to the change.
+8. If runtime reality conflicts with the visual spec, report the conflict. Do not silently rewrite canon.
+
+Suggested agent preamble:
+
+> Read `docs/visual_direction/README.md` first. Follow its authority map. Treat approved visual docs as creative truth and repo/runtime behavior as implementation truth. Do not reinterpret reference material against approved canon. Preserve retained gameplay systems unless an observed visual/readability problem justifies a bounded change.
+
+## Updating visual canon
+
+When a new visual decision is approved:
+
+- add or update the narrowest authoritative category document;
+- update this Wayfinder only if routing/status/precedence changes;
+- update `REFERENCE_ATLAS.md` only when provenance or extracted reference logic changes;
+- keep `PROPOSED`, `CANDIDATE`, `APPROVED`, `IMPLEMENTED`, `EXPERIMENTAL` and `UNKNOWN` explicit;
+- never convert inspiration material into canon without an approval decision;
+- never silently canonize names, mechanics, sentience, population behavior or narrative implications from a visual design alone.
+
+## Files in this directory
+
+- `README.md` — **START HERE / wayfinder**
+- `REFERENCE_ATLAS.md` — reference families, provenance and extracted rules
+- `GEARS_DISTRICT_VISUAL_DIRECTION_APPROVAL.md` — overall approval / production gate
+- `GEARS_DISTRICT_VISUAL_DIRECTION_V2_CONVERGENCE.md` — converged detailed direction
+- `GEARS_DISTRICT_VISUAL_DIRECTION_V1.md` — original detailed package
+- `GEARS_DISTRICT_CONCEPT_BOARD_01_BRIEF.md` — concept-board brief
+- `GEARS_DISTRICT_HUMANOID_BOT_VISUAL_FAMILY_APPROVAL.md` — humanoid-bot visual canon
+- `GEARS_DISTRICT_HUMANOID_BOT_IMPLEMENTATION_NOTE.md` — bounded implementation note

--- a/docs/visual_direction/REFERENCE_ATLAS.md
+++ b/docs/visual_direction/REFERENCE_ATLAS.md
@@ -1,0 +1,502 @@
+# Gears District Visual Reference Atlas
+
+**Purpose:** preserve the reference-to-rule trail behind the approved visual direction without making external inspiration material itself authoritative.
+
+This is a provenance and design-reasoning document, not a moodboard dump. The approved canon lives in the approval/convergence documents routed by `README.md`.
+
+## Reference handling rules
+
+- External images, Pinterest pins/boards and third-party concept art are **reference evidence only**.
+- Extract principles; do not copy protected characters, logos, vehicles, buildings, compositions or distinctive assets.
+- Do not commit third-party reference images unless commercial-use rights are verified and the project actually needs the file.
+- External links are mutable and may disappear. The durable project value is the extracted rule written here and in approved canon.
+- User-supplied screenshot batches discussed during the visual-direction pass were not automatically committed to the repo. They are represented below as `CHAT_REFERENCE_BATCH` when a durable source URL was not established.
+- Generated/original concept tests may be committed separately when they are useful production evidence and rights are clear.
+
+## Status vocabulary
+
+- `APPROVED_EXTRACT` — principle survived owner approval and is represented in visual canon.
+- `SUPPORTING_REFERENCE` — useful source family; not itself canon.
+- `AVOID_EXTRACT` — reference showed a direction explicitly rejected as baseline.
+- `UNKNOWN_SOURCE` — the design lesson was captured, but durable third-party provenance was not established.
+
+---
+
+## 1. Overall rendering / world synthesis
+
+**Source:** `CHAT_REFERENCE_BATCH` + approved generated visual-direction tests  
+**Status:** `APPROVED_EXTRACT`
+
+### Extract
+
+- industrial cel-shaded near future;
+- grounded material/architectural logic with graphic rendering;
+- broad value/color groups before texture;
+- selective contours, especially on characters, vehicles, interactables and structural edges;
+- anime/mecha design discipline without turning the entire world into flat anime illustration;
+- GTA-family readability/immediacy and satirical density as experiential reference, never literal visual copying;
+- near-future technology should feel old enough to have been repaired, privatized, regulated and repurposed.
+
+### Reject
+
+- photoreal cinematic concept-art look as production target;
+- generic neon cyberpunk;
+- full comic outline treatment on every environment surface;
+- glossy pristine sci-fi;
+- painterly atmosphere that obscures routes or silhouettes.
+
+---
+
+## 2. Buildings / district architecture
+
+**Source:** `CHAT_REFERENCE_BATCH` — stacked modular cream/teal mixed-use building, vertical utility-heavy structure, moody industrial alley/stair references  
+**Status:** `APPROVED_EXTRACT` / `UNKNOWN_SOURCE`
+
+### Extract
+
+- stacked, modular, repurposed architecture;
+- 2–5 storey mixed-use street massing rather than skyscraper default;
+- exterior stairs, balconies, utility boxes, wiring, pipe runs, vents and repaired panels;
+- warm occupied interiors against cooler industrial shells;
+- vertical density without megacity tower language;
+- one dominant silhouette feature per cluster;
+- architecture must simplify cleanly from elevated 3/4 camera.
+
+### Reject
+
+- tiny pipe/greeble density as identity;
+- dramatic emptiness that harms gameplay geography;
+- excessive roof/gantry occlusion;
+- every building being a hero asset.
+
+---
+
+## 3. Human character design
+
+**Source:** `CHAT_REFERENCE_BATCH` — courier/explorer, masked street/enforcer, mechanic/field-worker, oversized technical fashion, prosthetic/augmentation and municipal field-uniform references  
+**Status:** `APPROVED_EXTRACT` / `UNKNOWN_SOURCE`
+
+### Extract
+
+- anime-influenced faces and clean silhouettes;
+- practical layered clothing and workwear;
+- profession, class, neighborhood and hustle determine silhouette;
+- bags, helmets, boots, outerwear and tools are major shape language;
+- controlled muted palettes with selected accents;
+- augmentations/prosthetics are selective and functional;
+- background residents use simpler versions of the same grammar.
+
+### Reject
+
+- every NPC looking like a fashion-editorial protagonist;
+- universal masks/hoods;
+- red/black cyber-ninja default;
+- augmentation as mandatory aesthetic;
+- realistic human rendering disconnected from the stylized environment.
+
+---
+
+## 4. Compact robots / service machines
+
+**Source:** `CHAT_REFERENCE_BATCH` — small cube-headed bot, beige wheeled utility bot, orange quadruped sensor bot and stylized mechanical-character references  
+**Status:** `APPROVED_EXTRACT` / `UNKNOWN_SOURCE`
+
+### Extract
+
+- mechanical but charming;
+- obvious occupational function;
+- compact readable silhouette;
+- off-white/utility-color shells, dark structure, sparse signal lights;
+- maintenance panels, serial IDs and visible repair history;
+- personality through proportion, gait and wear rather than decorative anthropomorphism.
+
+### Reject
+
+- toy-like sameness;
+- glowing-tech overload;
+- micro-detail as primary character identity.
+
+---
+
+## 5. Humanoid bots
+
+**Status:** `APPROVED_EXTRACT`
+
+### Core extracted rule
+
+Humanoid because human-built spaces use human stairs, doors, tools and workstations — **not** because the machine is intended to imitate a human being.
+
+Approved families:
+
+- municipal maintenance;
+- salvage / yard labor;
+- civic service;
+- municipal enforcement support;
+- Echotel service;
+- obsolete / reclaimed.
+
+Shared design cues:
+
+- replaceable panels;
+- exposed/legible joints;
+- asset IDs;
+- occupational equipment;
+- non-human sensor/head architecture;
+- maintenance/reassignment history;
+- family-specific body mass and gait.
+
+### Pinterest provenance examples
+
+These were used as supporting searches during the humanoid-bot pass. They are not licensed production assets and do not override canon.
+
+- Maintenance Droid — Ryan Millard: `https://in.pinterest.com/pin/410742428522789155/`
+- Heavy Machinery Construction Robot board: `https://jp.pinterest.com/tsurubari/heavy-machinery-construction-robot/`
+- Mechanic kōbo board: `https://co.pinterest.com/juandabl16/mechanic-k%C5%8Dbo/`
+- Kitbash Robots board: `https://www.pinterest.com/wardjared19/kitbash-robots/`
+- Service Robot board: `https://se.pinterest.com/mfrimani/service-robot/`
+- Mechanical / Robots / Cyborgs / Industrial board: `https://at.pinterest.com/mechfox/mechanical-robots-cyborgs-industrial/`
+- Humanoid Robot Concept Dump board: `https://dk.pinterest.com/vrvdelta/humanoid-robot-concept-dump/`
+- Concept Robots & Droids board: `https://www.pinterest.com/davorkronja/concept-robots-droids/`
+
+### Reject
+
+- synthetic skin / realistic human faces as ordinary baseline;
+- sleek chrome android population;
+- generic Terminator skeletons;
+- sexy android framing;
+- every humanoid bot being combat-capable;
+- military-mech armor as normal civic body language.
+
+---
+
+## 6. Civilian / commercial vehicles
+
+**Source:** `CHAT_REFERENCE_BATCH` — chunky expedition van, worn local van, compact modified hatch, mint retro-future compact, wedge hatch, delivery truck, pod vehicle and modular cargo-bike/truck concepts  
+**Status:** `APPROVED_EXTRACT` / `UNKNOWN_SOURCE`
+
+### Extract
+
+- retro-utility near future;
+- boxy/compact or strongly role-driven forms;
+- short wheelbases, tall cabins, thick panels, oversized tires where appropriate;
+- modular racks, sensors, cargo, housings and replacement panels;
+- one clear job/use visible from silhouette;
+- controlled off-white/orange/mint/dusty-green/light-blue/charcoal color blocking;
+- local wear, relivery and salvage-economy modification.
+
+### Use selectively
+
+- clean bubble/pod vehicles for premium/corporate/special cases;
+- low wedge forms when role/readability supports them.
+
+### Reject
+
+- sleek luxury future as ordinary traffic;
+- identical hatchback population;
+- universal giant exposed tech;
+- global apocalypse damage treatment.
+
+---
+
+## 7. Enforcement fleet
+
+**Source:** `CHAT_REFERENCE_BATCH` — black/off-white armored pursuit coupe, compact wedge patrol form, long enforcement transport, pale civic sedan/police vehicle  
+**Status:** `APPROVED_EXTRACT` / `UNKNOWN_SOURCE`
+
+### Extract
+
+- bureaucratic pursuit fleet;
+- institutional first, threatening second;
+- fleet-purchased and standardized;
+- strong civic value grouping/livery;
+- roof IDs/beacons, reinforced fronts, sensors/comms and practical interception hardware;
+- clear interceptor, patrol/inspection and transport/support subclasses;
+- mild ugliness of procurement is a feature.
+
+### Reject
+
+- death-squad / elite SWAT baseline;
+- tank/APC language for normal pursuit;
+- generic contemporary police realism;
+- luxury performance-car aesthetic.
+
+---
+
+## 8. Courier Bike / motorcycle language
+
+**Source:** `CHAT_REFERENCE_BATCH` — chunky low mechanical bikes, slab-sided off-white/orange concept, prototype/police/mech bike references  
+**Status:** `APPROVED_EXTRACT` / `UNKNOWN_SOURCE`
+
+### Extract
+
+- signature gameplay object needs a unique elevated-camera silhouette;
+- compact modular courier machine;
+- low center of mass;
+- large wheel-to-body relationship;
+- chunky replaceable shell/body modules;
+- partially exposed suspension/drive structure;
+- strong cargo/signal mass;
+- asymmetrical replacement/repair panel;
+- stenciled fleet/serial graphics.
+
+### Use selectively
+
+- partially enclosed wheels;
+- broad bodywork;
+- low superbike cues;
+- heavy mech-bike architecture when gameplay role justifies it.
+
+### Reject
+
+- contemporary superbike + sci-fi trim as baseline;
+- giant smooth spaceship shell;
+- touring-bike bulk that contradicts nimble handling;
+- micro-detailed mechanical noise that disappears at camera distance.
+
+---
+
+## 9. Signage / branding / graphic design
+
+**Source:** `CHAT_REFERENCE_BATCH` — physical storefront/neon signs plus Y2K/tuner/sticker/logo systems  
+**Status:** `APPROVED_EXTRACT` / `UNKNOWN_SOURCE`
+
+### Extract
+
+Four approved graphic families:
+
+1. **Municipal / civic** — rigid grid, numbers, asset IDs, arrows, route bands, permits, clipped-corner plates, off-white/charcoal/amber/teal.
+2. **Commercial / neighborhood** — custom sign silhouettes, physical brackets/housings, reused substrates, local retro-future/Y2K energy.
+3. **Aftermarket / subculture** — sticker/wordmark/tuner/pirate-radio/cheap-tech/product graphics on vehicles, helmets, bags, crates and storefronts.
+4. **Criminal / gray-market spoof** — copied civic typography, altered permits, counterfeit seals, near-official businesses and decals.
+
+Hero sign priority:
+
+**shape -> color/value -> icon -> 1–3 readable words**.
+
+### Reject
+
+- tiny text as navigation;
+- every storefront being loud/cool;
+- contemporary clean-tech minimalism as default;
+- illegible graffiti/tuner lettering as primary civic/commercial wayfinding;
+- candy-color saturation across the whole district.
+
+---
+
+## 10. Props / street furniture / industrial clutter
+
+**Status:** `APPROVED_EXTRACT`
+
+### Extract
+
+Reusable families:
+
+- utility cabinets and meters;
+- kiosks/payment terminals;
+- vending machines;
+- bins/dumpsters;
+- generators/electrical/signal boxes;
+- barriers;
+- maintenance carts;
+- loading hardware;
+- streetlights;
+- yard-service machinery.
+
+Production rule:
+
+> obvious function + chunky silhouette + replaceable panel logic + serial/inspection graphics
+
+### Supporting Pinterest provenance
+
+- Industrial Design Props: `https://ca.pinterest.com/tylervoart/industrial-design-props/`
+- Industrial Design / Prototyping: `https://au.pinterest.com/gekkographics/industrial-design-prototyping/`
+- Vending Machines: `https://au.pinterest.com/the_braindeef_boy/vending-machines/`
+- Sci-fi Machinery: `https://www.pinterest.com/jinh74/sci-fi-machinery/`
+
+### Reject
+
+- random clutter with no function/provenance;
+- high-frequency prop fields that hide road edges/interactables.
+
+---
+
+## 11. Landmark / infrastructure silhouettes
+
+**Status:** `APPROVED_EXTRACT`
+
+### Extract
+
+Use infrastructure as navigation rather than skyline spectacle:
+
+- cranes;
+- relay masts;
+- capped stacks;
+- water towers;
+- gantries;
+- pipe bridges;
+- silos;
+- substations;
+- old transit structures;
+- extraction/service towers.
+
+Each important block/intersection should get a dominant orientation read before entry.
+
+### Supporting Pinterest provenance
+
+- Industrial Sci-fi: `https://www.pinterest.com/the_weird_one/industrial-sci-fi/`
+- Industrial Sci-fi mechanical reference: `https://za.pinterest.com/le_bastion/industrial-sci-fi/`
+- Industrial environments: `https://uk.pinterest.com/ashton9505photography/industrial/`
+
+### Reject
+
+- Blade Runner-style spectacle skyline as default;
+- landmarks whose only purpose is visual scale.
+
+---
+
+## 12. Silent Core / Sister Kael / mystery technology
+
+**Status:** `APPROVED_EXTRACT`
+
+### Extract
+
+- obsolete advanced infrastructure whose significance outlived its understood purpose;
+- telecom/relay/server/utility ancestry;
+- stripped/removed asset plates and quieter negative space;
+- ritual conveyed through maintenance, placement, repetition and human care;
+- sparse HS-7 cyan/memory phenomena;
+- advanced technology can look older, quieter and simpler than ordinary commercial technology;
+- emotional target: people discovered that obsolete infrastructure remembers something the city wants forgotten and learned to approach it with ritual seriousness.
+
+### Supporting Pinterest provenance
+
+- Machine God: `https://uk.pinterest.com/jackgreenall73/machine-god/`
+- New Machine God: `https://uk.pinterest.com/jackgreenall73/new-machine-god/`
+- Weakness of the Flesh / machine stuff: `https://ca.pinterest.com/wasteofgrass/weakness-of-the-flesh-machine-stuff/`
+- Industrial Cassette Futurism: `https://in.pinterest.com/iatk2025/industrial-cassette-futurism/`
+
+### Reject
+
+- glowing crystal shrine;
+- gothic sci-fi cathedral;
+- holographic altar;
+- cosmic machine-god spectacle;
+- neon mysticism.
+
+---
+
+## 13. Ordinary workers / civilian grounding
+
+**Status:** `APPROVED_EXTRACT`
+
+### Extract
+
+The population cannot consist entirely of protagonists. Use occupationally grounded variants for:
+
+- mechanics;
+- shopkeepers;
+- salvage workers;
+- clerks;
+- couriers;
+- food vendors;
+- utility crews;
+- older residents;
+- municipal field staff.
+
+### Supporting Pinterest provenance
+
+- Industrial + character art: `https://au.pinterest.com/rodrigomontigue/industrial/`
+- Janitor character concepts: `https://uk.pinterest.com/philcarlisle/janitor-character-concept/`
+- Fayn mechanic board: `https://www.pinterest.com/guywiththesuitc/fayn-mechanic/`
+- Mechanic character example: `https://www.pinterest.com/pin/831899362418290963/`
+
+### Reject
+
+- every civilian receiving protagonist-level accessories/detail;
+- fashion-first character design with no economic/job/world context.
+
+---
+
+## 14. Materials / palette / lighting
+
+**Source:** approved visual package synthesized from all reference families  
+**Status:** `APPROVED_EXTRACT`
+
+### Palette anchors
+
+- soot charcoal `#182126`;
+- worn off-white `#D7D2C3`;
+- municipal concrete `#827F73`;
+- oxidized iron `#8A4F37`;
+- faded safety amber `#D39A2C`;
+- utility teal `#2F7778`;
+- warning vermilion `#D24B3A`;
+- HS-7 signal cyan `#7CCFD0`;
+- Echotel oxblood `#682F38`.
+
+### Extract
+
+- roads/calmer navigation surfaces lower-frequency than walls/yards;
+- paint reads as block first, wear second;
+- rust localized to plausible wear/drainage/impact zones;
+- practical amber/cool-white/warm-interior night lighting;
+- broken wet reflections rather than mirror streets;
+- HS-7 cyan remains scarce and meaningful.
+
+### Reject
+
+- universal orange-rust grading;
+- bloom/neon increase simply because it is night/raining;
+- glossy material baseline.
+
+---
+
+## 15. FB-13 micro-scale identity anchor
+
+**Source:** project/user-provided FB-13 reference and approved visual package  
+**Status:** `APPROVED_EXTRACT`
+
+Use as a principle anchor, not a literal texture kit for the whole city:
+
+- worn pale/off-white casing;
+- dark structural core;
+- restrained cyan signal light;
+- stenciled numbering/IDs;
+- exposed repair hardware;
+- practical asymmetry;
+- evidence of continued use and maintenance.
+
+The city should share the logic without making every building look like a robot.
+
+---
+
+## 16. Negative-reference register
+
+These directions were useful precisely because they clarified what Gears is **not**.
+
+| Direction | Status | Reason |
+|---|---|---|
+| neon-everywhere cyberpunk | `AVOID_EXTRACT` | destroys signal hierarchy and makes setting generic |
+| glossy pristine future | `AVOID_EXTRACT` | conflicts with salvage/repair/institutional history |
+| universal post-apocalyptic ruin | `AVOID_EXTRACT` | Gears is functioning, inhabited and economically active |
+| full photoreal rendering | `AVOID_EXTRACT` | weakens authored graphic identity and gameplay read |
+| full heavy anime/comic environment outlines | `AVOID_EXTRACT` as baseline | risks noisy environment and scalability problems; selective contours preferred |
+| realistic synthetic-human android population | `AVOID_EXTRACT` | shifts genre toward android fiction and dilutes machine identity |
+| military-mech enforcement baseline | `AVOID_EXTRACT` | loses municipal procurement satire and escalation room |
+| fantasy sacred-tech temple language | `AVOID_EXTRACT` | Silent Core should emerge from real civic/telecom infrastructure |
+| tiny-detail/typography-driven world identity | `AVOID_EXTRACT` | fails elevated-camera readability |
+
+---
+
+## 17. How to add new references
+
+When a new reference materially improves the direction:
+
+1. Record the source or mark it `UNKNOWN_SOURCE` / `CHAT_REFERENCE_BATCH`.
+2. Write the **specific principle** we are extracting.
+3. Write what we are explicitly **not** copying or adopting.
+4. Mark the extract `SUPPORTING_REFERENCE`, `CANDIDATE`, or `APPROVED_EXTRACT` based on actual owner decision.
+5. If the principle changes canon, update the narrow authoritative visual document and the Wayfinder routing/status.
+6. Do not treat the presence of a reference in this file as approval by itself.
+
+The goal is continuity: future artists/agents should understand **why** a visual rule exists without needing the original chat or access to a third-party moodboard.


### PR DESCRIPTION
## State

Docs-only continuity/navigation improvement for approved Gears visual direction.

## Adds

- `docs/visual_direction/README.md` — START HERE wayfinder with authority precedence, category router, invariants, drift checks, implementation gate and agent workflow.
- `docs/visual_direction/REFERENCE_ATLAS.md` — inspiration/provenance map that records what was extracted from reference batches and what was explicitly rejected, without treating third-party reference material as canon.

## Design truth rules

- Approved canon remains in the approval/category docs.
- Reference material cannot override approved canon.
- Pinterest/third-party images are not committed as production assets.
- Proposed names remain non-canon unless separately approved.
- Issue #60 remains the bounded in-engine style-proof gate before full Gears production.

## Scope

No gameplay/runtime/assets changed. No canon change beyond documenting already-approved direction and routing.