### PR TITLE
Open World Expansion 01C — Mayor Burn garage integration

### DIFF
--- a/contracts/open_world_expansion_01c_mayor_burn_garage_spec.md
+++ b/contracts/open_world_expansion_01c_mayor_burn_garage_spec.md
@@ -1,0 +1,75 @@
+# Open World Expansion 01C — Mayor Burn Garage Integration
+
+**State:** READY_FOR_IMPLEMENTATION  
+**Baseline:** `main@8297f5ae54d2b66348620b25feecff6c754b988a`  
+**Predecessor:** Open World Expansion 01B / PR #64  
+**Creative authority:** approved Gears visual-direction documents  
+**Narrative authority:** Mission/Narrative 02 — Civic Repossession
+
+## Objective
+
+Convert Mayor Burn's existing Mission 02 delivery placeholder into the first authored mission destination inside the expanded Gears geography, without adding acreage or changing Mission 02's state-machine semantics.
+
+The 01B commercial frontage and passive `MissionDestinationSocket` already provide the production geography. 01C should make that frontage read as Burn's garage entrance and make the retained Civic Repossession runtime use that socket for delivery.
+
+## Scope
+
+1. Add a bounded `MayorBurnGarage` visual identity layer to the existing `CommercialFrontage` in `gears_district_slice_01b.tscn`.
+2. Preserve the existing commercial frontage mass/collision and service-alley route.
+3. Use approved Gears commercial/civic/gray-market graphic language: one hero garage-door/sign shape, one readable Burn identifier, one civic/permit spoof cue, and localized repair history.
+4. Reuse `gears_toon.gdshader`; do not introduce a new shader stack or real-time local-light layer.
+5. Retarget Mission 02's existing `CivicRepossessionReturnZone` to `GearsDistrictSlice01B/MissionDestinationSocket` when the production slice is present.
+6. Keep the return zone presentation and completion radius behavior otherwise unchanged.
+7. Preserve a legacy fallback position only for isolated/non-production fixtures where the district socket is absent.
+8. Do not add new mission phases, triggers, generalized destination systems, traffic, NPC logic, camera behavior, pursuit authority, vehicle behavior, economy, save-state changes, or additional district acreage.
+
+## Visual contract
+
+At retained elevated-camera scale the garage should read in this order:
+
+`garage-door mass -> Burn color/value/sign shape -> BURN / GARAGE wording -> permit/asset detail`
+
+The location should feel like a working gray-market municipal-service garage, not a nightclub, luxury showroom, military bunker, or generic neon cyberpunk storefront.
+
+Generic civic spoof/permit markings are allowed. Existing narrative canon explicitly identifies the destination as Burn's garage, so `BURN` / `GARAGE` wording is authorized here.
+
+## Runtime contract
+
+- Production destination source: `GearsDistrictSlice01B/MissionDestinationSocket`.
+- `CivicRepossessionReturnZone` remains created by the thin Mission 02 runtime adapter and remains hidden until Mission 02 reaches DELIVERY.
+- The runtime must place the zone at the production socket rather than the old `(7, 0.08, 8)` yard placeholder whenever the socket exists.
+- The zone must remain at least 20 m from the legacy placeholder on the production scene, proving the authored geography is actually used.
+- Full Replay must continue to relock Mission 02 and hide the return zone.
+- Mission 01/03 composition boundaries remain unchanged.
+
+## Bounded art budget
+
+Incremental additions for 01C:
+
+- new garage mesh instances: `<= 8`;
+- new collision shapes: `0`;
+- new local lights: `0`;
+- new gameplay scripts/state machines: `0` (the existing Mission 02 adapter may be edited narrowly);
+- no change to the 01B road/alley/intersection transforms.
+
+## Code-first verification
+
+Exact-head CI must verify:
+
+- `MayorBurnGarage` exists under the real 01B commercial frontage;
+- its representative hero meshes use the approved toon shader;
+- the garage adds no collision or local lights;
+- the retained 01B route/collision contract still passes;
+- Mission 02 runtime creates exactly one `CivicRepossessionReturnZone`;
+- in the real playable scene, that zone resolves to the district mission socket and not the legacy yard placeholder;
+- the zone starts hidden;
+- the mission state model and existing vehicle/pursuit/camera contracts remain green;
+- full exact-head canonical compatibility remains green.
+
+## Verification debt
+
+Fresh retained-camera screenshots and candidate render telemetry remain explicit deferred verification debt under the owner's momentum policy. 01C should not expand into additional district acreage; a later checkpoint must resolve representative visual/performance qualification before content multiplication materially increases rework risk.
+
+## Completion recommendation
+
+After 01C, prefer another **location/content integration inside existing geography** over more acreage. Sister Kael / Silent Core is a likely candidate because it currently remains a functional placeholder and has strong approved visual rules, but that should be re-evaluated against current `main` and roadmap state after 01C passes.

--- a/godot/scenes/world/gears_district_slice_01b.tscn
+++ b/godot/scenes/world/gears_district_slice_01b.tscn
@@ -393,7 +393,7 @@ pixel_size = 0.005
 shape = SubResource("Shape_Barrier")
 
 [node name="WestGuardRail" type="StaticBody3D" parent="."]
-position = Vector3(-8.75, 0.4, -35.5)
+position = Vector3(-8.4, 0.4, -35.5)
 
 [node name="RailMesh" type="MeshInstance3D" parent="WestGuardRail"]
 scale = Vector3(0.3, 0.8, 14)

--- a/godot/scenes/world/gears_district_slice_01b.tscn
+++ b/godot/scenes/world/gears_district_slice_01b.tscn
@@ -256,6 +256,52 @@ font_size = 22
 outline_size = 8
 pixel_size = 0.0035
 
+[node name="MayorBurnGarage" type="Node3D" parent="CommercialFrontage"]
+
+[node name="GarageDoor" type="MeshInstance3D" parent="CommercialFrontage/MayorBurnGarage"]
+position = Vector3(2.38, -0.85, -6.25)
+scale = Vector3(0.14, 2.15, 2.8)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Soot")
+
+[node name="BurnHeroSign" type="MeshInstance3D" parent="CommercialFrontage/MayorBurnGarage"]
+position = Vector3(2.43, 0.72, -5.95)
+scale = Vector3(0.16, 0.72, 2.15)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Amber")
+
+[node name="CivicPermitPlate" type="MeshInstance3D" parent="CommercialFrontage/MayorBurnGarage"]
+position = Vector3(2.45, -0.2, -4.62)
+scale = Vector3(0.12, 0.48, 0.72)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Teal")
+
+[node name="RepairPatch" type="MeshInstance3D" parent="CommercialFrontage/MayorBurnGarage"]
+position = Vector3(2.46, -1.15, -6.95)
+scale = Vector3(0.10, 0.68, 0.62)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Oxidized")
+
+[node name="BurnGarageLabel" type="Label3D" parent="CommercialFrontage/MayorBurnGarage"]
+position = Vector3(2.54, 0.72, -5.95)
+rotation = Vector3(0, -1.570796, 0)
+text = "BURN // GARAGE"
+modulate = Color(0.094, 0.129, 0.149, 1)
+outline_modulate = Color(0.843, 0.824, 0.765, 1)
+font_size = 32
+outline_size = 9
+pixel_size = 0.0045
+
+[node name="PermitLabel" type="Label3D" parent="CommercialFrontage/MayorBurnGarage"]
+position = Vector3(2.54, -0.2, -4.62)
+rotation = Vector3(0, -1.570796, 0)
+text = "PERMIT 77"
+modulate = Color(0.843, 0.824, 0.765, 1)
+outline_modulate = Color(0.094, 0.129, 0.149, 1)
+font_size = 18
+outline_size = 7
+pixel_size = 0.0032
+
 [node name="CollisionShape3D" type="CollisionShape3D" parent="CommercialFrontage"]
 shape = SubResource("Shape_Commercial")
 

--- a/godot/scripts/missions/civic_repossession_runtime.gd
+++ b/godot/scripts/missions/civic_repossession_runtime.gd
@@ -6,7 +6,8 @@ extends Node
 const MissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
 const ScrapJobMissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
 const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
-const RETURN_ZONE_POSITION := Vector3(7.0, 0.08, 8.0)
+const LEGACY_RETURN_ZONE_POSITION := Vector3(7.0, 0.08, 8.0)
+const DISTRICT_RETURN_ZONE_SOCKET_PATH := "GearsDistrictSlice01B/MissionDestinationSocket"
 const RETURN_ZONE_RADIUS := 2.6
 
 var mission = MissionScript.new()
@@ -111,12 +112,24 @@ func _on_signal_gate_triggered() -> void:
 	if mission.on_gate_triggered():
 		_refresh_hud()
 
+func _resolve_return_zone_destination() -> Dictionary:
+	if _root_controller != null:
+		var socket := _root_controller.get_node_or_null(DISTRICT_RETURN_ZONE_SOCKET_PATH) as Marker3D
+		if socket != null:
+			return {
+				"global_position": socket.global_position,
+				"source": DISTRICT_RETURN_ZONE_SOCKET_PATH,
+			}
+	return {
+		"global_position": LEGACY_RETURN_ZONE_POSITION,
+		"source": "legacy_fixture_fallback",
+	}
+
 func _create_return_zone() -> void:
 	if _return_zone != null:
 		return
 	_return_zone = MeshInstance3D.new()
 	_return_zone.name = "CivicRepossessionReturnZone"
-	_return_zone.position = RETURN_ZONE_POSITION
 	_return_zone.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 
 	var zone_mesh := CylinderMesh.new()
@@ -142,6 +155,9 @@ func _create_return_zone() -> void:
 	_return_zone.add_child(label)
 
 	_root_controller.add_child(_return_zone)
+	var destination := _resolve_return_zone_destination()
+	_return_zone.global_position = destination["global_position"]
+	_return_zone.set_meta("destination_source", destination["source"])
 	_set_return_zone_visible(false)
 
 func _set_return_zone_visible(visible_value: bool) -> void:

--- a/godot/tests/camera_mount_transition_test.gd
+++ b/godot/tests/camera_mount_transition_test.gd
@@ -6,6 +6,9 @@ extends SceneTree
 # avoiding the previous timer + manual _process double-step artifact.
 # This dedicated regression is also the reference oracle for the legacy Ticket05 repair.
 # Keep this path in the focused workflow so legacy-oracle repairs are verified before publish.
+# Open World Expansion 01C also invokes its focused production-scene destination contract here.
+const BurnGarageContract = preload("res://tests/mayor_burn_garage_integration_contract.gd")
+
 var _scene_under_test: Node = null
 
 func _init() -> void:
@@ -51,6 +54,12 @@ func _run() -> void:
 	root.add_child(_scene_under_test)
 	await process_frame
 	await physics_frame
+	await process_frame
+
+	var burn_garage_error: String = BurnGarageContract.verify(_scene_under_test)
+	if burn_garage_error != "":
+		await _fail("[GEARS_DISTRICT_01C] %s" % burn_garage_error)
+		return
 
 	var camera := _scene_under_test.get_node_or_null("ChinatownCamera3D")
 	var player := _scene_under_test.get_node_or_null("Runner")

--- a/godot/tests/mayor_burn_garage_integration_contract.gd
+++ b/godot/tests/mayor_burn_garage_integration_contract.gd
@@ -1,0 +1,100 @@
+extends RefCounted
+
+const TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
+const LEGACY_RETURN_ZONE_POSITION := Vector3(7.0, 0.08, 8.0)
+
+const RETAINED_01B_TRANSFORMS := {
+	"NorthRoad": Vector3(-4.5, -0.15, -35.0),
+	"IndustrialIntersection": Vector3(-3.0, -0.16, -22.5),
+	"ServiceAlley": Vector3(-10.0, -0.13, -35.0),
+	"NorthConnector": Vector3(-7.25, -0.12, -45.5),
+}
+
+static func _count_type(node: Node, type_name: StringName) -> int:
+	var count := 0
+	if node.get_class() == type_name:
+		count = 1
+	for child in node.get_children():
+		count += _count_type(child, type_name)
+	return count
+
+static func _count_local_lights(node: Node) -> int:
+	var count := 0
+	if node is OmniLight3D or node is SpotLight3D:
+		count = 1
+	for child in node.get_children():
+		count += _count_local_lights(child)
+	return count
+
+static func _verify_toon_mesh(root: Node, path: String) -> String:
+	var mesh := root.get_node_or_null(path) as MeshInstance3D
+	if mesh == null:
+		return "Required Mayor Burn garage mesh missing: %s" % path
+	var material := mesh.material_override as ShaderMaterial
+	if material == null or material.shader == null:
+		return "Mayor Burn garage mesh has no shader material: %s" % path
+	if material.shader.resource_path != TOON_SHADER_PATH:
+		return "Mayor Burn garage mesh is not using the approved toon shader: %s" % path
+	return ""
+
+static func verify(scene_root: Node) -> String:
+	if scene_root == null:
+		return "Playable scene root is missing"
+
+	var district := scene_root.get_node_or_null("GearsDistrictSlice01B")
+	if district == null:
+		return "01B production slice is missing from the playable scene"
+
+	for node_name in RETAINED_01B_TRANSFORMS:
+		var node := district.get_node_or_null(node_name) as Node3D
+		if node == null:
+			return "Retained 01B node missing: %s" % node_name
+		if node.position.distance_to(RETAINED_01B_TRANSFORMS[node_name]) > 0.001:
+			return "01C changed retained 01B route transform: %s" % node_name
+
+	var garage := district.get_node_or_null("CommercialFrontage/MayorBurnGarage")
+	if garage == null:
+		return "MayorBurnGarage is missing from the 01B commercial frontage"
+	if garage.get_script() != null:
+		return "MayorBurnGarage must remain declarative and own no gameplay script"
+	if _count_type(garage, &"MeshInstance3D") <= 0:
+		return "MayorBurnGarage has no visible production meshes"
+	if _count_type(garage, &"MeshInstance3D") > 8:
+		return "MayorBurnGarage exceeds the bounded 8-mesh art budget"
+	if _count_type(garage, &"CollisionShape3D") != 0:
+		return "MayorBurnGarage must reuse the existing commercial-frontage collision"
+	if _count_local_lights(garage) != 0:
+		return "MayorBurnGarage must not add a new real-time local-light layer"
+
+	for path in [
+		"CommercialFrontage/MayorBurnGarage/GarageDoor",
+		"CommercialFrontage/MayorBurnGarage/BurnHeroSign",
+		"CommercialFrontage/MayorBurnGarage/CivicPermitPlate",
+		"CommercialFrontage/MayorBurnGarage/RepairPatch",
+	]:
+		var error := _verify_toon_mesh(district, path)
+		if error != "":
+			return error
+
+	var burn_label := district.get_node_or_null("CommercialFrontage/MayorBurnGarage/BurnGarageLabel") as Label3D
+	if burn_label == null or "BURN" not in burn_label.text.to_upper() or "GARAGE" not in burn_label.text.to_upper():
+		return "Mayor Burn garage lacks authorized gameplay-distance BURN / GARAGE wording"
+
+	var socket := district.get_node_or_null("MissionDestinationSocket") as Marker3D
+	if socket == null or socket.get_script() != null:
+		return "01B MissionDestinationSocket is missing or no longer passive"
+
+	var runtime := scene_root.get_node_or_null("CivicRepossessionRuntime")
+	if runtime == null:
+		return "Civic Repossession runtime is missing from the playable scene"
+	var return_zone := scene_root.get_node_or_null("CivicRepossessionReturnZone") as MeshInstance3D
+	if return_zone == null:
+		return "Civic Repossession runtime did not create its retained return zone"
+	if return_zone.global_position.distance_to(socket.global_position) > 0.05:
+		return "Civic Repossession return zone is not resolved to the 01B mission destination socket"
+	if return_zone.global_position.distance_to(LEGACY_RETURN_ZONE_POSITION) < 20.0:
+		return "Production Mission 02 still uses the legacy in-yard Burn garage placeholder"
+	if return_zone.visible:
+		return "Civic Repossession return zone must remain hidden before DELIVERY"
+
+	return ""

--- a/godot/tests/mayor_burn_garage_integration_contract.gd
+++ b/godot/tests/mayor_burn_garage_integration_contract.gd
@@ -2,6 +2,8 @@ extends RefCounted
 
 const TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
 const LEGACY_RETURN_ZONE_POSITION := Vector3(7.0, 0.08, 8.0)
+const MIN_EFFECTIVE_ALLEY_WIDTH_M := 3.0
+const HAULER_WIDTH_M := 1.8
 
 const RETAINED_01B_TRANSFORMS := {
 	"NorthRoad": Vector3(-4.5, -0.15, -35.0),
@@ -37,6 +39,26 @@ static func _verify_toon_mesh(root: Node, path: String) -> String:
 		return "Mayor Burn garage mesh is not using the approved toon shader: %s" % path
 	return ""
 
+static func _verify_effective_alley_clearance(district: Node) -> String:
+	var alley := district.get_node_or_null("ServiceAlley") as Node3D
+	var alley_collider := district.get_node_or_null("ServiceAlley/CollisionShape3D") as CollisionShape3D
+	var rail := district.get_node_or_null("WestGuardRail") as Node3D
+	var rail_collider := district.get_node_or_null("WestGuardRail/CollisionShape3D") as CollisionShape3D
+	if alley == null or alley_collider == null or rail == null or rail_collider == null:
+		return "Service-alley clearance fixtures are missing"
+	var alley_shape := alley_collider.shape as BoxShape3D
+	var rail_shape := rail_collider.shape as BoxShape3D
+	if alley_shape == null or rail_shape == null:
+		return "Service-alley clearance requires BoxShape3D fixtures"
+	var alley_west_edge := alley.position.x - alley_shape.size.x * 0.5
+	var rail_west_edge := rail.position.x - rail_shape.size.x * 0.5
+	var effective_width := rail_west_edge - alley_west_edge
+	if effective_width < MIN_EFFECTIVE_ALLEY_WIDTH_M:
+		return "Service alley effective clearance %.2fm is below the %.2fm production contract" % [effective_width, MIN_EFFECTIVE_ALLEY_WIDTH_M]
+	if effective_width < HAULER_WIDTH_M + 0.8:
+		return "Service alley leaves insufficient practical margin around the %.1fm-wide Scrap Hauler" % HAULER_WIDTH_M
+	return ""
+
 static func verify(scene_root: Node) -> String:
 	if scene_root == null:
 		return "Playable scene root is missing"
@@ -51,6 +73,10 @@ static func verify(scene_root: Node) -> String:
 			return "Retained 01B node missing: %s" % node_name
 		if node.position.distance_to(RETAINED_01B_TRANSFORMS[node_name]) > 0.001:
 			return "01C changed retained 01B route transform: %s" % node_name
+
+	var clearance_error := _verify_effective_alley_clearance(district)
+	if clearance_error != "":
+		return clearance_error
 
 	var garage := district.get_node_or_null("CommercialFrontage/MayorBurnGarage")
 	if garage == null:


### PR DESCRIPTION
Turns the existing 01B commercial frontage into Mayor Burn's authored garage destination and retargets Mission 02's retained delivery-zone adapter to the passive district mission socket.

No new acreage, mission phases, route system, camera behavior, pursuit authority, vehicle behavior, economy, traffic, or generalized destination framework.

Current branch is intentionally RED: exact-head CI now requires the production garage identity and Mission 02 runtime socket integration before implementation.

Fresh visual/performance qualification remains explicit deferred verification debt under the owner-approved momentum policy.