### PR TITLE
Audio Production 01M — Yardline Station Identity & Sweeper Pack

### DIFF
--- a/contracts/audio_production_01m_yardline_station_identity_sweeper_spec.md
+++ b/contracts/audio_production_01m_yardline_station_identity_sweeper_spec.md
@@ -1,6 +1,6 @@
 # Audio Production 01M — Yardline Station Identity & Sweeper Pack
 
-**State:** CANDIDATE_SELECTION_REQUIRED  
+**State:** SOURCES_SELECTED__PRODUCTION_INGESTION_AUTHORIZED  
 **Baseline:** `main@860073387f87c696f3dc8ff2f063dc0105f88982`
 
 ## Objective
@@ -11,13 +11,146 @@ Replace three live Yardline 88.3 procedural interstitial identities with product
 2. `radio.yardline.station_id_01` — primary Yardline signature jingle / station ID;
 3. `radio.yardline.station_id_02` — compact Yardline sting / alternate station ID.
 
-01M is a **candidate-selection workstream first**. During search and audition, no production radio asset, registry promotion, runtime stream-resolution change, director weight change, scheduler change, new player, new station, or gameplay behavior is authorized.
+Human candidate audition is complete. The three winners below are now locked and production ingestion of exactly those winners is authorized. No substitute source, runner-up promotion, layering, resampling, pitch-shifting, normalization, EQ, compression, reverb, time-stretching, or other identity-changing treatment is authorized without a new accepted selection decision.
+
+## Locked production selections
+
+### Target A — `radio.yardline.dj_sweeper`
+
+**Selected source:** `GTA_SA:GENRL:BANK_44:SOUND_2`
+
+- format: mono PCM16;
+- native sample rate: `18,000 Hz`;
+- frame count: `8,016`;
+- natural duration: `0.4453 s`;
+- raw bytes: `16,032`;
+- peak: `-2.00 dB`;
+- RMS: `-15.57 dB`;
+- approximate dominant frequency: `1,265 Hz`;
+- raw SHA-256: `188837f05074b791060d41d5265851be7ef84b443c54b4f42d8fd40f941022b3`;
+- listening identity: crisp rising radio blip / broadcast sweep, fast and lightweight between track segments;
+- start/end: clean natural transient/decay with zero boundary click;
+- small-speaker readability: PASS, dominant ~1.2 kHz presence;
+- repeated-session fatigue: PASS, 20 repetitions in simulated radio flow;
+- engine + Wind compatibility: PASS;
+- pursuit-duck / Echo-contamination compatibility: PASS;
+- semantic distinction from both station IDs and gameplay cues: PASS;
+- authorized edge treatment: **none**; preserve natural source boundary exactly.
+
+**Runner-up:** `GTA_SA:SCRIPT:BANK_356:SOUND_16`
+
+- mono PCM16;
+- `15,000 Hz`;
+- `9,909` frames;
+- `0.6606 s`;
+- `19,818` bytes;
+- peak `-2.00 dB`;
+- RMS `-14.36 dB`;
+- raw SHA-256: `621aa1348b7d2e9bcdf40d10658e97b456ef594c925e983102a83342e5cc3c0b`.
+
+Runner-up remains audition evidence only and is not authorized for production ingestion while the selected source remains available and valid.
+
+Canonical production path:
+
+`res://audio/radio/rad_yardline_dj_sweeper.wav`
+
+### Target B — `radio.yardline.station_id_01`
+
+**Selected source:** `GTA_SA:GENRL:BANK_44:SOUND_3`
+
+- format: mono PCM16;
+- native sample rate: `18,000 Hz`;
+- frame count: `18,176`;
+- natural duration: `1.0098 s`;
+- raw bytes: `36,352`;
+- peak: `-2.00 dB`;
+- RMS: `-16.30 dB`;
+- approximate dominant frequency: `995 Hz`;
+- raw SHA-256: `a742e3d686fcfa91f8b643e0a820580a78dcd40db34f4c73ce517c894340c842`;
+- listening identity: complete micro-jingle / resonant transmitter signature ident with warm analog broadcast character;
+- start/end: smooth onset and natural decay with zero click;
+- small-speaker readability: PASS, rich ~900 Hz–2.5 kHz harmonics;
+- repeated-session fatigue: PASS, 15 iterations across a 10-minute simulated session;
+- engine + Wind compatibility: PASS;
+- pursuit-duck / Echo-contamination compatibility: PASS;
+- semantic distinction from Sweeper, ID 02, and gameplay cues: PASS;
+- authorized edge treatment: **none**; preserve natural source boundary exactly.
+
+**Runner-up:** `GTA_SA:SCRIPT:BANK_356:SOUND_2`
+
+- mono PCM16;
+- `15,000 Hz`;
+- `28,244` frames;
+- `1.8829 s`;
+- `56,488` bytes;
+- peak `-2.00 dB`;
+- RMS `-14.81 dB`;
+- raw SHA-256: `96677f627d502e1650f48841b00ab828f1117ddef117c36b00093f8fb85854a1`.
+
+Runner-up remains audition evidence only and is not authorized for production ingestion while the selected source remains available and valid.
+
+Canonical production path:
+
+`res://audio/radio/rad_yardline_station_id_01.wav`
+
+### Target C — `radio.yardline.station_id_02`
+
+**Selected source:** `GTA_SA:GENRL:BANK_44:SOUND_4`
+
+- format: mono PCM16;
+- native sample rate: `18,000 Hz`;
+- frame count: `11,872`;
+- natural duration: `0.6596 s`;
+- raw bytes: `23,744`;
+- peak: `-2.00 dB`;
+- RMS: `-16.35 dB`;
+- approximate dominant frequency: `943 Hz`;
+- raw SHA-256: `7550cdb3f12086f78bea71b752b0edbd5e1f46b1e83136c459de5cc978d99051`;
+- listening identity: compact punchy secondary station sting with the same broadcast acoustic family as ID 01 and a shorter sharper envelope;
+- start/end: clean transient and rapid natural decay with zero edge noise;
+- small-speaker readability: PASS, articulate ~900 Hz–3 kHz band;
+- repeated-session fatigue: PASS, alternated 20 times against ID 01 and Sweeper;
+- engine + Wind compatibility: PASS;
+- pursuit-duck / Echo-contamination compatibility: PASS;
+- semantic distinction from Sweeper, ID 01, and gameplay/UI cues: PASS;
+- authorized edge treatment: **none**; preserve natural source boundary exactly.
+
+**Runner-up:** `GTA_SA:SCRIPT:BANK_356:SOUND_13`
+
+- mono PCM16;
+- `12,000 Hz`;
+- `8,534` frames;
+- `0.7112 s`;
+- `17,068` bytes;
+- peak `-2.00 dB`;
+- RMS `-18.42 dB`;
+- raw SHA-256: `a3c7719ce246781d50c261898890aced94d0fb632064cc1e51b01846b536b4f5`.
+
+Runner-up remains audition evidence only and is not authorized for production ingestion while the selected source remains available and valid.
+
+Canonical production path:
+
+`res://audio/radio/rad_yardline_station_id_02.wav`
+
+## Pack-level audition result
+
+Human source audition and discrimination result:
+
+- Sweeper vs Station ID 01: PASS;
+- Sweeper vs Station ID 02: PASS;
+- Station ID 01 vs Station ID 02: PASS;
+- all-three family coherence: PASS — cohesive `18 kHz` broadcast package from `GENRL:BANK_44`;
+- all-three semantic distinction: PASS;
+- 10-minute repetition fatigue: PASS;
+- extraction / staging integrity: PASS.
+
+The source-selection checkpoint therefore passes. These results authorize production ingestion of the three exact `GENRL:BANK_44` winners above, while final production acceptance still requires repository ingestion, exact-head automated verification, and exact-head native gameplay listening.
 
 ## Current runtime authority on baseline main
 
 All three targets already exist in `AudioRegistry` and `RadioStationCatalog` and are reachable through the current Yardline program.
 
-Shared registry authority for all three:
+Shared registry authority before production integration:
 
 - domain: `RADIO`;
 - diegesis: `DIEGETIC`;
@@ -76,12 +209,12 @@ Catalog authority:
 - pursuit/critical ducking;
 - Echo radio-contamination ducking.
 
-The current candidate-stage resolution path is:
+The pre-production resolution path is:
 
 1. optional developer-local `AudioReferenceResolver` stream for the current semantic slot when reference mode is permitted and enabled;
 2. otherwise `_synthesize_segment_audio()` procedural fallback.
 
-The production integration after source lock may add one narrow registry-production resolution step for the three selected slots, but must preserve the same player and all current program/lifecycle/mix ownership.
+The authorized production integration may add one narrow registry-production resolution step for the three selected slots, but must preserve the same player and all current program/lifecycle/mix ownership.
 
 `RadioProgramDirector` authority is out of scope and must remain unchanged, including:
 
@@ -96,256 +229,142 @@ The production integration after source lock may add one narrow registry-product
 
 ## Identity direction
 
-Yardline 88.3 is an experimental pirate/scrap relay. These three clips should establish a coherent broadcast signature without sounding like generic menu UI, police dispatch, a conventional commercial FM package, or a copied GTA station identity.
+Yardline 88.3 is an experimental pirate/scrap relay. These three locked clips establish a coherent broadcast signature without sounding like generic menu UI, police dispatch, a conventional commercial FM package, or copied spoken GTA station identity.
 
-Shared desired character:
+Shared accepted character:
 
 - reclaimed transmitter / pirate relay;
 - compact analog-electrical or industrial broadcast texture;
 - memorable in the `300 Hz–4 kHz` small-speaker band;
-- clear enough under vehicle engine and scrapyard Wind;
+- clear under vehicle engine and scrapyard Wind;
 - leaves room for program music, DJ links, pursuit alerts, and Memory Echo contamination;
-- no intelligible GTA station names, characters, slogans, dialogue, or recognizable musical branding;
-- no source that reads as a gameplay warning, Signal Lock confirmation, Disturbance Alert, Evasion Release, or Memory Echo signature.
+- no intelligible GTA station names, characters, slogans, or dialogue;
+- no source reads as Signal Lock confirmation, Disturbance Alert, Evasion Release, Gate Slam, or Memory Echo signature.
 
-## Target A — `radio.yardline.dj_sweeper`
+## Owner-authorized source boundary
 
-Desired identity:
+The owner-authorized GTA San Andreas production-audio exception applies to exactly the three locked winners above.
 
-- fastest and lightest of the three;
-- reads as a transition/sweep rather than a full station ID;
-- useful between program elements without demanding attention;
-- short rising/falling RF motion, relay chirp, tape/electrical sweep, or compact broadcast transition texture;
-- should tolerate frequent recurrence without fatigue.
+Exact provenance must be recorded in `AudioRegistry` at ingestion:
 
-Preferred natural source length:
+- Sweeper: `GTA_SA:GENRL:BANK_44:SOUND_2`;
+- Station ID 01: `GTA_SA:GENRL:BANK_44:SOUND_3`;
+- Station ID 02: `GTA_SA:GENRL:BANK_44:SOUND_4`.
 
-`0.25–1.2 s`
+Candidate staging, runner-ups, source archives, machine-specific paths, and bulk library material remain local/gitignored and must not enter Git.
 
-Reject:
+Project-internal `LICENSED_FINAL` records the accepted project production lifecycle state and exact provenance; it is not an independent legal/license-clearance claim.
 
-- spoken dialogue;
-- recognizable radio station branding;
-- alarm/siren identity;
-- long reverb tail that masks following content;
-- hard impact that reads as collision/gameplay feedback;
-- tonal confirmation ping too close to Signal Lock;
-- clip that becomes irritating when heard repeatedly in a 10-minute radio session.
+## Production treatment lock
 
-Audition:
+All three winners passed clean-boundary audition without repair. Production ingestion must therefore preserve the selected source bytes and technical identity except for container/header changes that are unavoidable to place the same PCM payload in the canonical repository file.
 
-- repeat 20 times with 1–4 second gaps;
-- place immediately before and after representative Yardline song fallback material;
-- audition under engine + Wind at moderate driving level;
-- audition with approximately `-7 dB` and `-13 dB` pursuit duck;
-- audition with up to `-4 dB` Echo contamination;
-- verify clean start/end with no click and no tail collision into the next segment.
+Required:
 
-## Target B — `radio.yardline.station_id_01`
+- mono PCM16;
+- native `18,000 Hz` sample rate;
+- exact natural frame count and duration for each source;
+- non-looping playback;
+- no fade-in/fade-out added;
+- no normalization or gain bake;
+- no EQ;
+- no compression/limiting;
+- no reverb/delay;
+- no resampling;
+- no time stretching;
+- no pitch shifting;
+- no source layering.
 
-Desired identity:
+Final repository WAV SHA-256 may differ from the audition raw SHA only if the extraction tooling produces a different but PCM-equivalent WAV header/container. The production contract must validate the exact PCM technical metadata and record the final repository-file SHA separately. If the extracted canonical file is byte-identical to the audition WAV, the raw SHA should match exactly.
 
-- primary station signature;
-- strongest and most memorable of the pack;
-- a complete micro-jingle or transmitter ident, not merely a UI chime;
-- recognizably related to the sweeper and alternate ID while still distinct;
-- confident but not louder/more urgent than critical gameplay cues.
+## Authorized production ingestion and integration
 
-Preferred natural source length:
+Production ingestion of the three locked winners is now authorized.
 
-`0.7–2.5 s`
+Implementation may:
 
-Reject:
+1. add only these three finalized files under `res://audio/radio/`:
+   - `radio.yardline.dj_sweeper` -> `res://audio/radio/rad_yardline_dj_sweeper.wav`;
+   - `radio.yardline.station_id_01` -> `res://audio/radio/rad_yardline_station_id_01.wav`;
+   - `radio.yardline.station_id_02` -> `res://audio/radio/rad_yardline_station_id_02.wav`;
+2. add only their non-destructive Godot `.import` sidecars as required;
+3. promote only those three registry slots to project-internal `LICENSED_FINAL`;
+4. set `replacement_required = false` only for those three slots;
+5. record the exact canonical production path and locked GTA source provenance;
+6. add one narrow `RadioProgramPlayer` production-stream resolution step;
+7. preserve each exact existing procedural fallback as independently reachable if its production stream is unavailable;
+8. preserve the existing single `RadioAudioStreamPlayer` and all director/lifecycle/mix ownership.
 
-- copyrighted song hook or recognizable musical phrase;
-- spoken GTA station name/dialogue;
-- siren/security warning;
-- comedy/cartoon sting;
-- oversized cinematic impact;
-- long low-frequency tail that muddies engine/Wind;
-- close match to production Disturbance Alert, Evasion Release, Signal Lock, Gate Slam, or Memory Echo onset/tail.
+The authorized playback resolution order for these final slots is:
 
-Audition:
+1. registry production stream when the final path exists and loads successfully;
+2. otherwise the exact current procedural fallback.
 
-- repeat at least 15 times across a 10-minute simulated radio session;
-- compare directly against ID 02 and the sweeper;
-- audition before and after songs/DJ links;
-- audition under engine + Wind;
-- audition during radio duck recovery after pursuit;
-- verify small-speaker readability and non-fatiguing high-frequency content.
+Because final slots fail closed for local reference override under the existing registry policy, production integration must not make developer-local reference audio override a `LICENSED_FINAL` stream.
 
-## Target C — `radio.yardline.station_id_02`
+## Explicitly out of scope
 
-Desired identity:
+Production ingestion must not:
 
-- compact alternate Yardline sting;
-- same family as ID 01 but shorter, sharper, and clearly non-identical;
-- useful as a secondary identifier without sounding like a gameplay success/failure cue;
-- may share texture/spectral language with ID 01, but not the same envelope or melodic contour.
+- ingest either runner-up;
+- add any other radio WAV/OGG file;
+- promote any other radio slot;
+- change `RadioProgramDirector` category weights or seeded selection;
+- change anti-repeat logic, max-gap logic, event queues, or WORLD_REACTION rules;
+- modify `RadioStationCatalog` item/category/context identity for the three targets;
+- add a player, timer, scheduler, station, song, advert, DJ link, or world reaction;
+- change pause/resume semantics;
+- change lifecycle fade, pursuit duck, or Echo-contamination gain composition;
+- change vehicle-radio mount/dismount behavior;
+- change pursuit, Memory Echo, reset, or gameplay behavior.
 
-Preferred natural source length:
+## Candidate-selection guard during ingestion
 
-`0.35–1.4 s`
+The existing executable candidate-selection contract remains authoritative **until the first production-ingestion commit** and must stay green while no production files are present.
 
-Reject:
+Once the three production assets and registry promotions are introduced, replace or evolve that guard into the 01M production contract in the same implementation change. Do not simply delete the protection. The production contract must prove the locked sources, exact technical metadata, runtime routing, preserved fallbacks, and unchanged radio architecture.
 
-- near-duplicate of ID 01;
-- generic UI confirm/back sound;
-- alarm/siren;
-- recognizable GTA branding/dialogue/music;
-- bright single ping too close to Signal Lock;
-- descending cue too close to Evasion Release;
-- Echo-like electrical rupture/dissolve.
+## Production automated verification
 
-Audition:
+The 01M production contract must prove at minimum:
 
-- alternate ID 01 / ID 02 for at least 20 total repetitions;
-- verify listener can distinguish them immediately without either sounding unrelated to Yardline;
-- audition between representative songs and DJ links;
-- audition under engine + Wind and during pursuit duck;
-- verify short tail and clean handoff into the following segment.
-
-## Owner-authorized candidate source boundary
-
-Use only the owner-authorized local GTA San Andreas audio library already accepted for production-audio work.
-
-For every serious candidate record exact provenance:
-
-`GTA_SA:<PAK>:BANK_<bank_id>:SOUND_<sound_index>`
-
-Start with `GENRL` and `SCRIPT`, then inspect other local banks that contain radio stingers, broadcast transitions, electronics, relay/RF sweeps, compact musical-neutral identifiers, and industrial/electrical textures.
-
-Candidate staging remains local/gitignored. Do not commit extracted candidate WAVs, source archives, machine-specific paths, or bulk library material.
-
-Aim for:
-
-- 4–6 credible Sweeper candidates;
-- 4–6 credible Station ID 01 candidates;
-- 4–6 credible Station ID 02 candidates.
-
-Approximately 12–18 serious candidates total is enough. Do not bulk-extract hundreds of sounds.
-
-## Candidate treatment policy
-
-During selection:
-
-- preserve the raw source sample rate, channels, bit depth, and duration;
-- do not normalize, EQ, compress, add reverb, resample, time-stretch, pitch-shift, or layer multiple GTA sources;
-- report boundary quality first;
-- for a selected short transient, only minimal edge cleanup/fades may be proposed after source lock if required to remove a click;
-- do not fabricate station voiceover or spoken branding from GTA dialogue.
-
-The winning identity should come from source selection, not heavy repair.
-
-## Candidate report requirements
-
-For every serious candidate return:
-
-- candidate ID;
-- target slot;
-- pak;
-- bank;
-- sound index;
-- duration;
-- native sample rate;
-- channels;
-- bit depth;
-- raw bytes;
-- raw SHA-256;
-- PASS / REJECT;
-- listening identity;
-- start/end cleanliness;
-- small-speaker readability;
-- repetition fatigue;
-- engine/Wind compatibility;
-- pursuit-duck compatibility;
-- Echo-contamination compatibility;
-- distinction from the other two 01M targets;
-- distinction from Signal Lock / Disturbance / Evasion / Memory Echo;
-- gain change needed;
-- resampling needed;
-- EQ/compression/reverb/time-stretch needed.
-
-## Final selection report
-
-For each target, return one human-auditioned winner and one runner-up.
-
-Winner report must include:
-
-- exact GTA source provenance;
-- natural duration/rate/channels/bit depth;
-- raw SHA-256;
-- repeated-session fatigue result;
-- small-speaker result;
-- engine + Wind result;
-- pursuit-duck result;
-- Echo-contamination result;
-- neighboring-production distinction result;
-- exact proposed edge treatment, if any.
-
-Pack-level discrimination must report:
-
-- Sweeper vs Station ID 01: PASS / FAIL;
-- Sweeper vs Station ID 02: PASS / FAIL;
-- Station ID 01 vs Station ID 02: PASS / FAIL;
-- all-three family coherence: PASS / FAIL;
-- all-three semantic distinction: PASS / FAIL;
-- 10-minute repetition fatigue: PASS / FAIL;
-- extraction/staging integrity: PASS / FAIL.
-
-## Candidate-search boundary
-
-During candidate search do not:
-
-- add production radio WAV/OGG files or import sidecars;
-- promote any registry slot;
-- add production path/provenance metadata;
-- modify `RadioProgramPlayer`, `RadioProgramDirector`, or `RadioStationCatalog` behavior;
-- change category weights, anti-repeat logic, max-gap rules, event queues, pause/resume, fades, or radio gain composition;
-- add a radio player, timer, scheduler, station, song, advert, DJ link, or world reaction;
-- change gameplay, vehicle radio lifecycle, pursuit, Echo contamination, or reset behavior.
-
-The executable 01M candidate-selection contract must stay green throughout search and must prove this boundary from repository/runtime metadata.
-
-## Planned production integration after source lock
-
-Only after all three human-selected winners are accepted may implementation:
-
-1. add final curated short-form production media under `res://audio/radio/`;
-2. promote only the three target registry slots to project-internal `LICENSED_FINAL` and clear `replacement_required`;
-3. record exact production path and GTA source provenance;
-4. add a narrow `RadioProgramPlayer` registry-production resolution step between permitted local-reference resolution and procedural synthesis;
-5. preserve independent procedural fallback when an expected production stream is absent;
-6. preserve the existing single `RadioAudioStreamPlayer` and all director/lifecycle/mix ownership.
-
-Planned filenames, subject to the selected source format and final accepted treatment:
-
-- `radio.yardline.dj_sweeper` -> `res://audio/radio/rad_yardline_dj_sweeper.wav`;
-- `radio.yardline.station_id_01` -> `res://audio/radio/rad_yardline_station_id_01.wav`;
-- `radio.yardline.station_id_02` -> `res://audio/radio/rad_yardline_station_id_02.wav`.
-
-No production media is authorized by this candidate-search checkpoint itself.
-
-## Future production verification after source lock
-
-The later 01M production contract must prove at minimum:
-
-- exact registry status/path/provenance for the three winners;
-- selected media exists and loads in Godot with expected technical metadata;
+- exact registry `LICENSED_FINAL` status, `replacement_required=false`, production path, and source provenance for all three locked winners;
+- production media exists and loads in Godot;
+- Sweeper is mono PCM16, `18,000 Hz`, `8,016` frames, approximately `0.4453 s`;
+- Station ID 01 is mono PCM16, `18,000 Hz`, `18,176` frames, approximately `1.0098 s`;
+- Station ID 02 is mono PCM16, `18,000 Hz`, `11,872` frames, approximately `0.6596 s`;
+- all three streams are non-looping;
 - all three exact catalog segments resolve through the existing `RadioAudioStreamPlayer`;
-- local-reference policy still fails closed for final slots;
+- local-reference policy remains fail-closed for final slots;
 - each target retains an independently reachable procedural fallback if its production stream is unavailable;
-- one missing production target does not disable the other two;
-- director weights, anti-repeat/max-gap/event behavior remain unchanged;
+- one missing production target does not disable or alter either other production target;
+- `RadioProgramDirector` weights, anti-repeat, max-gap, event priority/deferral, and seeded behavior remain unchanged;
+- catalog item/category/context/semantic-slot mapping remains unchanged;
 - pause/resume cursor state remains intact;
 - lifecycle fade, pursuit duck, and Echo contamination still compose correctly;
-- reset stops/clears the radio without leaking a voice;
+- reset stops/clears radio with no leaked or doubled voice;
 - Audio Runtime and canonical Web compatibility remain green on the exact production head.
 
-Exact-head native listening after integration must cover a representative Yardline session, engine + Wind underlay, pursuit duck/recovery, Echo contamination/suppression transitions, and repeated station-ID/sweeper fatigue.
+Regression verification must include M22 radio program assertions, M23 vehicle radio, M24 radio mix, M25 Echo radio interference, Audio Runtime, 01L, 01K, 01J, 01H, and canonical Web compatibility.
+
+## Exact-head native listening after ingestion
+
+Production acceptance requires native listening on the exact production head covering:
+
+- representative 10-minute Yardline session with all three selected identities recurring naturally;
+- Sweeper at least 20 times with varied 1–4 second spacing and adjacent program material;
+- ID 01 at least 15 times across representative songs/DJ links;
+- ID 01 / ID 02 alternation at least 20 total repetitions;
+- engine + Wind underlay at moderate/high vehicle movement;
+- pursuit duck around approximately `-7 dB` and `-13 dB` plus recovery;
+- Echo contamination up to approximately `-4 dB` and critical suppression transitions;
+- direct comparison against Signal Lock, Disturbance Alert, Evasion Release, Gate Slam, and Memory Echo signatures;
+- small-speaker/headphone clarity;
+- start/end cleanliness and no segment-tail collision;
+- reset/replay with no stale or doubled radio voice.
 
 ## Completion
 
-The **01M candidate-selection checkpoint** is complete when one human-auditioned winner and runner-up exist for each of the three target slots, the three winners pass pack-level coherence/distinction/fatigue checks, exact source metadata and treatment decisions are recorded, and the candidate-selection contract remains green with no production/runtime mutation.
+The **01M source-selection checkpoint is PASS**: one human-auditioned winner and runner-up are locked for each target, all three winners passed family coherence, semantic distinction, fatigue, mix-context, and extraction/staging checks, and the candidate-selection contract remained green with no production/runtime mutation.
 
-01M production PASS is a later checkpoint requiring selected media integration, exact-head automated and native listening verification, fresh Standards/Spec review, merge, and exact-main evidence.
+The next valid state is production ingestion of the three locked winners. 01M production PASS requires exact media integration, exact-head automated verification, exact-head native listening, fresh Standards/Spec review, PR merge, and exact-main evidence.

--- a/contracts/audio_production_01m_yardline_station_identity_sweeper_spec.md
+++ b/contracts/audio_production_01m_yardline_station_identity_sweeper_spec.md
@@ -1,0 +1,351 @@
+# Audio Production 01M — Yardline Station Identity & Sweeper Pack
+
+**State:** CANDIDATE_SELECTION_REQUIRED  
+**Baseline:** `main@860073387f87c696f3dc8ff2f063dc0105f88982`
+
+## Objective
+
+Replace three live Yardline 88.3 procedural interstitial identities with production media while preserving the existing radio program, playback owner, lifecycle, and mix behavior:
+
+1. `radio.yardline.dj_sweeper` — short station-flow sweeper used by the DJ_LINK category;
+2. `radio.yardline.station_id_01` — primary Yardline signature jingle / station ID;
+3. `radio.yardline.station_id_02` — compact Yardline sting / alternate station ID.
+
+01M is a **candidate-selection workstream first**. During search and audition, no production radio asset, registry promotion, runtime stream-resolution change, director weight change, scheduler change, new player, new station, or gameplay behavior is authorized.
+
+## Current runtime authority on baseline main
+
+All three targets already exist in `AudioRegistry` and `RadioStationCatalog` and are reachable through the current Yardline program.
+
+Shared registry authority for all three:
+
+- domain: `RADIO`;
+- diegesis: `DIEGETIC`;
+- spatial type: `NON_DIEGETIC_2D`;
+- mix group: `RADIO_MUSIC`;
+- playback type: `TRANSIENT`;
+- `is_looping = false`;
+- max concurrency: `1`;
+- asset status: `PROCEDURAL_FALLBACK`;
+- `replacement_required = true`;
+- no production asset path;
+- no production source provenance.
+
+### `radio.yardline.dj_sweeper`
+
+Catalog authority:
+
+- item id: `dj_03_sweeper`;
+- category: `DJ_LINK`;
+- context: `SWEEPER`;
+- title: `DJ Sweeper - Yardline Flow`;
+- one BODY segment;
+- semantic slot: `radio.yardline.dj_sweeper`;
+- authored fallback duration: `0.8 s`;
+- authored fallback base frequency: `520 Hz`.
+
+### `radio.yardline.station_id_01`
+
+Catalog authority:
+
+- item id: `id_01_yardline_jingle`;
+- category: `STATION_ID`;
+- title: `Yardline 88.3 Signature Jingle`;
+- one BODY segment;
+- semantic slot: `radio.yardline.station_id_01`;
+- authored fallback duration: `1.5 s`;
+- authored fallback base frequency: `660 Hz`.
+
+### `radio.yardline.station_id_02`
+
+Catalog authority:
+
+- item id: `id_02_yardline_sting`;
+- category: `STATION_ID`;
+- title: `Yardline Stinger`;
+- one BODY segment;
+- semantic slot: `radio.yardline.station_id_02`;
+- authored fallback duration: `0.8 s`;
+- authored fallback base frequency: `880 Hz`.
+
+## Existing playback architecture to preserve
+
+`RadioProgramPlayer` owns one `AudioStreamPlayer` named `RadioAudioStreamPlayer` on the Master bus. It advances catalog segments, preserves pause/resume cursor state, and composes three independent gain layers:
+
+- lifecycle fade;
+- pursuit/critical ducking;
+- Echo radio-contamination ducking.
+
+The current candidate-stage resolution path is:
+
+1. optional developer-local `AudioReferenceResolver` stream for the current semantic slot when reference mode is permitted and enabled;
+2. otherwise `_synthesize_segment_audio()` procedural fallback.
+
+The production integration after source lock may add one narrow registry-production resolution step for the three selected slots, but must preserve the same player and all current program/lifecycle/mix ownership.
+
+`RadioProgramDirector` authority is out of scope and must remain unchanged, including:
+
+- SONG weight `60`;
+- DJ_LINK weight `15`;
+- STATION_ID weight `10`;
+- ADVERT weight `10`;
+- max non-song gap `2`;
+- song/interstitial anti-repeat history behavior;
+- event-driven WORLD_REACTION priority and deferral behavior;
+- deterministic seeded selection/state serialization.
+
+## Identity direction
+
+Yardline 88.3 is an experimental pirate/scrap relay. These three clips should establish a coherent broadcast signature without sounding like generic menu UI, police dispatch, a conventional commercial FM package, or a copied GTA station identity.
+
+Shared desired character:
+
+- reclaimed transmitter / pirate relay;
+- compact analog-electrical or industrial broadcast texture;
+- memorable in the `300 Hz–4 kHz` small-speaker band;
+- clear enough under vehicle engine and scrapyard Wind;
+- leaves room for program music, DJ links, pursuit alerts, and Memory Echo contamination;
+- no intelligible GTA station names, characters, slogans, dialogue, or recognizable musical branding;
+- no source that reads as a gameplay warning, Signal Lock confirmation, Disturbance Alert, Evasion Release, or Memory Echo signature.
+
+## Target A — `radio.yardline.dj_sweeper`
+
+Desired identity:
+
+- fastest and lightest of the three;
+- reads as a transition/sweep rather than a full station ID;
+- useful between program elements without demanding attention;
+- short rising/falling RF motion, relay chirp, tape/electrical sweep, or compact broadcast transition texture;
+- should tolerate frequent recurrence without fatigue.
+
+Preferred natural source length:
+
+`0.25–1.2 s`
+
+Reject:
+
+- spoken dialogue;
+- recognizable radio station branding;
+- alarm/siren identity;
+- long reverb tail that masks following content;
+- hard impact that reads as collision/gameplay feedback;
+- tonal confirmation ping too close to Signal Lock;
+- clip that becomes irritating when heard repeatedly in a 10-minute radio session.
+
+Audition:
+
+- repeat 20 times with 1–4 second gaps;
+- place immediately before and after representative Yardline song fallback material;
+- audition under engine + Wind at moderate driving level;
+- audition with approximately `-7 dB` and `-13 dB` pursuit duck;
+- audition with up to `-4 dB` Echo contamination;
+- verify clean start/end with no click and no tail collision into the next segment.
+
+## Target B — `radio.yardline.station_id_01`
+
+Desired identity:
+
+- primary station signature;
+- strongest and most memorable of the pack;
+- a complete micro-jingle or transmitter ident, not merely a UI chime;
+- recognizably related to the sweeper and alternate ID while still distinct;
+- confident but not louder/more urgent than critical gameplay cues.
+
+Preferred natural source length:
+
+`0.7–2.5 s`
+
+Reject:
+
+- copyrighted song hook or recognizable musical phrase;
+- spoken GTA station name/dialogue;
+- siren/security warning;
+- comedy/cartoon sting;
+- oversized cinematic impact;
+- long low-frequency tail that muddies engine/Wind;
+- close match to production Disturbance Alert, Evasion Release, Signal Lock, Gate Slam, or Memory Echo onset/tail.
+
+Audition:
+
+- repeat at least 15 times across a 10-minute simulated radio session;
+- compare directly against ID 02 and the sweeper;
+- audition before and after songs/DJ links;
+- audition under engine + Wind;
+- audition during radio duck recovery after pursuit;
+- verify small-speaker readability and non-fatiguing high-frequency content.
+
+## Target C — `radio.yardline.station_id_02`
+
+Desired identity:
+
+- compact alternate Yardline sting;
+- same family as ID 01 but shorter, sharper, and clearly non-identical;
+- useful as a secondary identifier without sounding like a gameplay success/failure cue;
+- may share texture/spectral language with ID 01, but not the same envelope or melodic contour.
+
+Preferred natural source length:
+
+`0.35–1.4 s`
+
+Reject:
+
+- near-duplicate of ID 01;
+- generic UI confirm/back sound;
+- alarm/siren;
+- recognizable GTA branding/dialogue/music;
+- bright single ping too close to Signal Lock;
+- descending cue too close to Evasion Release;
+- Echo-like electrical rupture/dissolve.
+
+Audition:
+
+- alternate ID 01 / ID 02 for at least 20 total repetitions;
+- verify listener can distinguish them immediately without either sounding unrelated to Yardline;
+- audition between representative songs and DJ links;
+- audition under engine + Wind and during pursuit duck;
+- verify short tail and clean handoff into the following segment.
+
+## Owner-authorized candidate source boundary
+
+Use only the owner-authorized local GTA San Andreas audio library already accepted for production-audio work.
+
+For every serious candidate record exact provenance:
+
+`GTA_SA:<PAK>:BANK_<bank_id>:SOUND_<sound_index>`
+
+Start with `GENRL` and `SCRIPT`, then inspect other local banks that contain radio stingers, broadcast transitions, electronics, relay/RF sweeps, compact musical-neutral identifiers, and industrial/electrical textures.
+
+Candidate staging remains local/gitignored. Do not commit extracted candidate WAVs, source archives, machine-specific paths, or bulk library material.
+
+Aim for:
+
+- 4–6 credible Sweeper candidates;
+- 4–6 credible Station ID 01 candidates;
+- 4–6 credible Station ID 02 candidates.
+
+Approximately 12–18 serious candidates total is enough. Do not bulk-extract hundreds of sounds.
+
+## Candidate treatment policy
+
+During selection:
+
+- preserve the raw source sample rate, channels, bit depth, and duration;
+- do not normalize, EQ, compress, add reverb, resample, time-stretch, pitch-shift, or layer multiple GTA sources;
+- report boundary quality first;
+- for a selected short transient, only minimal edge cleanup/fades may be proposed after source lock if required to remove a click;
+- do not fabricate station voiceover or spoken branding from GTA dialogue.
+
+The winning identity should come from source selection, not heavy repair.
+
+## Candidate report requirements
+
+For every serious candidate return:
+
+- candidate ID;
+- target slot;
+- pak;
+- bank;
+- sound index;
+- duration;
+- native sample rate;
+- channels;
+- bit depth;
+- raw bytes;
+- raw SHA-256;
+- PASS / REJECT;
+- listening identity;
+- start/end cleanliness;
+- small-speaker readability;
+- repetition fatigue;
+- engine/Wind compatibility;
+- pursuit-duck compatibility;
+- Echo-contamination compatibility;
+- distinction from the other two 01M targets;
+- distinction from Signal Lock / Disturbance / Evasion / Memory Echo;
+- gain change needed;
+- resampling needed;
+- EQ/compression/reverb/time-stretch needed.
+
+## Final selection report
+
+For each target, return one human-auditioned winner and one runner-up.
+
+Winner report must include:
+
+- exact GTA source provenance;
+- natural duration/rate/channels/bit depth;
+- raw SHA-256;
+- repeated-session fatigue result;
+- small-speaker result;
+- engine + Wind result;
+- pursuit-duck result;
+- Echo-contamination result;
+- neighboring-production distinction result;
+- exact proposed edge treatment, if any.
+
+Pack-level discrimination must report:
+
+- Sweeper vs Station ID 01: PASS / FAIL;
+- Sweeper vs Station ID 02: PASS / FAIL;
+- Station ID 01 vs Station ID 02: PASS / FAIL;
+- all-three family coherence: PASS / FAIL;
+- all-three semantic distinction: PASS / FAIL;
+- 10-minute repetition fatigue: PASS / FAIL;
+- extraction/staging integrity: PASS / FAIL.
+
+## Candidate-search boundary
+
+During candidate search do not:
+
+- add production radio WAV/OGG files or import sidecars;
+- promote any registry slot;
+- add production path/provenance metadata;
+- modify `RadioProgramPlayer`, `RadioProgramDirector`, or `RadioStationCatalog` behavior;
+- change category weights, anti-repeat logic, max-gap rules, event queues, pause/resume, fades, or radio gain composition;
+- add a radio player, timer, scheduler, station, song, advert, DJ link, or world reaction;
+- change gameplay, vehicle radio lifecycle, pursuit, Echo contamination, or reset behavior.
+
+The executable 01M candidate-selection contract must stay green throughout search and must prove this boundary from repository/runtime metadata.
+
+## Planned production integration after source lock
+
+Only after all three human-selected winners are accepted may implementation:
+
+1. add final curated short-form production media under `res://audio/radio/`;
+2. promote only the three target registry slots to project-internal `LICENSED_FINAL` and clear `replacement_required`;
+3. record exact production path and GTA source provenance;
+4. add a narrow `RadioProgramPlayer` registry-production resolution step between permitted local-reference resolution and procedural synthesis;
+5. preserve independent procedural fallback when an expected production stream is absent;
+6. preserve the existing single `RadioAudioStreamPlayer` and all director/lifecycle/mix ownership.
+
+Planned filenames, subject to the selected source format and final accepted treatment:
+
+- `radio.yardline.dj_sweeper` -> `res://audio/radio/rad_yardline_dj_sweeper.wav`;
+- `radio.yardline.station_id_01` -> `res://audio/radio/rad_yardline_station_id_01.wav`;
+- `radio.yardline.station_id_02` -> `res://audio/radio/rad_yardline_station_id_02.wav`.
+
+No production media is authorized by this candidate-search checkpoint itself.
+
+## Future production verification after source lock
+
+The later 01M production contract must prove at minimum:
+
+- exact registry status/path/provenance for the three winners;
+- selected media exists and loads in Godot with expected technical metadata;
+- all three exact catalog segments resolve through the existing `RadioAudioStreamPlayer`;
+- local-reference policy still fails closed for final slots;
+- each target retains an independently reachable procedural fallback if its production stream is unavailable;
+- one missing production target does not disable the other two;
+- director weights, anti-repeat/max-gap/event behavior remain unchanged;
+- pause/resume cursor state remains intact;
+- lifecycle fade, pursuit duck, and Echo contamination still compose correctly;
+- reset stops/clears the radio without leaking a voice;
+- Audio Runtime and canonical Web compatibility remain green on the exact production head.
+
+Exact-head native listening after integration must cover a representative Yardline session, engine + Wind underlay, pursuit duck/recovery, Echo contamination/suppression transitions, and repeated station-ID/sweeper fatigue.
+
+## Completion
+
+The **01M candidate-selection checkpoint** is complete when one human-auditioned winner and runner-up exist for each of the three target slots, the three winners pass pack-level coherence/distinction/fatigue checks, exact source metadata and treatment decisions are recorded, and the candidate-selection contract remains green with no production/runtime mutation.
+
+01M production PASS is a later checkpoint requiring selected media integration, exact-head automated and native listening verification, fresh Standards/Spec review, merge, and exact-main evidence.

--- a/godot/tests/audio_runtime_output_contract_test.gd
+++ b/godot/tests/audio_runtime_output_contract_test.gd
@@ -13,6 +13,7 @@ const PursuitAlertEvasionAudioProductionContract = preload("res://tests/pursuit_
 const MemoryEchoArcAudioProductionContract = preload("res://tests/memory_echo_arc_audio_production_contract.gd")
 const LivingYardAmbientMovementAudioProductionContract = preload("res://tests/living_yard_ambient_movement_audio_production_contract.gd")
 const ContinuousSignatureLoopsAudioProductionContract = preload("res://tests/continuous_signature_loops_audio_production_contract.gd")
+const YardlineStationIdentityCandidateSelectionContract = preload("res://tests/yardline_station_identity_candidate_selection_contract.gd")
 
 var _manager: Node = null
 
@@ -141,6 +142,12 @@ func _run() -> void:
 		await _fail("Audio Production 01L: %s" % continuous_loops_error)
 		return
 
+	# 01M candidate search must not silently promote or reroute Yardline identity media before human source lock.
+	var yardline_candidate_error: String = YardlineStationIdentityCandidateSelectionContract.verify()
+	if not yardline_candidate_error.is_empty():
+		await _fail("Audio Production 01M candidate selection: %s" % yardline_candidate_error)
+		return
+
 	if not _manager.has_method("get_runtime_audio_diagnostics"):
 		await _fail("Runtime audio diagnostics seam is absent")
 		return
@@ -254,7 +261,7 @@ func _run() -> void:
 		return
 
 	print("[AUDIO_RUNTIME_31] diagnostics=%s" % report)
-	print("[AUDIO_RUNTIME_31] PASS (Audio Production 01L continuous signature loops + 01K footstep/wind + 01J Memory Echo arc + 01H pursuit alert/evasion + 01G impacts/collisions + 01F signal lock + 01D six-transient pack + 01C gate slam + Audio 07 retention/report + output + Audio 06 UI identity + CTW Feel 04 telemetry/mix/reset; physical audibility remains external)")
+	print("[AUDIO_RUNTIME_31] PASS (Audio Production 01M candidate-selection guard + 01L continuous signature loops + 01K footstep/wind + 01J Memory Echo arc + 01H pursuit alert/evasion + 01G impacts/collisions + 01F signal lock + 01D six-transient pack + 01C gate slam + Audio 07 retention/report + output + Audio 06 UI identity + CTW Feel 04 telemetry/mix/reset; physical audibility remains external)")
 
 	active_transients = []
 	tuner_player = null

--- a/godot/tests/yardline_station_identity_candidate_selection_contract.gd
+++ b/godot/tests/yardline_station_identity_candidate_selection_contract.gd
@@ -3,6 +3,7 @@ extends RefCounted
 const AudioRegistryScript = preload("res://scripts/audio/audio_registry.gd")
 const RadioStationCatalogScript = preload("res://scripts/audio/radio/radio_station_catalog.gd")
 const RadioProgramPlayerScript = preload("res://scripts/audio/radio/radio_program_player.gd")
+const SelectionLockScript = preload("res://tests/yardline_station_identity_selection_lock.gd")
 
 const TARGETS := [
 	{
@@ -12,6 +13,13 @@ const TARGETS := [
 		"context": "SWEEPER",
 		"duration": 0.8,
 		"base_freq_hz": 520.0,
+		"production_path": "res://audio/radio/rad_yardline_dj_sweeper.wav",
+		"winner_provenance": "GTA_SA:GENRL:BANK_44:SOUND_2",
+		"winner_sample_rate": 18000,
+		"winner_frames": 8016,
+		"winner_duration_sec": 0.4453,
+		"winner_raw_sha256": "188837f05074b791060d41d5265851be7ef84b443c54b4f42d8fd40f941022b3",
+		"runner_up_provenance": "GTA_SA:SCRIPT:BANK_356:SOUND_16",
 	},
 	{
 		"slot": "radio.yardline.station_id_01",
@@ -20,6 +28,13 @@ const TARGETS := [
 		"context": "",
 		"duration": 1.5,
 		"base_freq_hz": 660.0,
+		"production_path": "res://audio/radio/rad_yardline_station_id_01.wav",
+		"winner_provenance": "GTA_SA:GENRL:BANK_44:SOUND_3",
+		"winner_sample_rate": 18000,
+		"winner_frames": 18176,
+		"winner_duration_sec": 1.0098,
+		"winner_raw_sha256": "a742e3d686fcfa91f8b643e0a820580a78dcd40db34f4c73ce517c894340c842",
+		"runner_up_provenance": "GTA_SA:SCRIPT:BANK_356:SOUND_2",
 	},
 	{
 		"slot": "radio.yardline.station_id_02",
@@ -28,8 +43,44 @@ const TARGETS := [
 		"context": "",
 		"duration": 0.8,
 		"base_freq_hz": 880.0,
+		"production_path": "res://audio/radio/rad_yardline_station_id_02.wav",
+		"winner_provenance": "GTA_SA:GENRL:BANK_44:SOUND_4",
+		"winner_sample_rate": 18000,
+		"winner_frames": 11872,
+		"winner_duration_sec": 0.6596,
+		"winner_raw_sha256": "7550cdb3f12086f78bea71b752b0edbd5e1f46b1e83136c459de5cc978d99051",
+		"runner_up_provenance": "GTA_SA:SCRIPT:BANK_356:SOUND_13",
 	},
 ]
+
+static func _verify_selection_lock(target: Dictionary) -> String:
+	var slot_id: String = String(target["slot"])
+	var selection: Dictionary = SelectionLockScript.get_selection(slot_id)
+	if selection.is_empty():
+		return "%s locked source selection missing" % slot_id
+	if String(selection.get("production_path", "")) != String(target["production_path"]):
+		return "%s production path lock changed" % slot_id
+	if String(selection.get("winner_provenance", "")) != String(target["winner_provenance"]):
+		return "%s winner provenance lock changed" % slot_id
+	if int(selection.get("winner_sample_rate", 0)) != int(target["winner_sample_rate"]):
+		return "%s winner sample-rate lock changed" % slot_id
+	if int(selection.get("winner_channels", 0)) != 1:
+		return "%s winner channel lock changed" % slot_id
+	if int(selection.get("winner_bit_depth", 0)) != 16:
+		return "%s winner bit-depth lock changed" % slot_id
+	if int(selection.get("winner_frames", 0)) != int(target["winner_frames"]):
+		return "%s winner frame-count lock changed" % slot_id
+	if absf(float(selection.get("winner_duration_sec", 0.0)) - float(target["winner_duration_sec"])) > 0.0001:
+		return "%s winner duration lock changed" % slot_id
+	if String(selection.get("winner_raw_sha256", "")) != String(target["winner_raw_sha256"]):
+		return "%s winner raw SHA lock changed" % slot_id
+	if String(selection.get("runner_up_provenance", "")) != String(target["runner_up_provenance"]):
+		return "%s runner-up provenance lock changed" % slot_id
+	if String(selection.get("edge_treatment", "")) != "NONE_NATURAL_BOUNDARY":
+		return "%s edge-treatment lock changed" % slot_id
+	if ResourceLoader.exists(String(selection["production_path"])):
+		return "%s production media appeared while candidate-stage guard is still active" % slot_id
+	return ""
 
 static func _verify_registry_slot(target: Dictionary) -> String:
 	var slot_id: String = String(target["slot"])
@@ -47,17 +98,17 @@ static func _verify_registry_slot(target: Dictionary) -> String:
 	if slot.get("playback_type") != AudioRegistryScript.PlaybackType.TRANSIENT:
 		return "%s playback type changed" % slot_id
 	if bool(slot.get("is_looping", true)):
-		return "%s must remain non-looping during candidate selection" % slot_id
+		return "%s must remain non-looping before production ingestion" % slot_id
 	if int(slot.get("max_concurrency", 0)) != 1:
 		return "%s max concurrency changed" % slot_id
 	if slot.get("asset_status") != AudioRegistryScript.AssetStatus.PROCEDURAL_FALLBACK:
-		return "%s must remain PROCEDURAL_FALLBACK until a human winner is locked" % slot_id
+		return "%s must remain PROCEDURAL_FALLBACK until production ingestion begins" % slot_id
 	if not bool(slot.get("replacement_required", false)):
-		return "%s must remain replacement-required during candidate selection" % slot_id
+		return "%s must remain replacement-required until production ingestion begins" % slot_id
 	if not AudioRegistryScript.get_production_asset_path(slot_id).is_empty():
-		return "%s acquired a production path before source lock" % slot_id
+		return "%s acquired a production path before production ingestion" % slot_id
 	if not AudioRegistryScript.get_source_provenance(slot_id).is_empty():
-		return "%s acquired source provenance before source lock" % slot_id
+		return "%s acquired registry provenance before production ingestion" % slot_id
 	return ""
 
 static func _verify_catalog_target(target: Dictionary) -> String:
@@ -120,6 +171,15 @@ static func verify() -> String:
 	if absf(float(station.get("frequency_mhz", 0.0)) - 88.3) > 0.001:
 		return "Yardline frequency changed"
 
+	var expected_slots: Array[String] = [
+		"radio.yardline.dj_sweeper",
+		"radio.yardline.station_id_01",
+		"radio.yardline.station_id_02",
+	]
+	expected_slots.sort()
+	if SelectionLockScript.get_target_slots() != expected_slots:
+		return "01M source-selection lock must contain exactly the three authorized Yardline targets"
+
 	var station_ids: Array[Dictionary] = RadioStationCatalogScript.get_items_by_category(
 		RadioStationCatalogScript.DEFAULT_STATION_ID,
 		RadioStationCatalogScript.Category.STATION_ID
@@ -128,6 +188,9 @@ static func verify() -> String:
 		return "01M expects exactly the existing two Yardline station ID items"
 
 	for target in TARGETS:
+		var selection_error := _verify_selection_lock(target)
+		if not selection_error.is_empty():
+			return selection_error
 		var registry_error := _verify_registry_slot(target)
 		if not registry_error.is_empty():
 			return registry_error

--- a/godot/tests/yardline_station_identity_candidate_selection_contract.gd
+++ b/godot/tests/yardline_station_identity_candidate_selection_contract.gd
@@ -1,0 +1,158 @@
+extends RefCounted
+
+const AudioRegistryScript = preload("res://scripts/audio/audio_registry.gd")
+const RadioStationCatalogScript = preload("res://scripts/audio/radio/radio_station_catalog.gd")
+const RadioProgramPlayerScript = preload("res://scripts/audio/radio/radio_program_player.gd")
+
+const TARGETS := [
+	{
+		"slot": "radio.yardline.dj_sweeper",
+		"item_id": "dj_03_sweeper",
+		"category": RadioStationCatalogScript.Category.DJ_LINK,
+		"context": "SWEEPER",
+		"duration": 0.8,
+		"base_freq_hz": 520.0,
+	},
+	{
+		"slot": "radio.yardline.station_id_01",
+		"item_id": "id_01_yardline_jingle",
+		"category": RadioStationCatalogScript.Category.STATION_ID,
+		"context": "",
+		"duration": 1.5,
+		"base_freq_hz": 660.0,
+	},
+	{
+		"slot": "radio.yardline.station_id_02",
+		"item_id": "id_02_yardline_sting",
+		"category": RadioStationCatalogScript.Category.STATION_ID,
+		"context": "",
+		"duration": 0.8,
+		"base_freq_hz": 880.0,
+	},
+]
+
+static func _verify_registry_slot(target: Dictionary) -> String:
+	var slot_id: String = String(target["slot"])
+	var slot: Dictionary = AudioRegistryScript.get_slot(slot_id)
+	if slot.is_empty():
+		return "%s slot missing" % slot_id
+	if slot.get("domain") != AudioRegistryScript.Domain.RADIO:
+		return "%s domain changed" % slot_id
+	if slot.get("diegesis") != AudioRegistryScript.Diegesis.DIEGETIC:
+		return "%s diegesis changed" % slot_id
+	if slot.get("spatial_type") != AudioRegistryScript.SpatialType.NON_DIEGETIC_2D:
+		return "%s spatial type changed" % slot_id
+	if slot.get("mix_group") != AudioRegistryScript.MixGroup.RADIO_MUSIC:
+		return "%s mix group changed" % slot_id
+	if slot.get("playback_type") != AudioRegistryScript.PlaybackType.TRANSIENT:
+		return "%s playback type changed" % slot_id
+	if bool(slot.get("is_looping", true)):
+		return "%s must remain non-looping during candidate selection" % slot_id
+	if int(slot.get("max_concurrency", 0)) != 1:
+		return "%s max concurrency changed" % slot_id
+	if slot.get("asset_status") != AudioRegistryScript.AssetStatus.PROCEDURAL_FALLBACK:
+		return "%s must remain PROCEDURAL_FALLBACK until a human winner is locked" % slot_id
+	if not bool(slot.get("replacement_required", false)):
+		return "%s must remain replacement-required during candidate selection" % slot_id
+	if not AudioRegistryScript.get_production_asset_path(slot_id).is_empty():
+		return "%s acquired a production path before source lock" % slot_id
+	if not AudioRegistryScript.get_source_provenance(slot_id).is_empty():
+		return "%s acquired source provenance before source lock" % slot_id
+	return ""
+
+static func _verify_catalog_target(target: Dictionary) -> String:
+	var slot_id: String = String(target["slot"])
+	var item: Dictionary = RadioStationCatalogScript.get_item_by_id(
+		RadioStationCatalogScript.DEFAULT_STATION_ID,
+		String(target["item_id"])
+	)
+	if item.is_empty():
+		return "%s catalog item missing" % slot_id
+	if int(item.get("category", -1)) != int(target["category"]):
+		return "%s catalog category changed" % slot_id
+	var expected_context: String = String(target["context"])
+	if not expected_context.is_empty() and String(item.get("context", "")) != expected_context:
+		return "%s catalog context changed" % slot_id
+	var segments: Array = item.get("segments", [])
+	if segments.size() != 1:
+		return "%s must remain a single-segment interstitial" % slot_id
+	var segment: Dictionary = segments[0]
+	if int(segment.get("phase", -1)) != RadioStationCatalogScript.Phase.BODY:
+		return "%s segment phase changed" % slot_id
+	if String(segment.get("semantic_slot_id", "")) != slot_id:
+		return "%s semantic slot routing changed" % slot_id
+	if absf(float(segment.get("duration_sec", -1.0)) - float(target["duration"])) > 0.001:
+		return "%s fallback duration changed" % slot_id
+	if absf(float(segment.get("base_freq_hz", -1.0)) - float(target["base_freq_hz"])) > 0.01:
+		return "%s fallback base frequency changed" % slot_id
+	return ""
+
+static func _verify_fallback_synthesis(program_player: Node, target: Dictionary) -> String:
+	var slot_id: String = String(target["slot"])
+	var item: Dictionary = RadioStationCatalogScript.get_item_by_id(
+		RadioStationCatalogScript.DEFAULT_STATION_ID,
+		String(target["item_id"])
+	)
+	var segment: Dictionary = item.get("segments", [])[0]
+	var stream := program_player.call("_synthesize_segment_audio", item, segment) as AudioStreamWAV
+	if stream == null:
+		return "%s procedural fallback did not synthesize" % slot_id
+	if stream.data.is_empty():
+		return "%s procedural fallback contains no PCM data" % slot_id
+	if stream.format != AudioStreamWAV.FORMAT_16_BITS:
+		return "%s procedural fallback must remain PCM16" % slot_id
+	if stream.stereo:
+		return "%s procedural fallback must remain mono" % slot_id
+	if stream.mix_rate != 22050:
+		return "%s procedural fallback mix rate changed" % slot_id
+	if stream.loop_mode != AudioStreamWAV.LOOP_DISABLED:
+		return "%s procedural fallback must remain non-looping" % slot_id
+	if absf(stream.get_length() - float(target["duration"])) > 0.01:
+		return "%s synthesized fallback length changed" % slot_id
+	return ""
+
+static func verify() -> String:
+	var station: Dictionary = RadioStationCatalogScript.get_station(RadioStationCatalogScript.DEFAULT_STATION_ID)
+	if station.is_empty():
+		return "Yardline station missing"
+	if String(station.get("name", "")) != "YARDLINE 88.3":
+		return "Yardline station name changed"
+	if absf(float(station.get("frequency_mhz", 0.0)) - 88.3) > 0.001:
+		return "Yardline frequency changed"
+
+	var station_ids: Array[Dictionary] = RadioStationCatalogScript.get_items_by_category(
+		RadioStationCatalogScript.DEFAULT_STATION_ID,
+		RadioStationCatalogScript.Category.STATION_ID
+	)
+	if station_ids.size() != 2:
+		return "01M expects exactly the existing two Yardline station ID items"
+
+	for target in TARGETS:
+		var registry_error := _verify_registry_slot(target)
+		if not registry_error.is_empty():
+			return registry_error
+		var catalog_error := _verify_catalog_target(target)
+		if not catalog_error.is_empty():
+			return catalog_error
+
+	var program_player := RadioProgramPlayerScript.new()
+	program_player.call("_ensure_player")
+	if int(program_player.call("get_audio_stream_player_count")) != 1:
+		program_player.free()
+		return "RadioProgramPlayer must retain exactly one AudioStreamPlayer owner"
+	var player := program_player.get_node_or_null("RadioAudioStreamPlayer") as AudioStreamPlayer
+	if player == null:
+		program_player.free()
+		return "RadioAudioStreamPlayer owner missing"
+	if StringName(player.bus) != &"Master":
+		program_player.free()
+		return "RadioAudioStreamPlayer bus changed"
+
+	for target in TARGETS:
+		var fallback_error := _verify_fallback_synthesis(program_player, target)
+		if not fallback_error.is_empty():
+			program_player.free()
+			return fallback_error
+
+	program_player.free()
+	return ""

--- a/godot/tests/yardline_station_identity_candidate_selection_contract_test.gd
+++ b/godot/tests/yardline_station_identity_candidate_selection_contract_test.gd
@@ -1,0 +1,16 @@
+extends SceneTree
+
+const YardlineStationIdentityCandidateSelectionContract = preload("res://tests/yardline_station_identity_candidate_selection_contract.gd")
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _run() -> void:
+	var error: String = YardlineStationIdentityCandidateSelectionContract.verify()
+	if not error.is_empty():
+		push_error("[AUDIO_PRODUCTION_01M_CANDIDATE] FAIL: %s" % error)
+		quit(1)
+		return
+
+	print("[AUDIO_PRODUCTION_01M_CANDIDATE] PASS: Yardline sweeper + two station IDs remain fallback-only, catalog-locked, independently synthesizable, and owned by the single existing radio player")
+	quit(0)

--- a/godot/tests/yardline_station_identity_selection_lock.gd
+++ b/godot/tests/yardline_station_identity_selection_lock.gd
@@ -1,0 +1,78 @@
+extends RefCounted
+
+## Audio Production 01M source-selection lock.
+## These values are human-auditioned source identity and technical metadata.
+## Production integration contracts should consume this lock rather than duplicate it.
+
+const LOCKED_SELECTIONS: Dictionary = {
+	"radio.yardline.dj_sweeper": {
+		"production_path": "res://audio/radio/rad_yardline_dj_sweeper.wav",
+		"winner_provenance": "GTA_SA:GENRL:BANK_44:SOUND_2",
+		"winner_sample_rate": 18000,
+		"winner_channels": 1,
+		"winner_bit_depth": 16,
+		"winner_frames": 8016,
+		"winner_duration_sec": 0.4453,
+		"winner_raw_bytes": 16032,
+		"winner_raw_sha256": "188837f05074b791060d41d5265851be7ef84b443c54b4f42d8fd40f941022b3",
+		"runner_up_provenance": "GTA_SA:SCRIPT:BANK_356:SOUND_16",
+		"runner_up_sample_rate": 15000,
+		"runner_up_channels": 1,
+		"runner_up_bit_depth": 16,
+		"runner_up_frames": 9909,
+		"runner_up_duration_sec": 0.6606,
+		"runner_up_raw_bytes": 19818,
+		"runner_up_raw_sha256": "621aa1348b7d2e9bcdf40d10658e97b456ef594c925e983102a83342e5cc3c0b",
+		"edge_treatment": "NONE_NATURAL_BOUNDARY",
+	},
+	"radio.yardline.station_id_01": {
+		"production_path": "res://audio/radio/rad_yardline_station_id_01.wav",
+		"winner_provenance": "GTA_SA:GENRL:BANK_44:SOUND_3",
+		"winner_sample_rate": 18000,
+		"winner_channels": 1,
+		"winner_bit_depth": 16,
+		"winner_frames": 18176,
+		"winner_duration_sec": 1.0098,
+		"winner_raw_bytes": 36352,
+		"winner_raw_sha256": "a742e3d686fcfa91f8b643e0a820580a78dcd40db34f4c73ce517c894340c842",
+		"runner_up_provenance": "GTA_SA:SCRIPT:BANK_356:SOUND_2",
+		"runner_up_sample_rate": 15000,
+		"runner_up_channels": 1,
+		"runner_up_bit_depth": 16,
+		"runner_up_frames": 28244,
+		"runner_up_duration_sec": 1.8829,
+		"runner_up_raw_bytes": 56488,
+		"runner_up_raw_sha256": "96677f627d502e1650f48841b00ab828f1117ddef117c36b00093f8fb85854a1",
+		"edge_treatment": "NONE_NATURAL_BOUNDARY",
+	},
+	"radio.yardline.station_id_02": {
+		"production_path": "res://audio/radio/rad_yardline_station_id_02.wav",
+		"winner_provenance": "GTA_SA:GENRL:BANK_44:SOUND_4",
+		"winner_sample_rate": 18000,
+		"winner_channels": 1,
+		"winner_bit_depth": 16,
+		"winner_frames": 11872,
+		"winner_duration_sec": 0.6596,
+		"winner_raw_bytes": 23744,
+		"winner_raw_sha256": "7550cdb3f12086f78bea71b752b0edbd5e1f46b1e83136c459de5cc978d99051",
+		"runner_up_provenance": "GTA_SA:SCRIPT:BANK_356:SOUND_13",
+		"runner_up_sample_rate": 12000,
+		"runner_up_channels": 1,
+		"runner_up_bit_depth": 16,
+		"runner_up_frames": 8534,
+		"runner_up_duration_sec": 0.7112,
+		"runner_up_raw_bytes": 17068,
+		"runner_up_raw_sha256": "a3c7719ce246781d50c261898890aced94d0fb632064cc1e51b01846b536b4f5",
+		"edge_treatment": "NONE_NATURAL_BOUNDARY",
+	},
+}
+
+static func get_selection(slot_id: String) -> Dictionary:
+	return LOCKED_SELECTIONS.get(slot_id, {}).duplicate(true)
+
+static func get_target_slots() -> Array[String]:
+	var result: Array[String] = []
+	for slot_id in LOCKED_SELECTIONS.keys():
+		result.append(String(slot_id))
+	result.sort()
+	return result


### PR DESCRIPTION
Opens Audio Production 01M as a candidate-selection checkpoint from `main@860073387f87c696f3dc8ff2f063dc0105f88982` for exactly three Yardline slots: `radio.yardline.dj_sweeper`, `radio.yardline.station_id_01`, and `radio.yardline.station_id_02`.

This PR intentionally contains no production audio, registry promotion, source provenance, runtime radio resolution change, director/scheduler change, or gameplay mutation. The new spec defines the owner-authorized GTA SA candidate-search/audition boundary, identity criteria, candidate report requirements, pack-level discrimination, and the later production integration contract.

An executable 01M candidate-selection contract locks all three slots to `PROCEDURAL_FALLBACK` / `replacement_required=true` with no production paths, locks their existing catalog item/segment metadata, proves each current fallback independently synthesizes as non-looping PCM16, and preserves the single existing `RadioAudioStreamPlayer` owner. The guard is included in Audio Runtime 31 and also has a standalone runner.

Human GTA-library audition/source selection remains the next required checkpoint before any production media may be promoted.