### PR TITLE
Open World Expansion 01E — retire proof-only production rendering

### DIFF
--- a/contracts/open_world_expansion_01e_proof_render_retirement_spec.md
+++ b/contracts/open_world_expansion_01e_proof_render_retirement_spec.md
@@ -1,0 +1,62 @@
+# Open World Expansion 01E — Proof Render Retirement
+
+**State:** READY_FOR_IMPLEMENTATION  
+**Baseline:** `main@e77eb6c330e984e31f862c8d45b456a205a0f2cc`  
+**Predecessors:** Open World Expansion 01B–01D and Gears Verification Debt Checkpoint / PR #71
+
+## Objective
+
+Reduce production render overhead before adding more district content by retiring the completed Issue #60 `GearsStyleProof` composition from normal gameplay rendering while preserving its standalone proof artifact, its executable contract, and the actor/interactable style treatments that current production presentation still receives from the mounted proof controller.
+
+The post-PR #71 exact-main verification report measured the combined Gears additions at `+173` draw calls, `+2,376` primitives and `+173` objects versus the same-host retained-yard control. The proof-only composition is still mounted visibly alongside the real `GearsDistrictSlice01B`; 01E removes that redundant rendered layer rather than adding acreage or redesigning the production slice.
+
+## Production contract
+
+In `godot/scenes/prototype/scrap_test_block.tscn`:
+
+- keep the `GearsStyleProof` instance mounted;
+- set the production instance root `visible = false`;
+- keep `GearsDistrictSlice01B` mounted and visible;
+- do not delete, rename, move or rewrite `godot/scenes/world/gears_style_proof.tscn`;
+- do not disable the proof controller script, because its deferred actor/interactable treatment remains the current bounded style-treatment authority;
+- do not change the retained 32-degree camera, routes, mission sockets, collisions, vehicles, pursuit, input, HUD, audio, save state, or mission state machines.
+
+The proof root being hidden must suppress proof-only mixed-use/route/gantry/storefront/relay meshes and proof practical lights from normal production rendering while leaving sibling actor treatment meshes/materials visible.
+
+## Verification contract
+
+Exact-head CI must verify in the real playable scene that:
+
+1. `GearsStyleProof` still exists and exposes `get_proof_contract()` and `set_lighting_mode()`;
+2. all existing Issue #60 proof composition nodes still exist for standalone/reference inspection;
+3. all existing required actor/interactable treatment metadata, contours and bounded identity markings remain present;
+4. production `GearsStyleProof.visible == false`;
+5. production `GearsDistrictSlice01B.visible == true`;
+6. the production district's 01B–01D contract remains green;
+7. retained camera and canonical compatibility suites remain green.
+
+The verification capture harness must preserve the production proof visibility state when taking current/control structural snapshots; it must not force the retired proof composition visible after measurement.
+
+## Post-merge evidence
+
+After merge, require the ordinary exact-main verification publication to be current and compare its structural report to the PR #71 baseline:
+
+- baseline Gears delta: `+173 draw calls`, `+2,376 primitives`, `+173 objects`;
+- expected direction: draw-call and rendered-object deltas must materially decrease while the nine retained-camera views remain visually coherent;
+- do not claim native frame-time improvement from Linux/Xvfb single-frame smoke timing.
+
+If hiding the proof composition causes a material visual-readability regression in the published nine-frame sheet, route to REPAIR rather than retaining the performance change by fiat.
+
+## Non-goals
+
+- no new acreage;
+- no new authored location;
+- no mesh batching/MultiMesh conversion;
+- no material redesign;
+- no deletion of Issue #60 evidence;
+- no new gameplay or framework authority;
+- no claim that this closes native desktop average/P95 timing or human FB-13 listening debt.
+
+## Completion recommendation
+
+If 01E reduces structural render cost without a material visual regression, resume content development using existing geography first. Prefer a bounded authored gameplay/narrative use of the current district before any further acreage expansion.

--- a/godot/scenes/prototype/scrap_test_block.tscn
+++ b/godot/scenes/prototype/scrap_test_block.tscn
@@ -218,6 +218,7 @@ script = ExtResource("9_ui_audio")
 [node name="ScrapYardDressing" parent="." instance=ExtResource("7_dressing")]
 
 [node name="GearsStyleProof" parent="." instance=ExtResource("13_gears")]
+visible = false
 
 [node name="GearsDistrictSlice01B" parent="." instance=ExtResource("14_gears_district")]
 

--- a/godot/tests/camera_mount_transition_test.gd
+++ b/godot/tests/camera_mount_transition_test.gd
@@ -10,6 +10,7 @@ extends SceneTree
 const BurnGarageContract = preload("res://tests/mayor_burn_garage_integration_contract.gd")
 const SilentCoreSiteContract = preload("res://tests/silent_core_site_integration_contract.gd")
 const FB13ThrumContract = preload("res://tests/fb13_thrum_world_event_contract.gd")
+const ProofRenderRetirementContract = preload("res://tests/gears_proof_render_retirement_contract.gd")
 
 var _scene_under_test: Node = null
 
@@ -71,6 +72,11 @@ func _run() -> void:
 	var fb13_thrum_error: String = await FB13ThrumContract.verify(_scene_under_test)
 	if fb13_thrum_error != "":
 		await _fail("[FB13_THRUM_WORLD_EVENT] %s" % fb13_thrum_error)
+		return
+
+	var retirement_error: String = ProofRenderRetirementContract.verify(_scene_under_test)
+	if retirement_error != "":
+		await _fail("[GEARS_DISTRICT_01E] %s" % retirement_error)
 		return
 
 	var camera := _scene_under_test.get_node_or_null("ChinatownCamera3D")

--- a/godot/tests/gears_proof_render_retirement_contract.gd
+++ b/godot/tests/gears_proof_render_retirement_contract.gd
@@ -1,0 +1,51 @@
+extends RefCounted
+
+## Open World Expansion 01E: retire the completed Issue #60 proof composition
+## from production rendering while preserving the proof artifact/controller and
+## the real district slice.
+
+static func verify(scene_root: Node) -> String:
+	if scene_root == null:
+		return "Playable scene root is missing"
+
+	var proof := scene_root.get_node_or_null("GearsStyleProof") as Node3D
+	if proof == null:
+		return "Mounted GearsStyleProof artifact is missing"
+	if not proof.has_method("get_proof_contract") or not proof.has_method("set_lighting_mode"):
+		return "Mounted GearsStyleProof no longer exposes its reference contract"
+
+	var district := scene_root.get_node_or_null("GearsDistrictSlice01B") as Node3D
+	if district == null:
+		return "Production GearsDistrictSlice01B is missing"
+	if not district.visible:
+		return "Production GearsDistrictSlice01B must remain visible"
+
+	if proof.visible:
+		return "Proof-only GearsStyleProof composition is still visible in production"
+
+	for node_path in [
+		"MixedUseBlock",
+		"PrimaryRouteBand",
+		"ShortcutRouteBand",
+		"MunicipalGantry",
+		"Storefront",
+		"DistantRelay",
+		"PracticalLights",
+	]:
+		if proof.get_node_or_null(node_path) == null:
+			return "Retired proof artifact lost reference node: %s" % node_path
+
+	for actor_path in [
+		"Runner",
+		"CourierBike",
+		"ScrapHauler",
+		"PursuerPrototype",
+		"ScrapWorker1",
+		"UtilityCrawler",
+		"CorrodedPanel",
+	]:
+		var actor := scene_root.get_node_or_null(actor_path)
+		if actor == null or not actor.has_meta("gears_style_proof_treatment"):
+			return "Retiring proof rendering removed style treatment from %s" % actor_path
+
+	return ""

--- a/godot/tests/gears_verification_capture.gd
+++ b/godot/tests/gears_verification_capture.gd
@@ -184,17 +184,19 @@ func _capture_and_measure() -> String:
 
 	_proof.call("set_lighting_mode", "day")
 	_place_player(Vector3(-1.5, 0.20, -18.0))
+	var proof_visible_before := _proof.visible
+	var district_visible_before := _district.visible
 	var full_current := await _measure_render_snapshot("full_current")
 	_proof.visible = false
 	_district.visible = false
 	_camera.call("reset_camera_instant", _player)
 	var retained_control := await _measure_render_snapshot("retained_yard_control")
-	_proof.visible = true
-	_district.visible = true
+	_proof.visible = proof_visible_before
+	_district.visible = district_visible_before
 
 	var viewport := get_viewport()
 	var report := {
-		"schema_version": 9,
+		"schema_version": 10,
 		"source_sha": OS.get_environment("SOURCE_SHA"),
 		"generated_utc": Time.get_datetime_string_from_system(true),
 		"godot_version": Engine.get_version_info().get("string", "unknown"),
@@ -209,6 +211,8 @@ func _capture_and_measure() -> String:
 			"mode": "single_frame_same_host_structural_snapshot",
 			"frame_time_scope": "advisory_smoke_only",
 			"native_avg_p95_status": "deferred_requires_native_runtime",
+			"production_proof_visible": proof_visible_before,
+			"production_district_visible": district_visible_before,
 			"full_current": full_current,
 			"retained_yard_control": retained_control,
 			"delta_full_minus_control": _telemetry_delta(full_current, retained_control),


### PR DESCRIPTION
Retires the completed Issue #60 Gears style-proof composition from normal production rendering while preserving the mounted proof artifact/controller and actor style treatments. TDD state on opening: intentionally RED until `GearsStyleProof.visible` is disabled in the production main scene. No acreage, gameplay, mission, camera, vehicle, pursuit, input, HUD, audio, or save-state authority changes.