### PR TITLE
01E repair — restore production dusk practicals

### DIFF
--- a/contracts/01e_dusk_practical_repair_spec.md
+++ b/contracts/01e_dusk_practical_repair_spec.md
@@ -1,0 +1,48 @@
+# 01E Repair — Production Dusk Practicals
+
+**State:** READY_FOR_IMPLEMENTATION  
+**Baseline:** `main@da6755e7d066e16d7598d3f339b7cff3eb1adbcc`  
+**Trigger evidence:** native Apple M4 / macOS / Godot 4.7.1 verification of exact baseline reported `PASS WITH FINDINGS`: day/dusk directional sun transition worked, but `StoreWorkLamp`, `GantryServiceLamp`, and `RelayMarkerLamp` were suppressed because they remained under hidden `GearsStyleProof`.
+
+## Objective
+
+Restore the approved dusk practical-light hierarchy without undoing Open World Expansion 01E's proof-render retirement or its structural performance win.
+
+## Production contract
+
+- Keep `GearsStyleProof.visible = false` in `scrap_test_block.tscn`.
+- Keep the standalone proof scene and its three proof practical lights unchanged for Issue #60 reference/testing.
+- Add one `PracticalLights` node under `GearsDistrictSlice01B` containing exactly three production `OmniLight3D` instances named:
+  - `StoreWorkLamp`
+  - `GantryServiceLamp`
+  - `RelayMarkerLamp`
+- Place the production practicals at authored production geography: Mayor Burn/commercial frontage, the civic industrial intersection, and the Silent Core/relay infrastructure pocket respectively.
+- Preserve the approved energies:
+  - day: `1.0`, `0.8`, `0.35`
+  - dusk: `1.55`, `1.24`, `0.54`
+- Preserve warm commercial/civic practical colors for Store/Gantry and restrained cyan for Relay.
+- Update the existing `GearsStyleProof.set_lighting_mode()` authority to target production district practicals when mounted in the playable scene, with fallback to the proof scene's own practicals when inspected standalone.
+- Do not add meshes, collisions, acreage, gameplay state, mission state, input, HUD, audio, save-state, pursuit or vehicle authority.
+
+## Verification contract
+
+Exact-head tests must prove:
+
+1. `GearsStyleProof` remains hidden in production.
+2. `GearsDistrictSlice01B` remains visible.
+3. `GearsDistrictSlice01B/PracticalLights` exists with exactly the three required lights.
+4. All three production practicals are visible and non-shadow-casting.
+5. Day mode drives production energies to `1.0 / 0.8 / 0.35`.
+6. Dusk mode drives production energies to `1.55 / 1.24 / 0.54`.
+7. The proof artifact still retains its own three reference practical lights.
+8. Existing 01B–01E, camera, mission, FB-13 and compatibility tests remain green.
+9. Fresh published nine-state verification preserves the 01E structural win and shows a materially restored dusk practical hierarchy without visual clutter.
+
+## Non-goals
+
+- no re-showing proof geometry;
+- no new light framework or day/night system;
+- no shadow-casting practical lights;
+- no new locations or acreage;
+- no audio changes;
+- no claim that this changes native frame-time qualification beyond the existing local evidence.

--- a/godot/scenes/world/gears_district_slice_01b.tscn
+++ b/godot/scenes/world/gears_district_slice_01b.tscn
@@ -425,6 +425,29 @@ position = Vector3(0, 0.15, 0.55)
 [node name="MissionDestinationSocket" type="Marker3D" parent="."]
 position = Vector3(-10, 0.2, -41.5)
 
+[node name="PracticalLights" type="Node3D" parent="."]
+
+[node name="StoreWorkLamp" type="OmniLight3D" parent="PracticalLights"]
+position = Vector3(-11.3, 2.8, -40.8)
+light_color = Color(1, 0.839, 0.541, 1)
+light_energy = 1.0
+omni_range = 5.0
+shadow_enabled = false
+
+[node name="GantryServiceLamp" type="OmniLight3D" parent="PracticalLights"]
+position = Vector3(-3.0, 3.6, -22.5)
+light_color = Color(1, 0.882, 0.659, 1)
+light_energy = 0.8
+omni_range = 4.5
+shadow_enabled = false
+
+[node name="RelayMarkerLamp" type="OmniLight3D" parent="PracticalLights"]
+position = Vector3(6.2, 1.8, -27.8)
+light_color = Color(0.486, 0.812, 0.816, 1)
+light_energy = 0.35
+omni_range = 3.0
+shadow_enabled = false
+
 [node name="ExpansionEdgeBarrier" type="StaticBody3D" parent="."]
 position = Vector3(-4.5, 0.75, -48.25)
 

--- a/godot/scripts/visual/gears_district_slice_01b.gd
+++ b/godot/scripts/visual/gears_district_slice_01b.gd
@@ -137,6 +137,7 @@ func get_production_contract() -> Dictionary:
 
 	var current_meshes := _count_meshes(self)
 	var current_colliders := _count_colliders(self)
+	var current_lights := _count_local_lights(self)
 	var extension_meshes := _count_extension_meshes()
 	var extension_colliders := _count_extension_colliders()
 
@@ -156,13 +157,15 @@ func get_production_contract() -> Dictionary:
 		"primary_route_width_m": road_shape.size.x if road_shape != null else 0.0,
 		"service_alley_width_m": alley_shape.size.x if alley_shape != null else 0.0,
 		"northbound_depth_m": northbound_depth,
-		# Preserve the original 01B budget as a historical contract while later
-		# authored locations report their own incremental budgets and cumulative totals.
+		# Preserve the original 01B budgets as historical contracts while later
+		# authored locations/lighting report their own additive and cumulative totals.
 		"mesh_instances": current_meshes - extension_meshes,
 		"collision_shapes": current_colliders - extension_colliders,
+		"local_lights": 0,
 		"current_mesh_instances": current_meshes,
 		"current_collision_shapes": current_colliders,
+		"current_local_lights": current_lights,
 		"extension_mesh_instances": extension_meshes,
 		"extension_collision_shapes": extension_colliders,
-		"local_lights": _count_local_lights(self),
+		"extension_local_lights": current_lights,
 	}

--- a/godot/scripts/visual/gears_style_proof.gd
+++ b/godot/scripts/visual/gears_style_proof.gd
@@ -210,9 +210,15 @@ func _resolve_practical_light(node_name: String) -> OmniLight3D:
 	return get_node_or_null("PracticalLights/%s" % node_name) as OmniLight3D
 
 func _set_practical_energy(node_name: String, energy: float) -> void:
-	var light := _resolve_practical_light(node_name)
-	if light != null:
-		light.light_energy = energy
+	var active_light := _resolve_practical_light(node_name)
+	if active_light != null:
+		active_light.light_energy = energy
+	# Keep the hidden Issue #60 reference light in sync so standalone/reference
+	# contracts remain deterministic. Its hidden parent means this does not add a
+	# second rendered light in production.
+	var reference_light := get_node_or_null("PracticalLights/%s" % node_name) as OmniLight3D
+	if reference_light != null and reference_light != active_light:
+		reference_light.light_energy = energy
 
 func set_lighting_mode(mode: String) -> void:
 	var scene_root := get_parent()

--- a/godot/scripts/visual/gears_style_proof.gd
+++ b/godot/scripts/visual/gears_style_proof.gd
@@ -199,8 +199,18 @@ func _apply_actor_treatments() -> void:
 		if actor != null:
 			actor.set_meta("gears_style_proof_treatment", true)
 
+func _resolve_practical_light(node_name: String) -> OmniLight3D:
+	var scene_root := get_parent()
+	if scene_root != null:
+		var production_light := scene_root.get_node_or_null(
+			"GearsDistrictSlice01B/PracticalLights/%s" % node_name
+		) as OmniLight3D
+		if production_light != null:
+			return production_light
+	return get_node_or_null("PracticalLights/%s" % node_name) as OmniLight3D
+
 func _set_practical_energy(node_name: String, energy: float) -> void:
-	var light := get_node_or_null("PracticalLights/%s" % node_name) as OmniLight3D
+	var light := _resolve_practical_light(node_name)
 	if light != null:
 		light.light_energy = energy
 

--- a/godot/tests/gears_proof_render_retirement_contract.gd
+++ b/godot/tests/gears_proof_render_retirement_contract.gd
@@ -70,6 +70,14 @@ static func verify(scene_root: Node) -> String:
 	if production_practicals.get_child_count() != 3:
 		return "Production district must own exactly three practical lights"
 
+	var district_contract: Dictionary = district.call("get_production_contract")
+	if int(district_contract.get("local_lights", -1)) != 0:
+		return "Historical 01B local-light budget must remain zero"
+	if int(district_contract.get("current_local_lights", -1)) != 3:
+		return "Current district must report exactly three production practical lights"
+	if int(district_contract.get("extension_local_lights", -1)) != 3:
+		return "Later additive lighting must report exactly three extension lights"
+
 	for light_name in DAY_ENERGIES:
 		var light := production_practicals.get_node_or_null(str(light_name)) as OmniLight3D
 		if light == null:

--- a/godot/tests/gears_proof_render_retirement_contract.gd
+++ b/godot/tests/gears_proof_render_retirement_contract.gd
@@ -1,8 +1,33 @@
 extends RefCounted
 
-## Open World Expansion 01E: retire the completed Issue #60 proof composition
-## from production rendering while preserving the proof artifact/controller and
-## the real district slice.
+## Open World Expansion 01E + dusk practical repair: retire the completed Issue
+## #60 proof composition from production rendering while preserving its
+## controller/treatments and moving the required dusk practicals into the real
+## production district.
+
+const DAY_ENERGIES := {
+	"StoreWorkLamp": 1.0,
+	"GantryServiceLamp": 0.8,
+	"RelayMarkerLamp": 0.35,
+}
+const DUSK_ENERGIES := {
+	"StoreWorkLamp": 1.55,
+	"GantryServiceLamp": 1.24,
+	"RelayMarkerLamp": 0.54,
+}
+
+static func _approx_equal(a: float, b: float) -> bool:
+	return absf(a - b) <= 0.001
+
+static func _verify_mode(proof: Node3D, practicals: Node3D, mode: String, expected: Dictionary) -> String:
+	proof.call("set_lighting_mode", mode)
+	for light_name in expected:
+		var light := practicals.get_node_or_null(str(light_name)) as OmniLight3D
+		if light == null:
+			return "Production practical light is missing: %s" % light_name
+		if not _approx_equal(light.light_energy, float(expected[light_name])):
+			return "%s energy mismatch in %s mode: %.3f" % [light_name, mode, light.light_energy]
+	return ""
 
 static func verify(scene_root: Node) -> String:
 	if scene_root == null:
@@ -34,6 +59,34 @@ static func verify(scene_root: Node) -> String:
 	]:
 		if proof.get_node_or_null(node_path) == null:
 			return "Retired proof artifact lost reference node: %s" % node_path
+
+	var proof_practicals := proof.get_node_or_null("PracticalLights") as Node3D
+	if proof_practicals == null or proof_practicals.get_child_count() != 3:
+		return "Standalone proof must retain exactly three reference practical lights"
+
+	var production_practicals := district.get_node_or_null("PracticalLights") as Node3D
+	if production_practicals == null:
+		return "Production district is missing PracticalLights"
+	if production_practicals.get_child_count() != 3:
+		return "Production district must own exactly three practical lights"
+
+	for light_name in DAY_ENERGIES:
+		var light := production_practicals.get_node_or_null(str(light_name)) as OmniLight3D
+		if light == null:
+			return "Production practical light is missing: %s" % light_name
+		if not light.visible:
+			return "Production practical light must remain visible: %s" % light_name
+		if light.shadow_enabled:
+			return "Production practical light must remain non-shadow-casting: %s" % light_name
+
+	var day_error := _verify_mode(proof, production_practicals, "day", DAY_ENERGIES)
+	if not day_error.is_empty():
+		return day_error
+	var dusk_error := _verify_mode(proof, production_practicals, "dusk", DUSK_ENERGIES)
+	if not dusk_error.is_empty():
+		return dusk_error
+	# Leave the shared production scene in its default day state after contract verification.
+	proof.call("set_lighting_mode", "day")
 
 	for actor_path in [
 		"Runner",


### PR DESCRIPTION
Repairs the native verification finding from exact main da6755e7: 01E hid the completed proof composition correctly, but its three practical lights were hidden with it. This PR keeps GearsStyleProof retired, adds three production practicals to GearsDistrictSlice01B, and makes the existing set_lighting_mode authority target production lights with proof-scene fallback. Opened intentionally RED until implementation lands.