### PR TITLE
World Event 01 — FB-13 infrastructure thrum

### DIFF
--- a/contracts/fb13_thrum_world_event_spec.md
+++ b/contracts/fb13_thrum_world_event_spec.md
@@ -1,0 +1,130 @@
+# World Event 01 — FB-13 Infrastructure Thrum
+
+**State:** READY_FOR_IMPLEMENTATION  
+**Baseline:** `main@172a56b3e896162eb69902f3e639b05296e3d848`  
+**Product direction:** exploit existing Gears geography before adding acreage  
+**Canon sources:** `skills/echos-in-the-scrap/SKILL.md`, `contracts/world-event.schema.json`, approved Gears visual-direction documents, and retained FB-13 identity from the legacy prototype
+
+## Objective
+
+Make FB-13 materially present in the production Godot slice through one bounded authored world event without introducing a companion-AI framework, new input, combat behavior, mission phase, route system, or additional geography.
+
+When the player enters the existing industrial-frontage mechanism zone during a calm/non-priority audio state, FB-13 emits one characteristic low thrum and nearby municipal/utility hardware briefly resonates. The event should feel like a compact companion response to machinery, not a mission objective or magical signal phenomenon.
+
+## Canon / semantics
+
+The legacy prototype establishes FB-13 as a close companion whose characteristic thrum can make mechanisms resonate. `contracts/world-event.schema.json` already recognizes the semantic directive `thrum_spike`.
+
+This Godot increment does **not** port the legacy prototype's combat-era controls or create a network/Nostr world-event runtime. It only uses the existing directive vocabulary as the authored semantic identity for a local production event.
+
+Canonical event payload exposed by the runtime contract:
+
+- `directive`: `thrum_spike`
+- `actor`: `FB-13`
+- `zone`: `gears_industrial_frontage`
+- `severity`: `0.30`
+- `ttl_msec`: `650`
+
+## Trigger topology
+
+Use the existing production mechanism:
+
+`GearsDistrictSlice01B/IndustrialFrontage/CivicUtilityPlate`
+
+as the authored trigger anchor.
+
+Behavior:
+
+1. Player enters within `5.5 m` of the anchor.
+2. Event is eligible only when retained audio priority is not `DISTURBANCE`, `PURSUIT_PRESSURE`, or `MEMORY_ECHO`.
+3. If armed and off cooldown, trigger exactly once.
+4. Play the retained `AudioManager` FB-13 thrum event spatially at the mechanism anchor.
+5. Briefly pulse only these existing mechanism meshes:
+   - `GearsDistrictSlice01B/IndustrialFrontage/CivicUtilityPlate`
+   - `GearsDistrictSlice01B/IndustrialFrontage/UtilitySpine`
+6. Event remains disarmed while the player stays in the zone.
+7. Player must leave beyond `8.0 m` and the `6.0 s` cooldown must expire before another thrum can trigger.
+
+The event is not mission-gated. It is ambient authored world behavior and may occur during quiet traversal before, between, or after missions.
+
+## Visual contract
+
+- Reuse the current `gears_toon.gdshader` materials already assigned to the industrial mechanisms.
+- Do not add new meshes, collision, local lights, outlines, particles, screen-space FX, HUD elements, or HS-7 cyan signal language.
+- Pulse by temporarily duplicating each target's existing material, setting emission from its own current base color, then restoring the exact original material after `650 ms`.
+- FB-13 resonance must remain a small infrastructure response. It must not read as a Silent Core/memory event, quest marker, nightclub/neon effect, or supernatural shockwave.
+
+## Audio contract
+
+Extend the existing `AudioManager.SoundEvent` enum by **appending** `FB13_THRUM`; do not reorder existing ordinals.
+
+`FB13_THRUM` must:
+
+- remain owned by `AudioManager.play_event()`;
+- be spatial/diegetic at the mechanism anchor;
+- use the retained procedural synthesis path;
+- be lower and more mechanical than Memory Echo or completion chimes;
+- respect the existing transient voice budget;
+- increment normal `AudioManager.event_counts` exactly once per accepted trigger;
+- require no new audio bus, global mix state, radio authority, or continuous loop.
+
+## Architecture
+
+Add one production node under the real playable scene:
+
+`FB13ThrumWorldEvent`
+
+with one bounded script, recommended path:
+
+`godot/scripts/world/fb13_thrum_world_event.gd`
+
+The node may own only:
+
+- trigger radius / rearm hysteresis;
+- cooldown;
+- current pulse lifecycle;
+- local event count and last-event contract snapshot;
+- temporary duplicate/restore of the two target materials;
+- one call into retained `AudioManager.play_event()`.
+
+It must not own or modify:
+
+- player movement;
+- camera;
+- input mapping or Action arbitration;
+- mission state;
+- pursuit;
+- vehicles;
+- radio state;
+- Memory Echo state;
+- HUD;
+- save state;
+- district geometry/collision;
+- network/Nostr directives;
+- generalized companion/world-event registries.
+
+## Code-first verification
+
+Exact-head CI must verify in the real playable scene:
+
+- `FB13ThrumWorldEvent` exists and exposes the authored contract;
+- directive/actor/zone/severity/TTL match this spec;
+- trigger/rearm/cooldown radii match this spec;
+- the two resonance targets are the existing production mechanism meshes and use the approved toon shader;
+- entering the zone from outside triggers exactly once;
+- `AudioManager.get_event_count(AudioManager.SoundEvent.FB13_THRUM)` increments exactly once;
+- both target meshes temporarily receive duplicate pulse materials;
+- after the TTL, both exact original material resources are restored;
+- repeated evaluation while still inside does not retrigger;
+- leaving beyond `8.0 m`, allowing the `6.0 s` cooldown to expire, then re-entering triggers a second time;
+- `DISTURBANCE`, `PURSUIT_PRESSURE`, and `MEMORY_ECHO` suppress triggering without consuming the armed state;
+- no collision/light/HUD/input/mission nodes are added by this event;
+- retained 01B–01D, Burn garage, Silent Core, camera, vehicle, mission, and canonical compatibility suites remain green.
+
+## Perceptual/audio debt
+
+Human/windowed listening and fresh retained-camera visual observation remain useful perceptual verification debt. Code-first acceptance may prove trigger semantics, spatial event routing, material lifecycle, and ownership boundaries, but must not be represented as a human listening-quality judgment.
+
+## Completion recommendation
+
+After this event passes, prefer another small world-use/content increment only if it has stronger visible product value than resolving accumulated visual/performance/audio verification debt. Do not use this event as precedent for a generalized companion AI, world-event bus, combat system, or additional acreage.

--- a/godot/scenes/prototype/scrap_test_block.tscn
+++ b/godot/scenes/prototype/scrap_test_block.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=3 uid="uid://c_scrap_test_block_001"]
+[gd_scene load_steps=31 format=3 uid="uid://c_scrap_test_block_001"]
 
 [ext_resource type="Script" path="res://scripts/prototype/scrap_test_block.gd" id="1_root"]
 
@@ -20,6 +20,7 @@
 [ext_resource type="Script" path="res://scripts/missions/city_that_forgot_runtime.gd" id="12_city_runtime"]
 [ext_resource type="PackedScene" path="res://scenes/world/gears_style_proof.tscn" id="13_gears"]
 [ext_resource type="PackedScene" path="res://scenes/world/gears_district_slice_01b.tscn" id="14_gears_district"]
+[ext_resource type="Script" path="res://scripts/world/fb13_thrum_world_event.gd" id="15_fb13_thrum"]
 
 [sub_resource type="Environment" id="Environment_1"]
 background_mode = 1
@@ -218,6 +219,9 @@ script = ExtResource("9_ui_audio")
 [node name="GearsStyleProof" parent="." instance=ExtResource("13_gears")]
 
 [node name="GearsDistrictSlice01B" parent="." instance=ExtResource("14_gears_district")]
+
+[node name="FB13ThrumWorldEvent" type="Node" parent="."]
+script = ExtResource("15_fb13_thrum")
 
 [node name="MissionScrapJobRuntime" type="Node" parent="."]
 script = ExtResource("10_mission_runtime")

--- a/godot/scripts/audio/audio_manager.gd
+++ b/godot/scripts/audio/audio_manager.gd
@@ -41,7 +41,9 @@ enum SoundEvent {
 	AMBIENT_WORK_CLINK,
 	AMBIENT_SERVO_HUM,
 	## CTW Feel 04 — appended to preserve all existing event ordinals
-	TRACTION_RECOVERY
+	TRACTION_RECOVERY,
+	## World Event 01 — appended; FB-13 companion identity without changing prior ordinals
+	FB13_THRUM
 }
 
 enum MixState {
@@ -309,6 +311,8 @@ func play_event(event: SoundEvent, pos: Vector3 = Vector3.ZERO) -> void:
 				_play_synth_sweep(pos, 220.0, 310.0, 0.25, 0.2)
 		SoundEvent.TRACTION_RECOVERY:
 			_play_synth_sweep(pos, 420.0, 620.0, 0.12, 0.22)
+		SoundEvent.FB13_THRUM:
+			_play_fb13_thrum(pos)
 
 func stop_event(event: SoundEvent) -> void:
 	if event == SoundEvent.PROXIMITY_HUM and _hum_player:
@@ -436,7 +440,7 @@ func set_pursuit_pressure(distance: float, pursuer_pos: Vector3) -> void:
 	if not _tension_layer_active and distance < 14.0:
 		_tension_layer_active = true
 		if _tension_player and not _tension_player.playing:
-			_tension_player.play()
+				_tension_player.play()
 	elif _tension_layer_active and distance > 18.0:
 		_tension_layer_active = false
 		if _tension_player and _tension_player.playing:
@@ -813,6 +817,12 @@ func _play_synth_rejection_buzz(pos: Vector3) -> void:
 	player_3d.unit_size = 10.0
 	player_3d.stream = _create_dual_beep_wav(160.0, 0.16, 0.5)
 	_register_and_play_transient(player_3d, pos, 0.16)
+
+func _play_fb13_thrum(pos: Vector3) -> void:
+	# A compact low mechanical resonance with one quieter upper contact tick.
+	# It stays diegetic/spatial and inside the existing transient voice budget.
+	_play_synth_sweep(pos, 92.0, 148.0, 0.55, 0.34)
+	_play_synth_click(pos, 310.0, 0.08, 0.16)
 
 func _play_synth_sweep(pos: Vector3, start_f: float, end_f: float, duration: float, volume: float = 0.4) -> void:
 	var player_3d := AudioStreamPlayer3D.new()

--- a/godot/scripts/world/fb13_thrum_world_event.gd
+++ b/godot/scripts/world/fb13_thrum_world_event.gd
@@ -103,8 +103,10 @@ func _pulse_mesh(mesh: MeshInstance3D, generation: int) -> void:
 	var pulse := original.duplicate() as ShaderMaterial
 	if pulse == null:
 		return
+	var base_color := Color.WHITE
 	var base_color_variant = pulse.get_shader_parameter("base_color")
-	var base_color := base_color_variant as Color if base_color_variant is Color else Color.WHITE
+	if base_color_variant is Color:
+		base_color = base_color_variant
 	pulse.set_shader_parameter("emission_color", base_color)
 	pulse.set_shader_parameter("emission_energy", PULSE_EMISSION_ENERGY)
 	mesh.material_override = pulse

--- a/godot/scripts/world/fb13_thrum_world_event.gd
+++ b/godot/scripts/world/fb13_thrum_world_event.gd
@@ -1,0 +1,141 @@
+extends Node
+
+## Bounded authored FB-13 world event. This node owns only local proximity,
+## cooldown/hysteresis, one retained AudioManager event call, and temporary
+## material pulse/restore on two existing industrial mechanism meshes.
+
+signal thrum_triggered(event_payload: Dictionary)
+
+const DIRECTIVE := "thrum_spike"
+const ACTOR := "FB-13"
+const ZONE := "gears_industrial_frontage"
+const SEVERITY := 0.30
+const TTL_MSEC := 650
+const TTL_SEC := 0.65
+const TRIGGER_RADIUS_M := 5.5
+const REARM_RADIUS_M := 8.0
+const COOLDOWN_SEC := 6.0
+const PULSE_EMISSION_ENERGY := 0.72
+
+const PLAYER_PATH := "../Runner"
+const AUDIO_MANAGER_PATH := "../AudioManager"
+const PRIMARY_RESONANCE_PATH := "../GearsDistrictSlice01B/IndustrialFrontage/CivicUtilityPlate"
+const SECONDARY_RESONANCE_PATH := "../GearsDistrictSlice01B/IndustrialFrontage/UtilitySpine"
+
+var trigger_count: int = 0
+var last_event: Dictionary = {}
+
+var _player: Node3D = null
+var _audio: AudioManager = null
+var _primary: MeshInstance3D = null
+var _secondary: MeshInstance3D = null
+var _armed: bool = true
+var _cooldown_remaining: float = 0.0
+var _pulse_generation: int = 0
+
+func _ready() -> void:
+	_resolve_dependencies()
+
+func _resolve_dependencies() -> void:
+	_player = get_node_or_null(PLAYER_PATH) as Node3D
+	_audio = get_node_or_null(AUDIO_MANAGER_PATH) as AudioManager
+	_primary = get_node_or_null(PRIMARY_RESONANCE_PATH) as MeshInstance3D
+	_secondary = get_node_or_null(SECONDARY_RESONANCE_PATH) as MeshInstance3D
+
+func _has_dependencies() -> bool:
+	return is_instance_valid(_player) \
+	and is_instance_valid(_audio) \
+	and is_instance_valid(_primary) \
+	and is_instance_valid(_secondary)
+
+func _process(delta: float) -> void:
+	if not _has_dependencies():
+		_resolve_dependencies()
+		if not _has_dependencies():
+			return
+
+	_cooldown_remaining = maxf(0.0, _cooldown_remaining - maxf(delta, 0.0))
+	var distance := _player.global_position.distance_to(_primary.global_position)
+	if distance >= REARM_RADIUS_M:
+		_armed = true
+
+	if not _armed or _cooldown_remaining > 0.0 or distance > TRIGGER_RADIUS_M:
+		return
+	if not _audio_priority_allows_thrum():
+		return
+	_trigger_thrum()
+
+func _audio_priority_allows_thrum() -> bool:
+	if not is_instance_valid(_audio):
+		return false
+	return _audio.current_mix_state not in [
+		AudioManager.MixState.DISTURBANCE,
+		AudioManager.MixState.PURSUIT_PRESSURE,
+		AudioManager.MixState.MEMORY_ECHO,
+	]
+
+func _trigger_thrum() -> void:
+	_armed = false
+	_cooldown_remaining = COOLDOWN_SEC
+	trigger_count += 1
+	last_event = {
+		"directive": DIRECTIVE,
+		"actor": ACTOR,
+		"zone": ZONE,
+		"severity": SEVERITY,
+		"ttl_msec": TTL_MSEC,
+		"trigger_index": trigger_count,
+	}
+
+	_audio.play_event(AudioManager.SoundEvent.FB13_THRUM, _primary.global_position)
+	_pulse_generation += 1
+	var generation := _pulse_generation
+	_pulse_mesh(_primary, generation)
+	_pulse_mesh(_secondary, generation)
+	thrum_triggered.emit(last_event.duplicate(true))
+
+func _pulse_mesh(mesh: MeshInstance3D, generation: int) -> void:
+	if mesh == null:
+		return
+	var original := mesh.material_override as ShaderMaterial
+	if original == null or original.shader == null:
+		return
+	var pulse := original.duplicate() as ShaderMaterial
+	if pulse == null:
+		return
+	var base_color_variant = pulse.get_shader_parameter("base_color")
+	var base_color := base_color_variant as Color if base_color_variant is Color else Color.WHITE
+	pulse.set_shader_parameter("emission_color", base_color)
+	pulse.set_shader_parameter("emission_energy", PULSE_EMISSION_ENERGY)
+	mesh.material_override = pulse
+
+	var tree := get_tree()
+	if tree == null:
+		mesh.material_override = original
+		return
+	tree.create_timer(TTL_SEC).timeout.connect(func() -> void:
+		if generation != _pulse_generation:
+			return
+		if is_instance_valid(mesh):
+			mesh.material_override = original
+	)
+
+func get_world_event_contract() -> Dictionary:
+	return {
+		"version": "fb13_thrum_world_event_v1",
+		"directive": DIRECTIVE,
+		"actor": ACTOR,
+		"zone": ZONE,
+		"severity": SEVERITY,
+		"ttl_msec": TTL_MSEC,
+		"trigger_radius_m": TRIGGER_RADIUS_M,
+		"rearm_radius_m": REARM_RADIUS_M,
+		"cooldown_sec": COOLDOWN_SEC,
+		"primary_resonance_path": "GearsDistrictSlice01B/IndustrialFrontage/CivicUtilityPlate",
+		"secondary_resonance_path": "GearsDistrictSlice01B/IndustrialFrontage/UtilitySpine",
+		"uses_retained_audio_manager": true,
+		"adds_input": false,
+		"adds_mission_state": false,
+		"adds_collision": false,
+		"adds_local_lights": false,
+	}

--- a/godot/tests/camera_mount_transition_test.gd
+++ b/godot/tests/camera_mount_transition_test.gd
@@ -6,9 +6,10 @@ extends SceneTree
 # avoiding the previous timer + manual _process double-step artifact.
 # This dedicated regression is also the reference oracle for the legacy Ticket05 repair.
 # Keep this path in the focused workflow so legacy-oracle repairs are verified before publish.
-# Open World Expansion location-integration contracts run before camera continuity here.
+# Open World Expansion and bounded world-event integration contracts run before camera continuity here.
 const BurnGarageContract = preload("res://tests/mayor_burn_garage_integration_contract.gd")
 const SilentCoreSiteContract = preload("res://tests/silent_core_site_integration_contract.gd")
+const FB13ThrumContract = preload("res://tests/fb13_thrum_world_event_contract.gd")
 
 var _scene_under_test: Node = null
 
@@ -65,6 +66,11 @@ func _run() -> void:
 	var silent_core_error: String = SilentCoreSiteContract.verify(_scene_under_test)
 	if silent_core_error != "":
 		await _fail("[GEARS_DISTRICT_01D] %s" % silent_core_error)
+		return
+
+	var fb13_thrum_error: String = await FB13ThrumContract.verify(_scene_under_test)
+	if fb13_thrum_error != "":
+		await _fail("[FB13_THRUM_WORLD_EVENT] %s" % fb13_thrum_error)
 		return
 
 	var camera := _scene_under_test.get_node_or_null("ChinatownCamera3D")

--- a/godot/tests/fb13_thrum_world_event_contract.gd
+++ b/godot/tests/fb13_thrum_world_event_contract.gd
@@ -1,0 +1,140 @@
+extends RefCounted
+
+const TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
+const PRIMARY_RESONANCE_PATH := "GearsDistrictSlice01B/IndustrialFrontage/CivicUtilityPlate"
+const SECONDARY_RESONANCE_PATH := "GearsDistrictSlice01B/IndustrialFrontage/UtilitySpine"
+
+static func _count_colliders(node: Node) -> int:
+	var count := 1 if node is CollisionShape3D else 0
+	for child in node.get_children():
+		count += _count_colliders(child)
+	return count
+
+static func _count_local_lights(node: Node) -> int:
+	var count := 1 if node is OmniLight3D or node is SpotLight3D else 0
+	for child in node.get_children():
+		count += _count_local_lights(child)
+	return count
+
+static func _verify_toon_target(root: Node, path: String) -> String:
+	var mesh := root.get_node_or_null(path) as MeshInstance3D
+	if mesh == null:
+		return "Required FB-13 resonance target missing: %s" % path
+	var material := mesh.material_override as ShaderMaterial
+	if material == null or material.shader == null:
+		return "FB-13 resonance target has no shader material: %s" % path
+	if material.shader.resource_path != TOON_SHADER_PATH:
+		return "FB-13 resonance target is not using the approved toon shader: %s" % path
+	return ""
+
+static func verify(scene_root: Node) -> String:
+	if scene_root == null:
+		return "Playable scene root is missing"
+
+	var event := scene_root.get_node_or_null("FB13ThrumWorldEvent")
+	if event == null or not event.has_method("get_world_event_contract"):
+		return "FB13ThrumWorldEvent production node/contract is missing"
+	if _count_colliders(event) != 0:
+		return "FB-13 thrum event must not add collision"
+	if _count_local_lights(event) != 0:
+		return "FB-13 thrum event must not add real-time local lights"
+
+	var contract: Dictionary = event.call("get_world_event_contract")
+	if contract.get("directive", "") != "thrum_spike":
+		return "FB-13 world-event directive must be thrum_spike"
+	if contract.get("actor", "") != "FB-13":
+		return "FB-13 world-event actor identity is missing"
+	if contract.get("zone", "") != "gears_industrial_frontage":
+		return "FB-13 world-event zone identity is incorrect"
+	if absf(float(contract.get("severity", -1.0)) - 0.30) > 0.001:
+		return "FB-13 world-event severity must remain 0.30"
+	if int(contract.get("ttl_msec", -1)) != 650:
+		return "FB-13 world-event TTL must remain 650ms"
+	if absf(float(contract.get("trigger_radius_m", 0.0)) - 5.5) > 0.001:
+		return "FB-13 thrum trigger radius must remain 5.5m"
+	if absf(float(contract.get("rearm_radius_m", 0.0)) - 8.0) > 0.001:
+		return "FB-13 thrum rearm radius must remain 8.0m"
+	if absf(float(contract.get("cooldown_sec", 0.0)) - 6.0) > 0.001:
+		return "FB-13 thrum cooldown must remain 6.0s"
+	if contract.get("adds_input", true) != false or contract.get("adds_mission_state", true) != false:
+		return "FB-13 thrum event must not add input or mission state"
+	if contract.get("primary_resonance_path", "") != PRIMARY_RESONANCE_PATH \
+	or contract.get("secondary_resonance_path", "") != SECONDARY_RESONANCE_PATH:
+		return "FB-13 thrum contract points at the wrong production mechanisms"
+
+	for path in [PRIMARY_RESONANCE_PATH, SECONDARY_RESONANCE_PATH]:
+		var target_error := _verify_toon_target(scene_root, path)
+		if target_error != "":
+			return target_error
+
+	var player := scene_root.get_node_or_null("Runner") as Node3D
+	var audio := scene_root.get_node_or_null("AudioManager") as AudioManager
+	var primary := scene_root.get_node_or_null(PRIMARY_RESONANCE_PATH) as MeshInstance3D
+	var secondary := scene_root.get_node_or_null(SECONDARY_RESONANCE_PATH) as MeshInstance3D
+	if player == null or audio == null or primary == null or secondary == null:
+		return "FB-13 thrum runtime dependencies are missing"
+
+	var thrum_event_id := int(AudioManager.SoundEvent.get("FB13_THRUM", -1))
+	if thrum_event_id < 0:
+		return "AudioManager.SoundEvent.FB13_THRUM is missing"
+
+	var original_player_position := player.global_position
+	var original_primary_material := primary.material_override
+	var original_secondary_material := secondary.material_override
+	event.set_process(false)
+	audio.reset_event_counts()
+	audio.set_mix_state(AudioManager.MixState.CALM)
+
+	# Entering from outside must trigger exactly once.
+	player.global_position = primary.global_position + Vector3(0.0, 0.0, 10.0)
+	event.call("_process", 0.10)
+	player.global_position = primary.global_position + Vector3(0.0, 0.0, 1.0)
+	event.call("_process", 0.10)
+	if int(event.get("trigger_count")) != 1:
+		return "FB-13 thrum did not trigger exactly once on zone entry"
+	if audio.get_event_count(thrum_event_id) != 1:
+		return "FB-13 thrum did not route exactly one event through retained AudioManager"
+	if primary.material_override == original_primary_material or secondary.material_override == original_secondary_material:
+		return "FB-13 thrum did not temporarily duplicate both resonance materials"
+
+	# Staying in-zone must not retrigger, and both exact originals must be restored after TTL.
+	event.call("_process", 0.10)
+	if int(event.get("trigger_count")) != 1:
+		return "FB-13 thrum retriggered while the player remained inside the zone"
+	await scene_root.get_tree().create_timer(0.75).timeout
+	if primary.material_override != original_primary_material or secondary.material_override != original_secondary_material:
+		return "FB-13 thrum failed to restore the exact original mechanism materials after TTL"
+
+	# Leave + cooldown + re-entry must permit a second event.
+	player.global_position = primary.global_position + Vector3(0.0, 0.0, 10.0)
+	event.call("_process", 6.10)
+	player.global_position = primary.global_position + Vector3(0.0, 0.0, 1.0)
+	event.call("_process", 0.10)
+	if int(event.get("trigger_count")) != 2 or audio.get_event_count(thrum_event_id) != 2:
+		return "FB-13 thrum did not rearm after leaving the zone and clearing cooldown"
+	await scene_root.get_tree().create_timer(0.75).timeout
+
+	# Priority audio states suppress without consuming the armed state.
+	player.global_position = primary.global_position + Vector3(0.0, 0.0, 10.0)
+	event.call("_process", 6.10)
+	player.global_position = primary.global_position + Vector3(0.0, 0.0, 1.0)
+	for blocked_state in [
+		AudioManager.MixState.DISTURBANCE,
+		AudioManager.MixState.PURSUIT_PRESSURE,
+		AudioManager.MixState.MEMORY_ECHO,
+	]:
+		audio.current_mix_state = blocked_state
+		event.call("_process", 0.10)
+		if int(event.get("trigger_count")) != 2:
+			return "FB-13 thrum consumed or triggered during retained priority audio state %s" % blocked_state
+
+	audio.current_mix_state = AudioManager.MixState.CALM
+	event.call("_process", 0.10)
+	if int(event.get("trigger_count")) != 3 or audio.get_event_count(thrum_event_id) != 3:
+		return "FB-13 thrum failed to remain armed after priority-state suppression"
+	await scene_root.get_tree().create_timer(0.75).timeout
+
+	player.global_position = original_player_position
+	audio.current_mix_state = AudioManager.MixState.CALM
+	event.set_process(true)
+	return ""


### PR DESCRIPTION
Adds a bounded authored FB-13 infrastructure-thrum world event using existing Gears geography and retained AudioManager ownership.

Scope is intentionally narrow: calm-state proximity trigger at the existing industrial frontage, one appended spatial FB13_THRUM sound event, brief pulse/restore of two existing toon-shaded mechanism materials, hysteresis/cooldown, and no new acreage, companion AI, input, mission state, collision, lights, HUD, network event bus, combat, or generalized world-event framework.

Current branch is intentionally RED: exact-head scene CI now requires the production event node, audio routing/count, pulse lifecycle, rearm/cooldown, and priority-state suppression before implementation exists.

Human/windowed listening and fresh retained-camera visual observation remain explicit perceptual verification debt rather than silently claimed.