### PR TITLE
Open World Expansion 01B — first Gears production block

### DIFF
--- a/contracts/open_world_expansion_01b_gears_production_slice_spec.md
+++ b/contracts/open_world_expansion_01b_gears_production_slice_spec.md
@@ -1,0 +1,102 @@
+# Open World Expansion 01B — Gears Production Slice
+
+**State:** READY_FOR_IMPLEMENTATION  
+**Baseline:** `main@ade4e51c147556f3e2964a22fce7c070a5c3737e`  
+**Predecessor:** Issue #60 / PR #63 — bounded in-engine style proof  
+**Creative authority:** `docs/visual_direction/README.md`, `REFERENCE_ATLAS.md`, and the approved Gears visual-direction documents
+
+## Objective
+
+Promote the approved Gears visual language into the smallest real contiguous district-production increment beyond the retained yard without beginning full-district production.
+
+The slice should make the current yard feel like one location inside a larger district by adding one traversable northbound block that connects directly to the existing gameplay floor and contains one readable intersection, one alternate service route, one commercial frontage, one industrial frontage, and one neutral mission-ready destination socket.
+
+## Player-facing topology
+
+The production increment is:
+
+`retained yard north edge -> primary industrial road -> industrial intersection -> north continuation`
+
+with one alternate path:
+
+`intersection -> narrow service alley -> north connector -> primary road`
+
+The alternate path is spatial production only. It does not introduce new route-switch logic, mission branching, traffic AI, or Signal Gate authority.
+
+## Required production content
+
+1. A real traversable primary-road collision surface extending beyond the current 40×40 gameplay floor.
+2. One traversable industrial intersection connected to that road.
+3. One narrower traversable service alley that rejoins the primary route through a second connector.
+4. One stacked commercial frontage using approved Gears value/color/signage hierarchy.
+5. One industrial/municipal frontage using approved repair-history and civic utility language.
+6. One neutral `Marker3D` mission-destination socket with no mission ownership or trigger behavior.
+7. One temporary expansion-edge safety barrier so the currently finite slice does not invite the player into missing geometry.
+8. Reuse the approved lightweight toon material path and restrained accent palette; do not add a new renderer/shader stack.
+
+## Architecture
+
+Create a separate production scene:
+
+`godot/scenes/world/gears_district_slice_01b.tscn`
+
+and integrate it additively into:
+
+`godot/scenes/prototype/scrap_test_block.tscn`
+
+The Issue #60 `GearsStyleProof` scene remains a separate proof/foundation layer. Do not silently rewrite it into the district-production scene.
+
+The production scene may have a tiny contract/introspection script but must not own:
+
+- player movement;
+- camera behavior;
+- Courier Bike or Scrap Hauler behavior;
+- pursuit/interception;
+- Signal Gate/action ownership;
+- mission state machines;
+- retry/replay;
+- HUD/input/audio authority.
+
+## Collision and route constraints
+
+- New collision is allowed because 01B is real traversable world production, but it must be additive and outside the retained gameplay geometry except for a small continuity seam at the existing north edge.
+- Primary traversable width: at least 6.0 m.
+- Service-alley traversable width: at least 3.0 m.
+- New northbound traversable depth beyond the old floor edge: at least 24 m.
+- Commercial/industrial building collision must remain outside the authored drive corridor.
+- No new collision may alter existing yard obstacle transforms or route geometry.
+
+## Bounded production budget
+
+This is one block, not a district pass.
+
+- production-scene mesh instances: `<= 36`;
+- production-scene collision shapes: `<= 10`;
+- real-time local lights added by 01B: `0`;
+- new gameplay scripts/state machines: `0`;
+- new mission triggers: `0`.
+
+## Code-first verification
+
+The exact-head CI gate must verify:
+
+- the production scene loads and is integrated into the real playable scene;
+- retained camera exists with unchanged 32° FOV;
+- all three traversable surfaces have real `CollisionShape3D` nodes;
+- primary/alley widths and northbound depth satisfy this contract;
+- service alley has two route connections rather than being a dead-end decoration;
+- mission socket is a passive `Marker3D`;
+- the temporary expansion-edge barrier has collision;
+- production mesh/collision counts remain within budget;
+- no mission/camera/player/vehicle/pursuit scripts are owned by the production scene;
+- existing exact-head camera and canonical compatibility suites remain green.
+
+## Deferred perceptual/performance qualification
+
+Owner direction explicitly prioritizes roadmap momentum. Fresh visual captures and exact candidate desktop render telemetry remain useful verification debt rather than a routine merge blocker for this incremental slice.
+
+Do not multiply this block into full Gears District acreage before a later verification checkpoint resolves retained-camera readability and performance at representative district scale.
+
+## Completion recommendation
+
+On code/review pass, the next increment should remain one bounded geography/content concern at a time—preferably converting one existing authored mission destination into a real location within the expanded district before adding more acreage.

--- a/godot/scenes/prototype/scrap_test_block.tscn
+++ b/godot/scenes/prototype/scrap_test_block.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=29 format=3 uid="uid://c_scrap_test_block_001"]
+[gd_scene load_steps=30 format=3 uid="uid://c_scrap_test_block_001"]
 
 [ext_resource type="Script" path="res://scripts/prototype/scrap_test_block.gd" id="1_root"]
 
@@ -19,6 +19,7 @@
 [ext_resource type="Script" path="res://scripts/missions/civic_repossession_runtime.gd" id="11_civic_runtime"]
 [ext_resource type="Script" path="res://scripts/missions/city_that_forgot_runtime.gd" id="12_city_runtime"]
 [ext_resource type="PackedScene" path="res://scenes/world/gears_style_proof.tscn" id="13_gears"]
+[ext_resource type="PackedScene" path="res://scenes/world/gears_district_slice_01b.tscn" id="14_gears_district"]
 
 [sub_resource type="Environment" id="Environment_1"]
 background_mode = 1
@@ -215,6 +216,8 @@ script = ExtResource("9_ui_audio")
 [node name="ScrapYardDressing" parent="." instance=ExtResource("7_dressing")]
 
 [node name="GearsStyleProof" parent="." instance=ExtResource("13_gears")]
+
+[node name="GearsDistrictSlice01B" parent="." instance=ExtResource("14_gears_district")]
 
 [node name="MissionScrapJobRuntime" type="Node" parent="."]
 script = ExtResource("10_mission_runtime")

--- a/godot/scenes/world/gears_district_slice_01b.tscn
+++ b/godot/scenes/world/gears_district_slice_01b.tscn
@@ -1,0 +1,369 @@
+[gd_scene load_steps=21 format=3]
+
+[ext_resource type="Script" path="res://scripts/visual/gears_district_slice_01b.gd" id="1_slice"]
+[ext_resource type="Shader" path="res://materials/gears_toon.gdshader" id="2_toon"]
+
+[sub_resource type="BoxMesh" id="Cube"]
+size = Vector3(1, 1, 1)
+
+[sub_resource type="ShaderMaterial" id="Mat_Road"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.11, 0.14, 0.15, 1)
+shader_parameter/roughness_value = 0.9
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_Soot"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.094, 0.129, 0.149, 1)
+shader_parameter/roughness_value = 0.86
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_OffWhite"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.843, 0.824, 0.765, 1)
+shader_parameter/roughness_value = 0.84
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_Concrete"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.51, 0.498, 0.451, 1)
+shader_parameter/roughness_value = 0.92
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_Amber"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.827, 0.604, 0.173, 1)
+shader_parameter/roughness_value = 0.78
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_Teal"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.184, 0.467, 0.471, 1)
+shader_parameter/roughness_value = 0.82
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_Oxidized"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.541, 0.31, 0.216, 1)
+shader_parameter/roughness_value = 0.92
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_Vermilion"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.824, 0.294, 0.227, 1)
+shader_parameter/roughness_value = 0.8
+shader_parameter/emission_color = Color(0, 0, 0, 1)
+shader_parameter/emission_energy = 0.0
+
+[sub_resource type="BoxShape3D" id="Shape_Road"]
+size = Vector3(8, 0.3, 26)
+
+[sub_resource type="BoxShape3D" id="Shape_Intersection"]
+size = Vector3(14, 0.3, 6)
+
+[sub_resource type="BoxShape3D" id="Shape_Alley"]
+size = Vector3(3.5, 0.26, 19)
+
+[sub_resource type="BoxShape3D" id="Shape_Connector"]
+size = Vector3(9, 0.24, 3)
+
+[sub_resource type="BoxShape3D" id="Shape_Commercial"]
+size = Vector3(4.5, 4.4, 14)
+
+[sub_resource type="BoxShape3D" id="Shape_Industrial"]
+size = Vector3(6, 5, 16)
+
+[sub_resource type="BoxShape3D" id="Shape_Barrier"]
+size = Vector3(16, 1.5, 0.5)
+
+[sub_resource type="BoxShape3D" id="Shape_WestRail"]
+size = Vector3(0.3, 0.8, 14)
+
+[sub_resource type="BoxShape3D" id="Shape_EastRail"]
+size = Vector3(0.3, 0.8, 14)
+
+[node name="GearsDistrictSlice01B" type="Node3D"]
+script = ExtResource("1_slice")
+
+[node name="DistrictEntrySocket" type="Marker3D" parent="."]
+position = Vector3(1.7, 0.15, -20)
+
+[node name="DistrictExitSocket" type="Marker3D" parent="."]
+position = Vector3(-4.5, 0.15, -47)
+
+[node name="NorthRoad" type="StaticBody3D" parent="."]
+position = Vector3(-4.5, -0.15, -35)
+
+[node name="RoadMesh" type="MeshInstance3D" parent="NorthRoad"]
+scale = Vector3(8, 0.3, 26)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Road")
+
+[node name="PrimaryWestBand" type="MeshInstance3D" parent="NorthRoad"]
+position = Vector3(-3.72, 0.17, 0)
+scale = Vector3(0.12, 0.035, 26)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="PrimaryEastBand" type="MeshInstance3D" parent="NorthRoad"]
+position = Vector3(3.72, 0.17, 0)
+scale = Vector3(0.12, 0.035, 26)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="NorthRouteMark" type="MeshInstance3D" parent="NorthRoad"]
+position = Vector3(0, 0.18, -8.5)
+scale = Vector3(1.8, 0.04, 0.55)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NorthRoad"]
+shape = SubResource("Shape_Road")
+
+[node name="IndustrialIntersection" type="StaticBody3D" parent="."]
+position = Vector3(-3, -0.16, -22.5)
+
+[node name="IntersectionMesh" type="MeshInstance3D" parent="IndustrialIntersection"]
+scale = Vector3(14, 0.3, 6)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Road")
+
+[node name="CivicCrossingBand" type="MeshInstance3D" parent="IndustrialIntersection"]
+position = Vector3(0, 0.17, -1.8)
+scale = Vector3(14, 0.035, 0.16)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="IntersectionAmberTab" type="MeshInstance3D" parent="IndustrialIntersection"]
+position = Vector3(5.2, 0.18, 1.4)
+scale = Vector3(1.1, 0.04, 0.55)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="IndustrialIntersection"]
+shape = SubResource("Shape_Intersection")
+
+[node name="ServiceAlley" type="StaticBody3D" parent="."]
+position = Vector3(-10, -0.13, -35)
+
+[node name="AlleyMesh" type="MeshInstance3D" parent="ServiceAlley"]
+scale = Vector3(3.5, 0.26, 19)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Soot")
+
+[node name="AlleyTealBand" type="MeshInstance3D" parent="ServiceAlley"]
+position = Vector3(-1.55, 0.15, 0)
+scale = Vector3(0.12, 0.03, 19)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Teal")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ServiceAlley"]
+shape = SubResource("Shape_Alley")
+
+[node name="ServiceAlleyEntrySocket" type="Marker3D" parent="."]
+position = Vector3(-10, 0.15, -26)
+
+[node name="ServiceAlleyExitSocket" type="Marker3D" parent="."]
+position = Vector3(-10, 0.15, -44)
+
+[node name="NorthConnector" type="StaticBody3D" parent="."]
+position = Vector3(-7.25, -0.12, -45.5)
+
+[node name="ConnectorMesh" type="MeshInstance3D" parent="NorthConnector"]
+scale = Vector3(9, 0.24, 3)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Road")
+
+[node name="ConnectorAmberBand" type="MeshInstance3D" parent="NorthConnector"]
+position = Vector3(0, 0.14, -1.2)
+scale = Vector3(9, 0.03, 0.12)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NorthConnector"]
+shape = SubResource("Shape_Connector")
+
+[node name="CommercialFrontage" type="StaticBody3D" parent="."]
+position = Vector3(-14.2, 2.2, -35)
+
+[node name="CommercialBase" type="MeshInstance3D" parent="CommercialFrontage"]
+position = Vector3(0, -1, 0)
+scale = Vector3(4.5, 2.4, 14)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Concrete")
+
+[node name="CommercialUpper" type="MeshInstance3D" parent="CommercialFrontage"]
+position = Vector3(-0.2, 1.15, 0.8)
+scale = Vector3(4, 2, 10.5)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="ServiceCanopy" type="MeshInstance3D" parent="CommercialFrontage"]
+position = Vector3(2.35, -0.6, -2.2)
+scale = Vector3(0.7, 0.28, 4.5)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Soot")
+
+[node name="HeroSign" type="MeshInstance3D" parent="CommercialFrontage"]
+position = Vector3(2.31, 0.65, -1.5)
+scale = Vector3(0.16, 1.25, 4.2)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Teal")
+
+[node name="HeroSignIcon" type="MeshInstance3D" parent="CommercialFrontage"]
+position = Vector3(2.41, 0.65, -2.65)
+rotation = Vector3(0.785398, 0, 0)
+scale = Vector3(0.1, 0.42, 0.42)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="AftermarketSticker" type="MeshInstance3D" parent="CommercialFrontage"]
+position = Vector3(2.32, -1.15, 1.8)
+scale = Vector3(0.12, 0.32, 0.85)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Vermilion")
+
+[node name="ReplacementPanel" type="MeshInstance3D" parent="CommercialFrontage"]
+position = Vector3(2.32, -0.5, 3.9)
+scale = Vector3(0.12, 0.8, 1.2)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Oxidized")
+
+[node name="CommercialLabel" type="Label3D" parent="CommercialFrontage"]
+position = Vector3(2.43, 0.65, -0.65)
+rotation = Vector3(0, -1.570796, 0)
+text = "PARTS"
+modulate = Color(0.843, 0.824, 0.765, 1)
+outline_modulate = Color(0.094, 0.129, 0.149, 1)
+font_size = 46
+outline_size = 10
+pixel_size = 0.006
+
+[node name="AftermarketLabel" type="Label3D" parent="CommercialFrontage"]
+position = Vector3(2.43, -1.15, 1.8)
+rotation = Vector3(0, -1.570796, 0)
+text = "RIDE/FIX"
+modulate = Color(0.843, 0.824, 0.765, 1)
+outline_modulate = Color(0.094, 0.129, 0.149, 1)
+font_size = 22
+outline_size = 8
+pixel_size = 0.0035
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="CommercialFrontage"]
+shape = SubResource("Shape_Commercial")
+
+[node name="IndustrialFrontage" type="StaticBody3D" parent="."]
+position = Vector3(4, 2.5, -38)
+
+[node name="IndustrialBase" type="MeshInstance3D" parent="IndustrialFrontage"]
+position = Vector3(0, -1.25, 0)
+scale = Vector3(6, 2.5, 16)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Soot")
+
+[node name="UtilityTower" type="MeshInstance3D" parent="IndustrialFrontage"]
+position = Vector3(0.8, 1.5, 1.2)
+scale = Vector3(4.2, 3, 8)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Concrete")
+
+[node name="UtilitySpine" type="MeshInstance3D" parent="IndustrialFrontage"]
+position = Vector3(-2.8, 0.8, -2.5)
+scale = Vector3(0.5, 3.6, 1.2)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="CivicUtilityPlate" type="MeshInstance3D" parent="IndustrialFrontage"]
+position = Vector3(-3.08, 0.3, -1.0)
+scale = Vector3(0.14, 1.1, 2.7)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="RepairPatch" type="MeshInstance3D" parent="IndustrialFrontage"]
+position = Vector3(-3.09, -0.9, 3.2)
+scale = Vector3(0.12, 0.9, 1.6)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Oxidized")
+
+[node name="VentBlock" type="MeshInstance3D" parent="IndustrialFrontage"]
+position = Vector3(1.8, 3.15, 0.5)
+scale = Vector3(1.5, 1.1, 2)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="CivicAssetLabel" type="Label3D" parent="IndustrialFrontage"]
+position = Vector3(-3.18, 0.3, -1.0)
+rotation = Vector3(0, 1.570796, 0)
+text = "UTIL 04"
+modulate = Color(0.094, 0.129, 0.149, 1)
+outline_modulate = Color(0.843, 0.824, 0.765, 1)
+font_size = 26
+outline_size = 8
+pixel_size = 0.004
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="IndustrialFrontage"]
+shape = SubResource("Shape_Industrial")
+
+[node name="MissionDestinationSocket" type="Marker3D" parent="."]
+position = Vector3(-10, 0.2, -41.5)
+
+[node name="ExpansionEdgeBarrier" type="StaticBody3D" parent="."]
+position = Vector3(-4.5, 0.75, -48.25)
+
+[node name="BarrierMesh" type="MeshInstance3D" parent="ExpansionEdgeBarrier"]
+scale = Vector3(16, 1.5, 0.5)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Soot")
+
+[node name="BarrierAmberBandLeft" type="MeshInstance3D" parent="ExpansionEdgeBarrier"]
+position = Vector3(-4, 0.1, 0.28)
+scale = Vector3(4.5, 0.3, 0.08)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="BarrierAmberBandRight" type="MeshInstance3D" parent="ExpansionEdgeBarrier"]
+position = Vector3(4, 0.1, 0.28)
+scale = Vector3(4.5, 0.3, 0.08)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="ExpansionLabel" type="Label3D" parent="ExpansionEdgeBarrier"]
+position = Vector3(0, 0.25, 0.34)
+text = "ROUTE HOLD"
+modulate = Color(0.843, 0.824, 0.765, 1)
+outline_modulate = Color(0.094, 0.129, 0.149, 1)
+font_size = 30
+outline_size = 9
+pixel_size = 0.005
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="ExpansionEdgeBarrier"]
+shape = SubResource("Shape_Barrier")
+
+[node name="WestGuardRail" type="StaticBody3D" parent="."]
+position = Vector3(-8.75, 0.4, -35.5)
+
+[node name="RailMesh" type="MeshInstance3D" parent="WestGuardRail"]
+scale = Vector3(0.3, 0.8, 14)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="WestGuardRail"]
+shape = SubResource("Shape_WestRail")
+
+[node name="EastGuardRail" type="StaticBody3D" parent="."]
+position = Vector3(-0.25, 0.4, -35.5)
+
+[node name="RailMesh" type="MeshInstance3D" parent="EastGuardRail"]
+scale = Vector3(0.3, 0.8, 14)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="EastGuardRail"]
+shape = SubResource("Shape_EastRail")

--- a/godot/scripts/visual/gears_district_slice_01b.gd
+++ b/godot/scripts/visual/gears_district_slice_01b.gd
@@ -1,0 +1,137 @@
+extends Node3D
+
+# Open World Expansion 01B — introspection only.
+# Traversable geometry is declarative in the scene; this script owns no gameplay authority.
+
+const RETAINED_NORTH_EDGE_Z := -20.0
+const APPROVED_TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
+
+func _box_shape(node_path: String) -> BoxShape3D:
+	var collider := get_node_or_null(node_path) as CollisionShape3D
+	if collider == null:
+		return null
+	return collider.shape as BoxShape3D
+
+func _count_meshes(node: Node) -> int:
+	var count := 1 if node is MeshInstance3D else 0
+	for child in node.get_children():
+		count += _count_meshes(child)
+	return count
+
+func _count_colliders(node: Node) -> int:
+	var count := 1 if node is CollisionShape3D and (node as CollisionShape3D).shape != null else 0
+	for child in node.get_children():
+		count += _count_colliders(child)
+	return count
+
+func _count_local_lights(node: Node) -> int:
+	var count := 1 if node is OmniLight3D or node is SpotLight3D else 0
+	for child in node.get_children():
+		count += _count_local_lights(child)
+	return count
+
+func _count_foreign_scripts(node: Node) -> int:
+	var count := 0
+	if node != self and node.get_script() != null:
+		count = 1
+	for child in node.get_children():
+		count += _count_foreign_scripts(child)
+	return count
+
+func _range_overlap(a_min: float, a_max: float, b_min: float, b_max: float) -> bool:
+	return minf(a_max, b_max) >= maxf(a_min, b_min) - 0.05
+
+func _surface_bounds(body_name: String, collider_name: String = "CollisionShape3D") -> Dictionary:
+	var body := get_node_or_null(body_name) as Node3D
+	var shape := _box_shape("%s/%s" % [body_name, collider_name])
+	if body == null or shape == null:
+		return {}
+	var half := shape.size * 0.5
+	return {
+		"min_x": body.position.x - half.x,
+		"max_x": body.position.x + half.x,
+		"min_z": body.position.z - half.z,
+		"max_z": body.position.z + half.z,
+	}
+
+func _alternate_route_rejoins() -> bool:
+	var intersection := _surface_bounds("IndustrialIntersection")
+	var alley := _surface_bounds("ServiceAlley")
+	var connector := _surface_bounds("NorthConnector")
+	var road := _surface_bounds("NorthRoad")
+	if intersection.is_empty() or alley.is_empty() or connector.is_empty() or road.is_empty():
+		return false
+	var alley_meets_intersection := _range_overlap(
+		float(alley.min_x), float(alley.max_x), float(intersection.min_x), float(intersection.max_x)
+	) and _range_overlap(
+		float(alley.min_z), float(alley.max_z), float(intersection.min_z), float(intersection.max_z)
+	)
+	var connector_meets_alley := _range_overlap(
+		float(connector.min_x), float(connector.max_x), float(alley.min_x), float(alley.max_x)
+	) and _range_overlap(
+		float(connector.min_z), float(connector.max_z), float(alley.min_z), float(alley.max_z)
+	)
+	var connector_meets_road := _range_overlap(
+		float(connector.min_x), float(connector.max_x), float(road.min_x), float(road.max_x)
+	) and _range_overlap(
+		float(connector.min_z), float(connector.max_z), float(road.min_z), float(road.max_z)
+	)
+	return alley_meets_intersection and connector_meets_alley and connector_meets_road
+
+func _uses_approved_toon_shader() -> bool:
+	for path in [
+		"CommercialFrontage/CommercialBase",
+		"CommercialFrontage/HeroSign",
+		"IndustrialFrontage/IndustrialBase",
+		"IndustrialFrontage/CivicUtilityPlate",
+	]:
+		var mesh := get_node_or_null(path) as MeshInstance3D
+		if mesh == null:
+			return false
+		var material := mesh.material_override as ShaderMaterial
+		if material == null or material.shader == null:
+			return false
+		if material.shader.resource_path != APPROVED_TOON_SHADER_PATH:
+			return false
+	return true
+
+func get_production_contract() -> Dictionary:
+	var road_shape := _box_shape("NorthRoad/CollisionShape3D")
+	var intersection_shape := _box_shape("IndustrialIntersection/CollisionShape3D")
+	var alley_shape := _box_shape("ServiceAlley/CollisionShape3D")
+	var connector_shape := _box_shape("NorthConnector/CollisionShape3D")
+	var barrier_shape := _box_shape("ExpansionEdgeBarrier/CollisionShape3D")
+	var socket := get_node_or_null("MissionDestinationSocket")
+
+	var contiguous := false
+	var northbound_depth := 0.0
+	if road_shape != null and intersection_shape != null:
+		var road := get_node_or_null("NorthRoad") as Node3D
+		var intersection := get_node_or_null("IndustrialIntersection") as Node3D
+		if road != null and intersection != null:
+			var intersection_south_edge := intersection.position.z + intersection_shape.size.z * 0.5
+			var road_south_edge := road.position.z + road_shape.size.z * 0.5
+			var road_north_edge := road.position.z - road_shape.size.z * 0.5
+			contiguous = intersection_south_edge >= RETAINED_NORTH_EDGE_Z - 0.1 and road_south_edge >= intersection.position.z - intersection_shape.size.z * 0.5 - 0.1
+			northbound_depth = RETAINED_NORTH_EDGE_Z - road_north_edge
+
+	return {
+		"version": "open_world_expansion_01b_v1",
+		"contiguous_with_retained_yard": contiguous,
+		"primary_route_traversable": road_shape != null and road_shape.size.x >= 6.0 and road_shape.size.z >= 24.0,
+		"intersection_traversable": intersection_shape != null and intersection_shape.size.x >= 10.0 and intersection_shape.size.z >= 5.0,
+		"alternate_route_traversable": alley_shape != null and alley_shape.size.x >= 3.0 and connector_shape != null,
+		"alternate_route_rejoins": _alternate_route_rejoins(),
+		"commercial_frontage": has_node("CommercialFrontage/CommercialBase") and has_node("CommercialFrontage/HeroSign"),
+		"industrial_frontage": has_node("IndustrialFrontage/IndustrialBase") and has_node("IndustrialFrontage/CivicUtilityPlate"),
+		"mission_socket_passive": socket is Marker3D and socket.get_script() == null,
+		"temporary_edge_safe": barrier_shape != null and barrier_shape.size.x >= 14.0,
+		"uses_approved_toon_shader": _uses_approved_toon_shader(),
+		"owns_no_gameplay_authority": _count_foreign_scripts(self) == 0,
+		"primary_route_width_m": road_shape.size.x if road_shape != null else 0.0,
+		"service_alley_width_m": alley_shape.size.x if alley_shape != null else 0.0,
+		"northbound_depth_m": northbound_depth,
+		"mesh_instances": _count_meshes(self),
+		"collision_shapes": _count_colliders(self),
+		"local_lights": _count_local_lights(self),
+	}

--- a/godot/tests/dynamic_camera_follow_test.gd
+++ b/godot/tests/dynamic_camera_follow_test.gd
@@ -2,8 +2,8 @@ extends SceneTree
 
 # Issue #30 regression: desktop/touch traversal remains live-camera-relative while
 # the camera follows on-foot movement and vehicle heading without snaps.
-# Issue #60 adds a bounded visual-style integration contract here because this test
-# is already an exact-head PR gate in godot-web-playtest.yml.
+# Issue #60 keeps its bounded visual-style contract here, and Open World Expansion
+# 01B adds the smallest real district-production integration gate on the same exact-head CI path.
 var _scene_under_test: Node = null
 
 const GEARS_REQUIRED_PROOF_NODES := [
@@ -68,6 +68,27 @@ const GEARS_REQUIRED_FLAGS := [
 
 const GEARS_GRAPHIC_FAMILIES := ["municipal", "commercial", "aftermarket", "asset_marking"]
 
+const DISTRICT_01B_REQUIRED_NODES := [
+	"NorthRoad",
+	"IndustrialIntersection",
+	"ServiceAlley",
+	"NorthConnector",
+	"CommercialFrontage",
+	"IndustrialFrontage",
+	"MissionDestinationSocket",
+	"ExpansionEdgeBarrier",
+]
+
+const DISTRICT_01B_REQUIRED_COLLIDERS := [
+	"NorthRoad/CollisionShape3D",
+	"IndustrialIntersection/CollisionShape3D",
+	"ServiceAlley/CollisionShape3D",
+	"NorthConnector/CollisionShape3D",
+	"CommercialFrontage/CollisionShape3D",
+	"IndustrialFrontage/CollisionShape3D",
+	"ExpansionEdgeBarrier/CollisionShape3D",
+]
+
 func _init() -> void:
 	call_deferred("_run")
 
@@ -85,6 +106,10 @@ func _fail(message: String) -> void:
 
 func _proof_fail(message: String, exit_code: int) -> void:
 	push_error("[GEARS_STYLE_PROOF_60] %s [diagnostic=%d]" % [message, exit_code])
+	await _finish(exit_code)
+
+func _district_fail(message: String, exit_code: int) -> void:
+	push_error("[GEARS_DISTRICT_01B] %s [diagnostic=%d]" % [message, exit_code])
 	await _finish(exit_code)
 
 func _key_event(key: Key, pressed: bool) -> InputEventKey:
@@ -201,6 +226,71 @@ func _verify_gears_style_proof() -> bool:
 		return false
 	return true
 
+func _verify_gears_district_01b() -> bool:
+	var district := _scene_under_test.get_node_or_null("GearsDistrictSlice01B")
+	if district == null or not district.has_method("get_production_contract"):
+		await _district_fail("Production slice integration node/contract is missing", 180)
+		return false
+
+	for i in range(DISTRICT_01B_REQUIRED_NODES.size()):
+		var node_path: String = DISTRICT_01B_REQUIRED_NODES[i]
+		if district.get_node_or_null(node_path) == null:
+			await _district_fail("Required production node missing: %s" % node_path, 181 + i)
+			return false
+
+	for i in range(DISTRICT_01B_REQUIRED_COLLIDERS.size()):
+		var collider_path: String = DISTRICT_01B_REQUIRED_COLLIDERS[i]
+		var collider := district.get_node_or_null(collider_path) as CollisionShape3D
+		if collider == null or collider.shape == null:
+			await _district_fail("Required traversable/boundary collision missing: %s" % collider_path, 190 + i)
+			return false
+
+	var socket := district.get_node_or_null("MissionDestinationSocket")
+	if socket == null or not (socket is Marker3D):
+		await _district_fail("Mission destination socket must remain a passive Marker3D", 200)
+		return false
+	if socket.get_script() != null:
+		await _district_fail("Mission destination socket must not own mission behavior", 201)
+		return false
+
+	var contract: Dictionary = district.call("get_production_contract")
+	for flag in [
+		"contiguous_with_retained_yard",
+		"primary_route_traversable",
+		"intersection_traversable",
+		"alternate_route_traversable",
+		"alternate_route_rejoins",
+		"commercial_frontage",
+		"industrial_frontage",
+		"mission_socket_passive",
+		"temporary_edge_safe",
+		"uses_approved_toon_shader",
+		"owns_no_gameplay_authority",
+	]:
+		if contract.get(flag, false) != true:
+			await _district_fail("Production contract flag failed: %s" % flag, 202)
+			return false
+
+	if float(contract.get("primary_route_width_m", 0.0)) < 6.0:
+		await _district_fail("Primary route is too narrow for retained vehicle readability", 203)
+		return false
+	if float(contract.get("service_alley_width_m", 0.0)) < 3.0:
+		await _district_fail("Service alley is too narrow for the bounded alternate-route contract", 204)
+		return false
+	if float(contract.get("northbound_depth_m", 0.0)) < 24.0:
+		await _district_fail("District production does not extend far enough beyond the retained yard", 205)
+		return false
+	if int(contract.get("mesh_instances", 9999)) > 36:
+		await _district_fail("01B production mesh budget exceeded", 206)
+		return false
+	if int(contract.get("collision_shapes", 9999)) > 10:
+		await _district_fail("01B production collision budget exceeded", 207)
+		return false
+	if int(contract.get("local_lights", 9999)) != 0:
+		await _district_fail("01B must not add a new real-time local-light layer", 208)
+		return false
+	return true
+
 func _run() -> void:
 	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
 	if packed == null:
@@ -222,6 +312,8 @@ func _run() -> void:
 		return
 
 	if not await _verify_gears_style_proof():
+		return
+	if not await _verify_gears_district_01b():
 		return
 
 	# 1. CourierBike uses the strong vehicle-heading follow path.


### PR DESCRIPTION
Promotes the approved Gears visual direction into the smallest real contiguous district-production slice beyond the retained yard.

Scope is intentionally bounded: one northbound road/intersection block, one alternate service alley/rejoin, one commercial frontage, one industrial frontage, one passive mission destination socket, and one temporary expansion-edge safety barrier. No new mission, camera, pursuit, vehicle, input, audio, traffic, or district-wide authority.

The branch is currently intentionally RED: exact-head CI now requires the 01B production integration contract before the scene exists.

Verification debt from Issue #60 remains explicit in `contracts/open_world_expansion_01b_gears_production_slice_spec.md`; visual/performance qualification is deferred rather than silently claimed.