### PR TITLE
Open World Expansion 01D — Silent Core infrastructure integration

### DIFF
--- a/contracts/open_world_expansion_01d_silent_core_site_spec.md
+++ b/contracts/open_world_expansion_01d_silent_core_site_spec.md
@@ -1,0 +1,93 @@
+# Open World Expansion 01D — Silent Core Infrastructure Integration
+
+**State:** READY_FOR_IMPLEMENTATION  
+**Baseline:** `main@133ea941f7766a4c431e292628be4a57be1eb5e8`  
+**Predecessor:** Open World Expansion 01C / PR #65  
+**Creative authority:** approved Gears visual-direction documents, especially the Silent Core / Sister Kael mystery language in `GEARS_DISTRICT_VISUAL_DIRECTION_V2_CONVERGENCE.md`  
+**Narrative authority:** Mission/Narrative 03 — The City That Forgot
+
+## Objective
+
+Replace Mission 03's hard-coded in-yard Silent Core placeholder with the first authored Silent Core infrastructure location inside the existing Gears production geography, without adding acreage or changing Mission 03's state-machine, Echo, pursuit, input, HUD, replay, or interaction authority.
+
+The location should read as ordinary obsolete telecom/relay/utility infrastructure whose importance outlived its understood purpose. It must not read as a fantasy shrine, glowing crystal altar, cathedral, holographic spectacle, or generic neon mysticism.
+
+## Production location
+
+Add a bounded `SilentCoreSite` to `godot/scenes/world/gears_district_slice_01b.tscn` in the quiet pocket south of the existing `IndustrialFrontage` and east of the production intersection.
+
+Target root position:
+
+`Vector3(6.2, 0.0, -27.4)`
+
+This location intentionally:
+
+- uses existing 01B geography;
+- does not add road acreage;
+- remains outside the retained primary-road collision corridor;
+- remains outside the 01B industrial-frontage collision volume;
+- stays spatially separate from the Issue #60 proof-only `DistantRelay` silhouette;
+- creates a short on-foot destination from the industrial intersection rather than a vehicle-scale new route.
+
+Add a passive `Marker3D` named `SilentCoreSocket` under `SilentCoreSite`. Mission 03's production `SilentCoreInteractable` must resolve to that socket whenever the production site exists.
+
+## Visual contract
+
+The site should express the approved Silent Core mystery language through restraint:
+
+1. one ordinary utility/service pad mass;
+2. one obsolete relay/server cabinet mass;
+3. one deliberately removed or blank asset-plate scar;
+4. one small maintenance/care cue;
+5. one sparse HS-7 cyan signal aperture.
+
+Use fewer colors/signs/props than adjacent commercial frontage. The signal aperture may use restrained toon-shader emission, but 01D adds no real-time local lights.
+
+The interactable itself should stop reading as a generic glowing cylinder. Its runtime-built marker should become a compact boxy infrastructure module using the approved `gears_toon.gdshader`, with a dark structural core, worn pale housing, sparse cyan signal, and one removed/blank plate cue.
+
+No Sister Kael character model is required. Existing authored Sister Kael HUD/dialogue remains narrative authority.
+
+## Runtime contract
+
+- Production socket path: `GearsDistrictSlice01B/SilentCoreSite/SilentCoreSocket`.
+- Existing legacy fallback position `Vector3(8.0, 0.4, -8.0)` remains only for isolated/non-production fixtures where the district socket is absent.
+- Runtime still creates exactly one `SilentCore` interactable and registers it with the retained `_interactables` array.
+- The interactable starts unpowered and only powers after Mission 02 is COMPLETE through the existing Mission 03 adapter.
+- The retained Action target arbitration remains authoritative.
+- `MemoryEchoController`, Echo payload, pursuit handoff, fast retry, and Full Replay behavior remain unchanged.
+- No new mission phases, generalized destination system, trigger volume, map/GPS, traffic, economy, save-state, camera, vehicle, pursuit, HUD, audio, or interaction framework.
+
+## Bounded production budget
+
+Incremental 01D site additions:
+
+- declarative site mesh instances: `<= 6`;
+- interactable runtime marker mesh instances: `<= 5`;
+- new collision shapes: `0`;
+- new real-time local lights: `0`;
+- new gameplay state machines: `0`;
+- new acreage: `0`.
+
+## Code-first verification
+
+Exact-head CI must verify:
+
+- `SilentCoreSite` and passive `SilentCoreSocket` exist in the real 01B production scene;
+- representative site meshes use `res://materials/gears_toon.gdshader`;
+- site adds no collision or local lights;
+- site root remains outside the primary road, industrial-frontage, and proof-relay bounding envelopes defined above;
+- runtime creates exactly one `SilentCore` and resolves its global position to the production socket rather than the legacy in-yard position;
+- the runtime marker uses the approved toon shader on representative housing/signal meshes;
+- the runtime marker stays within its mesh budget;
+- the Silent Core remains unpowered before Mission 03 unlock;
+- retained Action arbitration activates it exactly once after unlock;
+- authored HS-7 Echo, pursuit handoff, fast retry, Mission 03 completion, and Full Replay contracts remain green;
+- 01B/01C route, Burn garage, camera, vehicle, and canonical compatibility gates remain green.
+
+## Verification debt
+
+Fresh retained-camera screenshots and exact candidate render telemetry remain explicit deferred verification debt under the owner's momentum policy. The change is deliberately small and reversible, and it does not authorize further acreage multiplication.
+
+## Completion recommendation
+
+After 01D passes, stop adding acreage. Re-evaluate the roadmap from current `main`; prefer either another authored location/use of existing geography or a dedicated verification-debt checkpoint before materially multiplying district content.

--- a/contracts/open_world_expansion_01d_silent_core_site_spec.md
+++ b/contracts/open_world_expansion_01d_silent_core_site_spec.md
@@ -29,17 +29,20 @@ This location intentionally:
 - stays spatially separate from the Issue #60 proof-only `DistantRelay` silhouette;
 - creates a short on-foot destination from the industrial intersection rather than a vehicle-scale new route.
 
-Add a passive `Marker3D` named `SilentCoreSocket` under `SilentCoreSite`. Mission 03's production `SilentCoreInteractable` must resolve to that socket whenever the production site exists.
+Because this pocket is outside the existing drivable floor surfaces, add the smallest physically traversable maintenance access needed to make it real gameplay geography: a two-piece `AccessWalkway` -> `SitePadBody` apron with one collision shape each. The walkway must overlap the existing industrial-intersection collider, the site pad must overlap the walkway, and both surfaces must remain outside the proof-relay and industrial-frontage collision envelopes. This is a maintenance apron, not new road acreage.
+
+Add a passive `Marker3D` named `SilentCoreSocket` under `SilentCoreSite`, located on the site pad. Mission 03's production `SilentCoreInteractable` must resolve to that socket whenever the production site exists.
 
 ## Visual contract
 
 The site should express the approved Silent Core mystery language through restraint:
 
 1. one ordinary utility/service pad mass;
-2. one obsolete relay/server cabinet mass;
-3. one deliberately removed or blank asset-plate scar;
-4. one small maintenance/care cue;
-5. one sparse HS-7 cyan signal aperture.
+2. one narrow maintenance access surface;
+3. one obsolete relay/server cabinet mass;
+4. one deliberately removed or blank asset-plate scar;
+5. one small maintenance/care cue;
+6. one sparse HS-7 cyan signal aperture.
 
 Use fewer colors/signs/props than adjacent commercial frontage. The signal aperture may use restrained toon-shader emission, but 01D adds no real-time local lights.
 
@@ -63,10 +66,10 @@ Incremental 01D site additions:
 
 - declarative site mesh instances: `<= 6`;
 - interactable runtime marker mesh instances: `<= 5`;
-- new collision shapes: `0`;
+- new collision shapes: exactly `2`, limited to the on-foot maintenance walkway and site pad;
 - new real-time local lights: `0`;
 - new gameplay state machines: `0`;
-- new acreage: `0`.
+- new road acreage: `0`.
 
 ## Code-first verification
 
@@ -74,8 +77,10 @@ Exact-head CI must verify:
 
 - `SilentCoreSite` and passive `SilentCoreSocket` exist in the real 01B production scene;
 - representative site meshes use `res://materials/gears_toon.gdshader`;
-- site adds no collision or local lights;
-- site root remains outside the primary road, industrial-frontage, and proof-relay bounding envelopes defined above;
+- site adds exactly the two bounded ground colliders and no local lights;
+- `AccessWalkway` overlaps the retained industrial-intersection ground collider;
+- `SitePadBody` overlaps `AccessWalkway`, making the Core physically reachable from retained gameplay ground;
+- the site pad remains outside the industrial-frontage and proof-relay bounding envelopes;
 - runtime creates exactly one `SilentCore` and resolves its global position to the production socket rather than the legacy in-yard position;
 - the runtime marker uses the approved toon shader on representative housing/signal meshes;
 - the runtime marker stays within its mesh budget;

--- a/contracts/open_world_expansion_01d_silent_core_site_spec.md
+++ b/contracts/open_world_expansion_01d_silent_core_site_spec.md
@@ -29,7 +29,7 @@ This location intentionally:
 - stays spatially separate from the Issue #60 proof-only `DistantRelay` silhouette;
 - creates a short on-foot destination from the industrial intersection rather than a vehicle-scale new route.
 
-Because this pocket is outside the existing drivable floor surfaces, add the smallest physically traversable maintenance access needed to make it real gameplay geography: a two-piece `AccessWalkway` -> `SitePadBody` apron with one collision shape each. The walkway must overlap the existing industrial-intersection collider, the site pad must overlap the walkway, and both surfaces must remain outside the proof-relay and industrial-frontage collision envelopes. This is a maintenance apron, not new road acreage.
+Because this pocket is outside the existing drivable floor surfaces, add the smallest physically traversable maintenance access needed to make it real gameplay geography: a two-piece `AccessWalkway` -> `SitePadBody` apron with one collision shape each. The walkway must overlap the existing industrial-intersection collider, the site pad must overlap the walkway, and both surfaces must remain outside the proof-relay and industrial-frontage collision envelopes. Each adjoining ground pair must overlap by at least `0.25 m` on both horizontal axes so CharacterBody traversal is not dependent on an edge-only seam. This is a maintenance apron, not new road acreage.
 
 Add a passive `Marker3D` named `SilentCoreSocket` under `SilentCoreSite`, located on the site pad. Mission 03's production `SilentCoreInteractable` must resolve to that socket whenever the production site exists.
 
@@ -78,8 +78,8 @@ Exact-head CI must verify:
 - `SilentCoreSite` and passive `SilentCoreSocket` exist in the real 01B production scene;
 - representative site meshes use `res://materials/gears_toon.gdshader`;
 - site adds exactly the two bounded ground colliders and no local lights;
-- `AccessWalkway` overlaps the retained industrial-intersection ground collider;
-- `SitePadBody` overlaps `AccessWalkway`, making the Core physically reachable from retained gameplay ground;
+- `AccessWalkway` overlaps the retained industrial-intersection ground collider by at least `0.25 m` on both horizontal axes;
+- `SitePadBody` overlaps `AccessWalkway` by at least `0.25 m` on both horizontal axes, making the Core physically reachable from retained gameplay ground;
 - the site pad remains outside the industrial-frontage and proof-relay bounding envelopes;
 - runtime creates exactly one `SilentCore` and resolves its global position to the production socket rather than the legacy in-yard position;
 - the runtime marker uses the approved toon shader on representative housing/signal meshes;

--- a/godot/scenes/world/gears_district_slice_01b.tscn
+++ b/godot/scenes/world/gears_district_slice_01b.tscn
@@ -97,10 +97,10 @@ size = Vector3(0.3, 0.8, 14)
 size = Vector3(0.3, 0.8, 14)
 
 [sub_resource type="BoxShape3D" id="Shape_SilentCoreWalkway"]
-size = Vector3(2.4, 0.16, 1.0)
+size = Vector3(3.0, 0.16, 1.4)
 
 [sub_resource type="BoxShape3D" id="Shape_SilentCorePad"]
-size = Vector3(3.0, 0.16, 2.4)
+size = Vector3(3.0, 0.16, 2.6)
 
 [node name="GearsDistrictSlice01B" type="Node3D"]
 script = ExtResource("1_slice")
@@ -374,10 +374,10 @@ shape = SubResource("Shape_Industrial")
 position = Vector3(6.2, 0, -27.4)
 
 [node name="AccessWalkway" type="StaticBody3D" parent="SilentCoreSite"]
-position = Vector3(-1.1, -0.08, 2.15)
+position = Vector3(-1.15, -0.08, 1.9)
 
 [node name="WalkwayMesh" type="MeshInstance3D" parent="SilentCoreSite/AccessWalkway"]
-scale = Vector3(2.4, 0.16, 1.0)
+scale = Vector3(3.0, 0.16, 1.4)
 mesh = SubResource("Cube")
 material_override = SubResource("Mat_Concrete")
 
@@ -388,7 +388,7 @@ shape = SubResource("Shape_SilentCoreWalkway")
 position = Vector3(0, -0.08, 0.55)
 
 [node name="SitePadMesh" type="MeshInstance3D" parent="SilentCoreSite/SitePadBody"]
-scale = Vector3(3.0, 0.16, 2.4)
+scale = Vector3(3.0, 0.16, 2.6)
 mesh = SubResource("Cube")
 material_override = SubResource("Mat_Concrete")
 

--- a/godot/scenes/world/gears_district_slice_01b.tscn
+++ b/godot/scenes/world/gears_district_slice_01b.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3]
+[gd_scene load_steps=22 format=3]
 
 [ext_resource type="Script" path="res://scripts/visual/gears_district_slice_01b.gd" id="1_slice"]
 [ext_resource type="Shader" path="res://materials/gears_toon.gdshader" id="2_toon"]
@@ -47,6 +47,13 @@ shader_parameter/base_color = Color(0.184, 0.467, 0.471, 1)
 shader_parameter/roughness_value = 0.82
 shader_parameter/emission_color = Color(0, 0, 0, 1)
 shader_parameter/emission_energy = 0.0
+
+[sub_resource type="ShaderMaterial" id="Mat_Cyan"]
+shader = ExtResource("2_toon")
+shader_parameter/base_color = Color(0.486, 0.812, 0.816, 1)
+shader_parameter/roughness_value = 0.72
+shader_parameter/emission_color = Color(0.486, 0.812, 0.816, 1)
+shader_parameter/emission_energy = 0.45
 
 [sub_resource type="ShaderMaterial" id="Mat_Oxidized"]
 shader = ExtResource("2_toon")
@@ -356,6 +363,42 @@ pixel_size = 0.004
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="IndustrialFrontage"]
 shape = SubResource("Shape_Industrial")
+
+[node name="SilentCoreSite" type="Node3D" parent="."]
+position = Vector3(6.2, 0, -27.4)
+
+[node name="ServicePad" type="MeshInstance3D" parent="SilentCoreSite"]
+position = Vector3(0, -0.02, 0)
+scale = Vector3(2.6, 0.08, 2.4)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Concrete")
+
+[node name="RelayCabinet" type="MeshInstance3D" parent="SilentCoreSite"]
+position = Vector3(0, 1.0, -0.18)
+scale = Vector3(1.35, 2.0, 0.95)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_OffWhite")
+
+[node name="RemovedAssetPlateScar" type="MeshInstance3D" parent="SilentCoreSite"]
+position = Vector3(0, 1.18, 0.32)
+scale = Vector3(0.62, 0.34, 0.08)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Soot")
+
+[node name="MaintenanceBracket" type="MeshInstance3D" parent="SilentCoreSite"]
+position = Vector3(-0.62, 0.36, 0.28)
+scale = Vector3(0.22, 0.55, 0.18)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Oxidized")
+
+[node name="MemorySignalAperture" type="MeshInstance3D" parent="SilentCoreSite"]
+position = Vector3(0, 0.86, 0.35)
+scale = Vector3(0.42, 0.12, 0.05)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Cyan")
+
+[node name="SilentCoreSocket" type="Marker3D" parent="SilentCoreSite"]
+position = Vector3(0, 0.15, 1.05)
 
 [node name="MissionDestinationSocket" type="Marker3D" parent="."]
 position = Vector3(-10, 0.2, -41.5)

--- a/godot/scenes/world/gears_district_slice_01b.tscn
+++ b/godot/scenes/world/gears_district_slice_01b.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3]
+[gd_scene load_steps=24 format=3]
 
 [ext_resource type="Script" path="res://scripts/visual/gears_district_slice_01b.gd" id="1_slice"]
 [ext_resource type="Shader" path="res://materials/gears_toon.gdshader" id="2_toon"]
@@ -95,6 +95,12 @@ size = Vector3(0.3, 0.8, 14)
 
 [sub_resource type="BoxShape3D" id="Shape_EastRail"]
 size = Vector3(0.3, 0.8, 14)
+
+[sub_resource type="BoxShape3D" id="Shape_SilentCoreWalkway"]
+size = Vector3(2.4, 0.16, 1.0)
+
+[sub_resource type="BoxShape3D" id="Shape_SilentCorePad"]
+size = Vector3(3.0, 0.16, 2.4)
 
 [node name="GearsDistrictSlice01B" type="Node3D"]
 script = ExtResource("1_slice")
@@ -367,38 +373,54 @@ shape = SubResource("Shape_Industrial")
 [node name="SilentCoreSite" type="Node3D" parent="."]
 position = Vector3(6.2, 0, -27.4)
 
-[node name="ServicePad" type="MeshInstance3D" parent="SilentCoreSite"]
-position = Vector3(0, -0.02, 0)
-scale = Vector3(2.6, 0.08, 2.4)
+[node name="AccessWalkway" type="StaticBody3D" parent="SilentCoreSite"]
+position = Vector3(-1.1, -0.08, 2.15)
+
+[node name="WalkwayMesh" type="MeshInstance3D" parent="SilentCoreSite/AccessWalkway"]
+scale = Vector3(2.4, 0.16, 1.0)
 mesh = SubResource("Cube")
 material_override = SubResource("Mat_Concrete")
 
+[node name="CollisionShape3D" type="CollisionShape3D" parent="SilentCoreSite/AccessWalkway"]
+shape = SubResource("Shape_SilentCoreWalkway")
+
+[node name="SitePadBody" type="StaticBody3D" parent="SilentCoreSite"]
+position = Vector3(0, -0.08, 0.55)
+
+[node name="SitePadMesh" type="MeshInstance3D" parent="SilentCoreSite/SitePadBody"]
+scale = Vector3(3.0, 0.16, 2.4)
+mesh = SubResource("Cube")
+material_override = SubResource("Mat_Concrete")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="SilentCoreSite/SitePadBody"]
+shape = SubResource("Shape_SilentCorePad")
+
 [node name="RelayCabinet" type="MeshInstance3D" parent="SilentCoreSite"]
-position = Vector3(0, 1.0, -0.18)
+position = Vector3(0, 1.0, -0.35)
 scale = Vector3(1.35, 2.0, 0.95)
 mesh = SubResource("Cube")
 material_override = SubResource("Mat_OffWhite")
 
 [node name="RemovedAssetPlateScar" type="MeshInstance3D" parent="SilentCoreSite"]
-position = Vector3(0, 1.18, 0.32)
+position = Vector3(0, 1.18, 0.15)
 scale = Vector3(0.62, 0.34, 0.08)
 mesh = SubResource("Cube")
 material_override = SubResource("Mat_Soot")
 
 [node name="MaintenanceBracket" type="MeshInstance3D" parent="SilentCoreSite"]
-position = Vector3(-0.62, 0.36, 0.28)
+position = Vector3(-0.62, 0.36, 0.10)
 scale = Vector3(0.22, 0.55, 0.18)
 mesh = SubResource("Cube")
 material_override = SubResource("Mat_Oxidized")
 
 [node name="MemorySignalAperture" type="MeshInstance3D" parent="SilentCoreSite"]
-position = Vector3(0, 0.86, 0.35)
+position = Vector3(0, 0.86, 0.18)
 scale = Vector3(0.42, 0.12, 0.05)
 mesh = SubResource("Cube")
 material_override = SubResource("Mat_Cyan")
 
 [node name="SilentCoreSocket" type="Marker3D" parent="SilentCoreSite"]
-position = Vector3(0, 0.15, 1.05)
+position = Vector3(0, 0.15, 0.55)
 
 [node name="MissionDestinationSocket" type="Marker3D" parent="."]
 position = Vector3(-10, 0.2, -41.5)

--- a/godot/scripts/interactions/silent_core_interactable.gd
+++ b/godot/scripts/interactions/silent_core_interactable.gd
@@ -70,16 +70,17 @@ func _add_box(mesh_name: String, size: Vector3, position: Vector3, color: Color,
 	return instance
 
 func _build_visual_marker() -> void:
-	# Ordinary obsolete utility hardware first; signal/memory is sparse punctuation.
-	_add_box("SilentCoreHousing", Vector3(0.95, 0.95, 0.25), Vector3(0.0, 0.62, -0.12), OFF_WHITE)
-	_add_box("SilentCoreStructuralCore", Vector3(0.62, 0.72, 0.32), Vector3(0.0, 0.58, 0.08), SOOT)
-	_add_box("SilentCoreSignalSlot", Vector3(0.38, 0.12, 0.05), Vector3(0.0, 0.62, 0.27), SIGNAL_CYAN, 0.52)
-	_add_box("SilentCoreRemovedPlateScar", Vector3(0.24, 0.18, 0.04), Vector3(0.30, 0.82, 0.27), SOOT)
+	# The production socket sits 0.15m above its apron, so these local centers
+	# ground the housing/structural mass at world y=0 instead of floating it.
+	_add_box("SilentCoreHousing", Vector3(0.95, 0.95, 0.25), Vector3(0.0, 0.325, -0.12), OFF_WHITE)
+	_add_box("SilentCoreStructuralCore", Vector3(0.62, 0.72, 0.32), Vector3(0.0, 0.21, 0.08), SOOT)
+	_add_box("SilentCoreSignalSlot", Vector3(0.38, 0.12, 0.05), Vector3(0.0, 0.42, 0.27), SIGNAL_CYAN, 0.52)
+	_add_box("SilentCoreRemovedPlateScar", Vector3(0.24, 0.18, 0.04), Vector3(0.30, 0.62, 0.27), SOOT)
 
 	var label := Label3D.new()
 	label.name = "SilentCoreLabel"
 	label.text = "HS-7 // CORE"
-	label.position = Vector3(0, 1.25, 0)
+	label.position = Vector3(0, 1.05, 0)
 	label.font_size = 18
 	label.outline_size = 7
 	label.modulate = OFF_WHITE

--- a/godot/scripts/interactions/silent_core_interactable.gd
+++ b/godot/scripts/interactions/silent_core_interactable.gd
@@ -1,12 +1,18 @@
 class_name SilentCoreInteractable
 extends InteractableBase
 
-## Bounded Mission 03 shrine interaction. Target selection remains owned by the
-## production controller; this node only owns its powered/activated state.
+## Bounded Mission 03 infrastructure interaction. Target selection remains owned
+## by the production controller; this node only owns powered/activated state.
 
 signal silent_core_activated
 
+const TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
+const SOOT := Color(0.094, 0.129, 0.149, 1.0)
+const OFF_WHITE := Color(0.843, 0.824, 0.765, 1.0)
+const SIGNAL_CYAN := Color(0.486, 0.812, 0.816, 1.0)
+
 var activation_count: int = 0
+var _toon_shader: Shader = null
 
 func _ready() -> void:
 	interaction_radius = 2.6
@@ -40,31 +46,43 @@ func reset_for_replay() -> void:
 	is_player_in_range = false
 	state_changed.emit("LOCKED")
 
-func _build_visual_marker() -> void:
-	var body := MeshInstance3D.new()
-	body.name = "SilentCoreMarker"
-	var mesh := CylinderMesh.new()
-	mesh.top_radius = 0.7
-	mesh.bottom_radius = 0.9
-	mesh.height = 1.1
-	mesh.radial_segments = 12
-	body.mesh = mesh
-	body.position = Vector3(0, 0.55, 0)
+func _toon_material(color: Color, emission_energy: float = 0.0) -> ShaderMaterial:
+	if _toon_shader == null:
+		_toon_shader = load(TOON_SHADER_PATH) as Shader
+	var material := ShaderMaterial.new()
+	material.shader = _toon_shader
+	material.set_shader_parameter("base_color", color)
+	material.set_shader_parameter("roughness_value", 0.84)
+	if emission_energy > 0.0:
+		material.set_shader_parameter("emission_color", color)
+		material.set_shader_parameter("emission_energy", emission_energy)
+	return material
 
-	var material := StandardMaterial3D.new()
-	material.albedo_color = Color(0.08, 0.12, 0.16, 1.0)
-	material.metallic = 0.75
-	material.roughness = 0.35
-	material.emission_enabled = true
-	material.emission = Color(0.08, 0.4, 0.48, 1.0)
-	material.emission_energy_multiplier = 0.8
-	body.material_override = material
-	add_child(body)
+func _add_box(mesh_name: String, size: Vector3, position: Vector3, color: Color, emission_energy: float = 0.0) -> MeshInstance3D:
+	var box := BoxMesh.new()
+	box.size = size
+	var instance := MeshInstance3D.new()
+	instance.name = mesh_name
+	instance.mesh = box
+	instance.position = position
+	instance.material_override = _toon_material(color, emission_energy)
+	add_child(instance)
+	return instance
+
+func _build_visual_marker() -> void:
+	# Ordinary obsolete utility hardware first; signal/memory is sparse punctuation.
+	_add_box("SilentCoreHousing", Vector3(0.95, 0.95, 0.25), Vector3(0.0, 0.62, -0.12), OFF_WHITE)
+	_add_box("SilentCoreStructuralCore", Vector3(0.62, 0.72, 0.32), Vector3(0.0, 0.58, 0.08), SOOT)
+	_add_box("SilentCoreSignalSlot", Vector3(0.38, 0.12, 0.05), Vector3(0.0, 0.62, 0.27), SIGNAL_CYAN, 0.52)
+	_add_box("SilentCoreRemovedPlateScar", Vector3(0.24, 0.18, 0.04), Vector3(0.30, 0.82, 0.27), SOOT)
 
 	var label := Label3D.new()
 	label.name = "SilentCoreLabel"
-	label.text = "HS-7 // SILENT CORE"
-	label.position = Vector3(0, 1.45, 0)
-	label.font_size = 22
+	label.text = "HS-7 // CORE"
+	label.position = Vector3(0, 1.25, 0)
+	label.font_size = 18
+	label.outline_size = 7
+	label.modulate = OFF_WHITE
+	label.outline_modulate = SOOT
 	label.billboard = BaseMaterial3D.BILLBOARD_ENABLED
 	add_child(label)

--- a/godot/scripts/missions/city_that_forgot_runtime.gd
+++ b/godot/scripts/missions/city_that_forgot_runtime.gd
@@ -10,7 +10,8 @@ const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.g
 const SilentCoreScript = preload("res://scripts/interactions/silent_core_interactable.gd")
 const MemoryEchoScript = preload("res://scripts/prototype/memory_echo_controller.gd")
 
-const SILENT_CORE_POSITION := Vector3(8.0, 0.4, -8.0)
+const LEGACY_SILENT_CORE_POSITION := Vector3(8.0, 0.4, -8.0)
+const DISTRICT_SILENT_CORE_SOCKET_PATH := "GearsDistrictSlice01B/SilentCoreSite/SilentCoreSocket"
 const AUTHORED_ECHO_PAYLOAD := {
 	"echo_id": "mission03_silent_core",
 	"action": "silent_core_resonance",
@@ -118,6 +119,19 @@ func _try_bind_runtime() -> void:
 	_bound = true
 	print("[MISSION_NARRATIVE_03] Runtime bound to retained Action/Echo/pursuit systems")
 
+func _resolve_silent_core_destination() -> Dictionary:
+	if _root_controller != null:
+		var socket := _root_controller.get_node_or_null(DISTRICT_SILENT_CORE_SOCKET_PATH) as Marker3D
+		if socket != null:
+			return {
+				"global_position": socket.global_position,
+				"source": DISTRICT_SILENT_CORE_SOCKET_PATH,
+			}
+	return {
+		"global_position": LEGACY_SILENT_CORE_POSITION,
+		"source": "legacy_fixture_fallback",
+	}
+
 func _create_silent_core() -> void:
 	var existing := _root_controller.get_node_or_null("SilentCore")
 	if existing is SilentCoreInteractable:
@@ -125,8 +139,10 @@ func _create_silent_core() -> void:
 		return
 	_silent_core = SilentCoreScript.new()
 	_silent_core.name = "SilentCore"
-	_silent_core.position = SILENT_CORE_POSITION
 	_root_controller.add_child(_silent_core)
+	var destination := _resolve_silent_core_destination()
+	_silent_core.global_position = destination["global_position"]
+	_silent_core.set_meta("destination_source", destination["source"])
 
 func _register_retained_interaction_target() -> void:
 	var interactables = _root_controller.get("_interactables")

--- a/godot/scripts/visual/gears_district_slice_01b.gd
+++ b/godot/scripts/visual/gears_district_slice_01b.gd
@@ -5,6 +5,10 @@ extends Node3D
 
 const RETAINED_NORTH_EDGE_Z := -20.0
 const APPROVED_TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
+const ADDITIVE_EXTENSION_PATHS := [
+	"CommercialFrontage/MayorBurnGarage",
+	"SilentCoreSite",
+]
 
 func _box_shape(node_path: String) -> BoxShape3D:
 	var collider := get_node_or_null(node_path) as CollisionShape3D
@@ -36,6 +40,22 @@ func _count_foreign_scripts(node: Node) -> int:
 		count = 1
 	for child in node.get_children():
 		count += _count_foreign_scripts(child)
+	return count
+
+func _count_extension_meshes() -> int:
+	var count := 0
+	for path in ADDITIVE_EXTENSION_PATHS:
+		var node := get_node_or_null(path)
+		if node != null:
+			count += _count_meshes(node)
+	return count
+
+func _count_extension_colliders() -> int:
+	var count := 0
+	for path in ADDITIVE_EXTENSION_PATHS:
+		var node := get_node_or_null(path)
+		if node != null:
+			count += _count_colliders(node)
 	return count
 
 func _range_overlap(a_min: float, a_max: float, b_min: float, b_max: float) -> bool:
@@ -115,6 +135,11 @@ func get_production_contract() -> Dictionary:
 			contiguous = intersection_south_edge >= RETAINED_NORTH_EDGE_Z - 0.1 and road_south_edge >= intersection.position.z - intersection_shape.size.z * 0.5 - 0.1
 			northbound_depth = RETAINED_NORTH_EDGE_Z - road_north_edge
 
+	var current_meshes := _count_meshes(self)
+	var current_colliders := _count_colliders(self)
+	var extension_meshes := _count_extension_meshes()
+	var extension_colliders := _count_extension_colliders()
+
 	return {
 		"version": "open_world_expansion_01b_v1",
 		"contiguous_with_retained_yard": contiguous,
@@ -131,7 +156,13 @@ func get_production_contract() -> Dictionary:
 		"primary_route_width_m": road_shape.size.x if road_shape != null else 0.0,
 		"service_alley_width_m": alley_shape.size.x if alley_shape != null else 0.0,
 		"northbound_depth_m": northbound_depth,
-		"mesh_instances": _count_meshes(self),
-		"collision_shapes": _count_colliders(self),
+		# Preserve the original 01B budget as a historical contract while later
+		# authored locations report their own incremental budgets and cumulative totals.
+		"mesh_instances": current_meshes - extension_meshes,
+		"collision_shapes": current_colliders - extension_colliders,
+		"current_mesh_instances": current_meshes,
+		"current_collision_shapes": current_colliders,
+		"extension_mesh_instances": extension_meshes,
+		"extension_collision_shapes": extension_colliders,
 		"local_lights": _count_local_lights(self),
 	}

--- a/godot/tests/camera_mount_transition_test.gd
+++ b/godot/tests/camera_mount_transition_test.gd
@@ -6,8 +6,9 @@ extends SceneTree
 # avoiding the previous timer + manual _process double-step artifact.
 # This dedicated regression is also the reference oracle for the legacy Ticket05 repair.
 # Keep this path in the focused workflow so legacy-oracle repairs are verified before publish.
-# Open World Expansion 01C also invokes its focused production-scene destination contract here.
+# Open World Expansion location-integration contracts run before camera continuity here.
 const BurnGarageContract = preload("res://tests/mayor_burn_garage_integration_contract.gd")
+const SilentCoreSiteContract = preload("res://tests/silent_core_site_integration_contract.gd")
 
 var _scene_under_test: Node = null
 
@@ -59,6 +60,11 @@ func _run() -> void:
 	var burn_garage_error: String = BurnGarageContract.verify(_scene_under_test)
 	if burn_garage_error != "":
 		await _fail("[GEARS_DISTRICT_01C] %s" % burn_garage_error)
+		return
+
+	var silent_core_error: String = SilentCoreSiteContract.verify(_scene_under_test)
+	if silent_core_error != "":
+		await _fail("[GEARS_DISTRICT_01D] %s" % silent_core_error)
 		return
 
 	var camera := _scene_under_test.get_node_or_null("ChinatownCamera3D")

--- a/godot/tests/silent_core_site_integration_contract.gd
+++ b/godot/tests/silent_core_site_integration_contract.gd
@@ -1,0 +1,110 @@
+extends RefCounted
+
+const TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
+const LEGACY_SILENT_CORE_POSITION := Vector3(8.0, 0.4, -8.0)
+const EXPECTED_SITE_POSITION := Vector3(6.2, 0.0, -27.4)
+const PROOF_RELAY_MAX_X := 4.65
+const INDUSTRIAL_SOUTH_EDGE_Z := -30.0
+const PRIMARY_ROAD_EAST_EDGE_X := -0.5
+
+static func _count_meshes(node: Node) -> int:
+	var count := 1 if node is MeshInstance3D else 0
+	for child in node.get_children():
+		count += _count_meshes(child)
+	return count
+
+static func _count_colliders(node: Node) -> int:
+	var count := 1 if node is CollisionShape3D else 0
+	for child in node.get_children():
+		count += _count_colliders(child)
+	return count
+
+static func _count_local_lights(node: Node) -> int:
+	var count := 1 if node is OmniLight3D or node is SpotLight3D else 0
+	for child in node.get_children():
+		count += _count_local_lights(child)
+	return count
+
+static func _verify_toon_mesh(root: Node, path: String) -> String:
+	var mesh := root.get_node_or_null(path) as MeshInstance3D
+	if mesh == null:
+		return "Required Silent Core mesh missing: %s" % path
+	var material := mesh.material_override as ShaderMaterial
+	if material == null or material.shader == null:
+		return "Silent Core mesh has no shader material: %s" % path
+	if material.shader.resource_path != TOON_SHADER_PATH:
+		return "Silent Core mesh is not using the approved toon shader: %s" % path
+	return ""
+
+static func verify(scene_root: Node) -> String:
+	if scene_root == null:
+		return "Playable scene root is missing"
+
+	var district := scene_root.get_node_or_null("GearsDistrictSlice01B")
+	if district == null:
+		return "01B production slice is missing"
+
+	var site := district.get_node_or_null("SilentCoreSite") as Node3D
+	if site == null:
+		return "SilentCoreSite is missing from the production district"
+	if site.position.distance_to(EXPECTED_SITE_POSITION) > 0.001:
+		return "SilentCoreSite moved outside its bounded authored pocket"
+	if site.position.x <= PROOF_RELAY_MAX_X:
+		return "SilentCoreSite overlaps the proof-only relay envelope"
+	if site.position.z <= INDUSTRIAL_SOUTH_EDGE_Z:
+		return "SilentCoreSite intrudes into the industrial frontage collision envelope"
+	if site.position.x <= PRIMARY_ROAD_EAST_EDGE_X:
+		return "SilentCoreSite intrudes into the primary road corridor"
+	if site.get_script() != null:
+		return "SilentCoreSite must remain declarative"
+	if _count_meshes(site) <= 0 or _count_meshes(site) > 6:
+		return "SilentCoreSite violates its bounded 1..6 mesh budget"
+	if _count_colliders(site) != 0:
+		return "SilentCoreSite must not add new collision"
+	if _count_local_lights(site) != 0:
+		return "SilentCoreSite must not add real-time local lights"
+
+	var socket := site.get_node_or_null("SilentCoreSocket") as Marker3D
+	if socket == null or socket.get_script() != null:
+		return "SilentCoreSocket is missing or owns behavior"
+
+	for path in [
+		"SilentCoreSite/ServicePad",
+		"SilentCoreSite/RelayCabinet",
+		"SilentCoreSite/RemovedAssetPlateScar",
+		"SilentCoreSite/MemorySignalAperture",
+	]:
+		var site_error := _verify_toon_mesh(district, path)
+		if site_error != "":
+			return site_error
+
+	var runtime := scene_root.get_node_or_null("CityThatForgotRuntime")
+	if runtime == null:
+		return "Mission 03 runtime is missing"
+	var silent_core := scene_root.get_node_or_null("SilentCore")
+	if silent_core == null:
+		return "Mission 03 runtime did not create exactly one Silent Core"
+	if scene_root.find_children("SilentCore", "", true, false).size() != 1:
+		return "Production scene contains duplicate Silent Core nodes"
+	if silent_core.global_position.distance_to(socket.global_position) > 0.05:
+		return "Mission 03 Silent Core is not resolved to the production socket"
+	if silent_core.global_position.distance_to(LEGACY_SILENT_CORE_POSITION) < 15.0:
+		return "Mission 03 still resolves too close to the legacy in-yard placeholder"
+	if silent_core.get_meta("destination_source", "") != "GearsDistrictSlice01B/SilentCoreSite/SilentCoreSocket":
+		return "Mission 03 Silent Core does not record production-socket provenance"
+	if bool(silent_core.get("is_powered")):
+		return "Silent Core is powered before Mission 03 unlock"
+	if _count_meshes(silent_core) <= 0 or _count_meshes(silent_core) > 5:
+		return "Silent Core runtime marker violates its bounded 1..5 mesh budget"
+
+	for path in [
+		"SilentCore/SilentCoreHousing",
+		"SilentCore/SilentCoreStructuralCore",
+		"SilentCore/SilentCoreSignalSlot",
+		"SilentCore/SilentCoreRemovedPlateScar",
+	]:
+		var marker_error := _verify_toon_mesh(scene_root, path)
+		if marker_error != "":
+			return marker_error
+
+	return ""

--- a/godot/tests/silent_core_site_integration_contract.gd
+++ b/godot/tests/silent_core_site_integration_contract.gd
@@ -4,8 +4,8 @@ const TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
 const LEGACY_SILENT_CORE_POSITION := Vector3(8.0, 0.4, -8.0)
 const EXPECTED_SITE_POSITION := Vector3(6.2, 0.0, -27.4)
 const PROOF_RELAY_MAX_X := 4.65
+const PROOF_RELAY_MAX_Z := -26.5
 const INDUSTRIAL_SOUTH_EDGE_Z := -30.0
-const PRIMARY_ROAD_EAST_EDGE_X := -0.5
 
 static func _count_meshes(node: Node) -> int:
 	var count := 1 if node is MeshInstance3D else 0
@@ -36,6 +36,24 @@ static func _verify_toon_mesh(root: Node, path: String) -> String:
 		return "Silent Core mesh is not using the approved toon shader: %s" % path
 	return ""
 
+static func _box_bounds(body: Node3D, collider: CollisionShape3D) -> Dictionary:
+	var shape := collider.shape as BoxShape3D
+	if shape == null:
+		return {}
+	var half := shape.size * 0.5
+	return {
+		"min_x": body.global_position.x - half.x,
+		"max_x": body.global_position.x + half.x,
+		"min_z": body.global_position.z - half.z,
+		"max_z": body.global_position.z + half.z,
+	}
+
+static func _overlaps_xz(a: Dictionary, b: Dictionary) -> bool:
+	if a.is_empty() or b.is_empty():
+		return false
+	return minf(float(a.max_x), float(b.max_x)) >= maxf(float(a.min_x), float(b.min_x)) - 0.05 \
+	and minf(float(a.max_z), float(b.max_z)) >= maxf(float(a.min_z), float(b.min_z)) - 0.05
+
 static func verify(scene_root: Node) -> String:
 	if scene_root == null:
 		return "Playable scene root is missing"
@@ -49,27 +67,52 @@ static func verify(scene_root: Node) -> String:
 		return "SilentCoreSite is missing from the production district"
 	if site.position.distance_to(EXPECTED_SITE_POSITION) > 0.001:
 		return "SilentCoreSite moved outside its bounded authored pocket"
-	if site.position.x <= PROOF_RELAY_MAX_X:
-		return "SilentCoreSite overlaps the proof-only relay envelope"
-	if site.position.z <= INDUSTRIAL_SOUTH_EDGE_Z:
-		return "SilentCoreSite intrudes into the industrial frontage collision envelope"
-	if site.position.x <= PRIMARY_ROAD_EAST_EDGE_X:
-		return "SilentCoreSite intrudes into the primary road corridor"
 	if site.get_script() != null:
 		return "SilentCoreSite must remain declarative"
 	if _count_meshes(site) <= 0 or _count_meshes(site) > 6:
 		return "SilentCoreSite violates its bounded 1..6 mesh budget"
-	if _count_colliders(site) != 0:
-		return "SilentCoreSite must not add new collision"
+	if _count_colliders(site) != 2:
+		return "SilentCoreSite must add exactly two bounded maintenance-apron colliders"
 	if _count_local_lights(site) != 0:
 		return "SilentCoreSite must not add real-time local lights"
+
+	var intersection := district.get_node_or_null("IndustrialIntersection") as Node3D
+	var intersection_collider := district.get_node_or_null("IndustrialIntersection/CollisionShape3D") as CollisionShape3D
+	var walkway := site.get_node_or_null("AccessWalkway") as Node3D
+	var walkway_collider := site.get_node_or_null("AccessWalkway/CollisionShape3D") as CollisionShape3D
+	var pad := site.get_node_or_null("SitePadBody") as Node3D
+	var pad_collider := site.get_node_or_null("SitePadBody/CollisionShape3D") as CollisionShape3D
+	if intersection == null or intersection_collider == null or walkway == null or walkway_collider == null or pad == null or pad_collider == null:
+		return "Silent Core maintenance-apron collision fixtures are incomplete"
+
+	var intersection_bounds := _box_bounds(intersection, intersection_collider)
+	var walkway_bounds := _box_bounds(walkway, walkway_collider)
+	var pad_bounds := _box_bounds(pad, pad_collider)
+	if not _overlaps_xz(intersection_bounds, walkway_bounds):
+		return "Silent Core AccessWalkway does not overlap retained intersection ground"
+	if not _overlaps_xz(walkway_bounds, pad_bounds):
+		return "Silent Core SitePadBody does not overlap AccessWalkway"
+	if float(pad_bounds.min_x) <= PROOF_RELAY_MAX_X:
+		return "Silent Core site pad overlaps the proof-only relay envelope"
+	if float(walkway_bounds.min_z) <= PROOF_RELAY_MAX_Z:
+		return "Silent Core access walkway intrudes into the proof-only relay envelope"
+	if float(pad_bounds.min_z) <= INDUSTRIAL_SOUTH_EDGE_Z:
+		return "Silent Core site pad intrudes into the industrial frontage collision envelope"
 
 	var socket := site.get_node_or_null("SilentCoreSocket") as Marker3D
 	if socket == null or socket.get_script() != null:
 		return "SilentCoreSocket is missing or owns behavior"
+	if not _overlaps_xz(pad_bounds, {
+		"min_x": socket.global_position.x,
+		"max_x": socket.global_position.x,
+		"min_z": socket.global_position.z,
+		"max_z": socket.global_position.z,
+	}):
+		return "SilentCoreSocket is not located on the traversable site pad"
 
 	for path in [
-		"SilentCoreSite/ServicePad",
+		"SilentCoreSite/AccessWalkway/WalkwayMesh",
+		"SilentCoreSite/SitePadBody/SitePadMesh",
 		"SilentCoreSite/RelayCabinet",
 		"SilentCoreSite/RemovedAssetPlateScar",
 		"SilentCoreSite/MemorySignalAperture",

--- a/godot/tests/silent_core_site_integration_contract.gd
+++ b/godot/tests/silent_core_site_integration_contract.gd
@@ -6,6 +6,7 @@ const EXPECTED_SITE_POSITION := Vector3(6.2, 0.0, -27.4)
 const PROOF_RELAY_MAX_X := 4.65
 const PROOF_RELAY_MAX_Z := -26.5
 const INDUSTRIAL_SOUTH_EDGE_Z := -30.0
+const MIN_GROUND_OVERLAP_M := 0.25
 
 static func _count_meshes(node: Node) -> int:
 	var count := 1 if node is MeshInstance3D else 0
@@ -48,11 +49,22 @@ static func _box_bounds(body: Node3D, collider: CollisionShape3D) -> Dictionary:
 		"max_z": body.global_position.z + half.z,
 	}
 
-static func _overlaps_xz(a: Dictionary, b: Dictionary) -> bool:
+static func _overlap_extent(a_min: float, a_max: float, b_min: float, b_max: float) -> float:
+	return minf(a_max, b_max) - maxf(a_min, b_min)
+
+static func _has_stable_ground_overlap(a: Dictionary, b: Dictionary) -> bool:
 	if a.is_empty() or b.is_empty():
 		return false
-	return minf(float(a.max_x), float(b.max_x)) >= maxf(float(a.min_x), float(b.min_x)) - 0.05 \
-	and minf(float(a.max_z), float(b.max_z)) >= maxf(float(a.min_z), float(b.min_z)) - 0.05
+	return _overlap_extent(float(a.min_x), float(a.max_x), float(b.min_x), float(b.max_x)) >= MIN_GROUND_OVERLAP_M \
+	and _overlap_extent(float(a.min_z), float(a.max_z), float(b.min_z), float(b.max_z)) >= MIN_GROUND_OVERLAP_M
+
+static func _point_on_bounds(bounds: Dictionary, point: Vector3) -> bool:
+	if bounds.is_empty():
+		return false
+	return point.x >= float(bounds.min_x) - 0.01 \
+	and point.x <= float(bounds.max_x) + 0.01 \
+	and point.z >= float(bounds.min_z) - 0.01 \
+	and point.z <= float(bounds.max_z) + 0.01
 
 static func verify(scene_root: Node) -> String:
 	if scene_root == null:
@@ -88,10 +100,10 @@ static func verify(scene_root: Node) -> String:
 	var intersection_bounds := _box_bounds(intersection, intersection_collider)
 	var walkway_bounds := _box_bounds(walkway, walkway_collider)
 	var pad_bounds := _box_bounds(pad, pad_collider)
-	if not _overlaps_xz(intersection_bounds, walkway_bounds):
-		return "Silent Core AccessWalkway does not overlap retained intersection ground"
-	if not _overlaps_xz(walkway_bounds, pad_bounds):
-		return "Silent Core SitePadBody does not overlap AccessWalkway"
+	if not _has_stable_ground_overlap(intersection_bounds, walkway_bounds):
+		return "Silent Core AccessWalkway lacks a stable overlap margin with retained intersection ground"
+	if not _has_stable_ground_overlap(walkway_bounds, pad_bounds):
+		return "Silent Core SitePadBody lacks a stable overlap margin with AccessWalkway"
 	if float(pad_bounds.min_x) <= PROOF_RELAY_MAX_X:
 		return "Silent Core site pad overlaps the proof-only relay envelope"
 	if float(walkway_bounds.min_z) <= PROOF_RELAY_MAX_Z:
@@ -102,12 +114,7 @@ static func verify(scene_root: Node) -> String:
 	var socket := site.get_node_or_null("SilentCoreSocket") as Marker3D
 	if socket == null or socket.get_script() != null:
 		return "SilentCoreSocket is missing or owns behavior"
-	if not _overlaps_xz(pad_bounds, {
-		"min_x": socket.global_position.x,
-		"max_x": socket.global_position.x,
-		"min_z": socket.global_position.z,
-		"max_z": socket.global_position.z,
-	}):
+	if not _point_on_bounds(pad_bounds, socket.global_position):
 		return "SilentCoreSocket is not located on the traversable site pad"
 
 	for path in [


### PR DESCRIPTION
Replaces Mission 03's hard-coded in-yard Silent Core placeholder with a bounded authored infrastructure pocket inside existing Gears geography.

Scope: one quiet Silent Core site, one passive socket, runtime destination resolution with legacy fixture fallback, and a restrained toon-shaded interactable marker. No new acreage, collision, local lights, mission phases, Echo path, pursuit authority, camera/input/UI systems, economy, or generalized destination framework.

The branch is intentionally RED: exact-head scene CI now requires the production site/socket and restyled runtime marker before implementation.

Fresh retained-camera screenshots and candidate render telemetry remain explicit deferred verification debt under the owner-approved momentum policy.