### PR TITLE
Burnside Production 02 — Field Hacking / Report Suppression Tracer

### DIFF
--- a/.github/workflows/burnside-wanted-119.yml
+++ b/.github/workflows/burnside-wanted-119.yml
@@ -4,17 +4,21 @@ on:
   push:
     branches:
       - "chatgpt/burnside-wanted-119"
+      - "chatgpt/burnside-field-hacking-122"
     paths:
       - "godot/project.godot"
       - "godot/scripts/world/wanted_authority.gd"
       - "godot/scripts/world/wanted_heat1_runtime.gd"
       - "godot/scripts/interactions/civic_service_alarm.gd"
       - "godot/scenes/interactions/civic_service_alarm.tscn"
+      - "godot/scripts/interactions/civic_report_access.gd"
+      - "godot/scenes/interactions/civic_report_access.tscn"
       - "godot/scripts/prototype/scrap_test_block.gd"
       - "godot/scenes/prototype/scrap_test_block.tscn"
       - "godot/tests/wanted_heat1_contract_test.gd"
       - "godot/tests/wanted_heat1_contract_runner.gd"
       - "godot/tests/wanted_heat1_scene_test.gd"
+      - "godot/tests/field_hacking_report_suppression_test.gd"
       - "godot/tests/wanted_heat1_render_capture.gd"
       - "godot/tests/wanted_hud_layout_test.gd"
       - ".github/workflows/burnside-wanted-119.yml"
@@ -25,11 +29,14 @@ on:
       - "godot/scripts/world/wanted_heat1_runtime.gd"
       - "godot/scripts/interactions/civic_service_alarm.gd"
       - "godot/scenes/interactions/civic_service_alarm.tscn"
+      - "godot/scripts/interactions/civic_report_access.gd"
+      - "godot/scenes/interactions/civic_report_access.tscn"
       - "godot/scripts/prototype/scrap_test_block.gd"
       - "godot/scenes/prototype/scrap_test_block.tscn"
       - "godot/tests/wanted_heat1_contract_test.gd"
       - "godot/tests/wanted_heat1_contract_runner.gd"
       - "godot/tests/wanted_heat1_scene_test.gd"
+      - "godot/tests/field_hacking_report_suppression_test.gd"
       - "godot/tests/wanted_heat1_render_capture.gd"
       - "godot/tests/wanted_hud_layout_test.gd"
       - ".github/workflows/burnside-wanted-119.yml"
@@ -95,6 +102,16 @@ jobs:
             --rendering-method gl_compatibility \
             --path godot \
             --script res://tests/wanted_heat1_scene_test.gd
+
+      - name: Run Field Hacking report suppression tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/field_hacking_report_suppression_test.gd
 
       - name: Run Wanted HUD lane regression
         shell: bash

--- a/.github/workflows/burnside-wanted-119.yml
+++ b/.github/workflows/burnside-wanted-119.yml
@@ -133,7 +133,7 @@ jobs:
             --path godot \
             --script res://tests/desktop_vehicle_authority_test.gd
 
-      - name: Capture windowed rendered Heat-1 proof
+      - name: Capture windowed rendered Heat-1 + Field Hacking proof
         shell: bash
         run: |
           set -euo pipefail
@@ -145,9 +145,11 @@ jobs:
           test -s godot/verification/wanted/01_report_contact.png
           test -s godot/verification/wanted/02_search_last_known.png
           test -s godot/verification/wanted/03_evaded_clear.png
+          test -s godot/verification/wanted/04_field_hack_report_suppressed.png
+          test -s godot/verification/wanted/05_restored_report_contact.png
           test -s godot/verification/wanted/render_report.json
 
-      - name: Upload rendered Heat-1 proof
+      - name: Upload rendered Heat-1 + Field Hacking proof
         uses: actions/upload-artifact@v4
         with:
           name: wanted-heat1-proof-${{ env.SOURCE_SHA }}

--- a/godot/scenes/interactions/civic_report_access.tscn
+++ b/godot/scenes/interactions/civic_report_access.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/interactions/civic_report_access.gd" id="1_access"]
+
+[sub_resource type="BoxMesh" id="BoxMesh_access"]
+size = Vector3(0.42, 0.72, 0.18)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial_access"]
+albedo_color = Color(0.16, 0.22, 0.18, 1)
+metallic = 0.45
+roughness = 0.68
+
+[sub_resource type="BoxShape3D" id="BoxShape_access"]
+size = Vector3(0.48, 0.78, 0.24)
+
+[node name="CivicReportAccess" type="Area3D"]
+script = ExtResource("1_access")
+
+[node name="ServiceHousing" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_access")
+material_override = SubResource("StandardMaterial_access")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape_access")
+
+[node name="StatusLabel" type="Label3D" parent="."]
+position = Vector3(0, 0.56, 0)
+text = "SERVICE TAP"
+font_size = 22
+outline_size = 5
+billboard = 1
+no_depth_test = true

--- a/godot/scenes/interactions/civic_report_access.tscn
+++ b/godot/scenes/interactions/civic_report_access.tscn
@@ -24,9 +24,10 @@ material_override = SubResource("StandardMaterial_access")
 shape = SubResource("BoxShape_access")
 
 [node name="StatusLabel" type="Label3D" parent="."]
-position = Vector3(0, 0.56, 0)
+position = Vector3(0, 0.68, 0)
 text = "SERVICE TAP"
-font_size = 22
-outline_size = 5
+font_size = 28
+pixel_size = 0.012
+outline_size = 6
 billboard = 1
 no_depth_test = true

--- a/godot/scenes/interactions/civic_service_alarm.tscn
+++ b/godot/scenes/interactions/civic_service_alarm.tscn
@@ -24,9 +24,10 @@ material_override = SubResource("StandardMaterial_alarm")
 shape = SubResource("BoxShape_alarm")
 
 [node name="StatusLabel" type="Label3D" parent="."]
-position = Vector3(0, 0.62, 0)
+position = Vector3(0, 0.72, 0)
 text = "SERVICE ALARM"
-font_size = 24
-outline_size = 5
+font_size = 28
+pixel_size = 0.012
+outline_size = 6
 billboard = 1
 no_depth_test = true

--- a/godot/scripts/interactions/civic_report_access.gd
+++ b/godot/scripts/interactions/civic_report_access.gd
@@ -1,0 +1,41 @@
+class_name CivicReportAccess
+extends InteractableBase
+
+## Burnside Production 02 / #122
+## One authored physical service tap for bounded Field Hacking interference.
+## This is intentionally not a generalized hacking target or network framework.
+
+signal report_interference_requested
+
+var is_compromised: bool = false
+
+@onready var status_label: Label3D = get_node_or_null("StatusLabel") as Label3D
+
+func _ready() -> void:
+	interaction_radius = 1.5
+	interaction_priority = 1.25
+	_update_label()
+
+func can_interact(player_pos: Vector3) -> bool:
+	return super.can_interact(player_pos) and not is_compromised
+
+func begin_interaction(player_pos: Vector3) -> bool:
+	if not can_interact(player_pos):
+		return false
+
+	is_compromised = true
+	_update_label()
+	state_changed.emit("REPORT_LINK_JAMMED")
+	report_interference_requested.emit()
+	interaction_completed.emit()
+	return true
+
+func reset_access() -> void:
+	is_compromised = false
+	_update_label()
+	state_changed.emit("SERVICE_READY")
+
+func _update_label() -> void:
+	if status_label == null:
+		return
+	status_label.text = "REPORT LINK JAMMED" if is_compromised else "SERVICE TAP"

--- a/godot/scripts/world/wanted_heat1_runtime.gd
+++ b/godot/scripts/world/wanted_heat1_runtime.gd
@@ -1,11 +1,13 @@
 extends Node
 
-## Burnside Production 01 / #119
+## Burnside Production 01 / #119 + Production 02 / #122
 ## Thin Heat-1 runtime adapter over the retained golden-slice player/pursuer/HUD seams.
-## It owns open-world authority knowledge, not mission pursuit and not a police director.
+## It owns open-world authority knowledge plus one bounded civic-report interference seam,
+## not mission pursuit, a police director, or a generalized hacking framework.
 
 const WantedAuthorityScript = preload("res://scripts/world/wanted_authority.gd")
 const CivicServiceAlarmScene = preload("res://scenes/interactions/civic_service_alarm.tscn")
+const CivicReportAccessScene = preload("res://scenes/interactions/civic_report_access.tscn")
 
 const LEGACY_PURSUIT_CALM := 0
 const CONTACT_LOSS_GRACE_SECONDS := 0.8
@@ -19,6 +21,7 @@ var _player: Node3D = null
 var _pursuer: Node3D = null
 var _touch_ui: Node = null
 var _alarm: CivicServiceAlarm = null
+var _report_access: CivicReportAccess = null
 var _wanted_label: Label = null
 var _contact_loss_timer: float = 0.0
 var _saved_intercept_distance: float = 1.5
@@ -71,19 +74,35 @@ func bind_to_scene(scene: Node) -> bool:
 		return false
 	_alarm.name = "CivicServiceAlarm"
 	_scene_controller.add_child(_alarm)
+
+	_report_access = CivicReportAccessScene.instantiate() as CivicReportAccess
+	if _report_access == null:
+		_unbind_scene()
+		return false
+	_report_access.name = "CivicReportAccess"
+	_scene_controller.add_child(_report_access)
+
 	var utility_plate := _scene_controller.get_node_or_null("GearsDistrictSlice01B/IndustrialFrontage/CivicUtilityPlate") as Node3D
 	if utility_plate != null:
 		_alarm.global_position = utility_plate.global_position + Vector3(0.0, -1.8, 0.35)
+		_report_access.global_position = utility_plate.global_position + Vector3(0.0, -1.8, 3.55)
 	else:
 		_alarm.global_position = Vector3(0.9, 1.0, -38.65)
+		_report_access.global_position = Vector3(0.9, 1.0, -35.45)
 
 	var interactables = _scene_controller.get("_interactables")
-	if interactables is Array and not interactables.has(_alarm):
-		interactables.append(_alarm)
+	if interactables is Array:
+		if not interactables.has(_alarm):
+			interactables.append(_alarm)
+		if not interactables.has(_report_access):
+			interactables.append(_report_access)
 
 	var report_callable := Callable(self, "_on_report_requested")
 	if not _alarm.report_requested.is_connected(report_callable):
 		_alarm.report_requested.connect(report_callable)
+	var interference_callable := Callable(self, "_on_report_interference_requested")
+	if not _report_access.report_interference_requested.is_connected(interference_callable):
+		_report_access.report_interference_requested.connect(interference_callable)
 
 	_wanted_label = Label.new()
 	_wanted_label.name = "WantedStatusLabel"
@@ -113,14 +132,17 @@ func bind_to_scene(scene: Node) -> bool:
 	return true
 
 func handle_action_pressed() -> bool:
-	if not _bound or _scene_controller == null or _alarm == null:
+	if not _bound or _scene_controller == null or _alarm == null or _report_access == null:
 		return false
 	var active_target = _scene_controller.get("_active_target")
-	if active_target != _alarm:
+	if active_target != _alarm and active_target != _report_access:
 		return false
 	var actor := _get_player_target()
 	if actor == null:
 		return false
+	if active_target == _report_access:
+		_report_access.update_player_distance(actor.global_position)
+		return _report_access.begin_interaction(actor.global_position)
 	_alarm.update_player_distance(actor.global_position)
 	return _alarm.begin_interaction(actor.global_position)
 
@@ -198,12 +220,16 @@ func reset_runtime() -> void:
 	wanted_authority.reset()
 	_contact_loss_timer = 0.0
 	_restore_open_world_interception()
-	if _alarm != null and is_instance_valid(_alarm):
-		_alarm.reset_alarm()
+	_restore_civic_reporting_service()
 	if had_open_world_response and _pursuer != null and is_instance_valid(_pursuer) and _legacy_pursuit_is_calm():
 		if _pursuer.has_method("reset_pursuer"):
 			_pursuer.call("reset_pursuer", RESPONSE_SPAWN)
 	_update_hud()
+
+func _on_report_interference_requested() -> void:
+	if _alarm == null or not is_instance_valid(_alarm):
+		return
+	_alarm.report_enabled = false
 
 func _on_report_requested(report_source: String, observed_position: Vector3, contact_source: String) -> void:
 	if not _bound or not _legacy_pursuit_is_calm():
@@ -224,14 +250,20 @@ func _on_report_requested(report_source: String, observed_position: Vector3, con
 		_pursuer.call("activate_pursuit", search_anchor)
 	_update_hud()
 
+func _restore_civic_reporting_service() -> void:
+	if _alarm != null and is_instance_valid(_alarm):
+		_alarm.report_enabled = true
+		_alarm.reset_alarm()
+	if _report_access != null and is_instance_valid(_report_access):
+		_report_access.reset_access()
+
 func _yield_to_legacy_pursuit() -> void:
 	wanted_authority.reset()
 	_contact_loss_timer = 0.0
 	_restore_open_world_interception()
 	if _pursuer != null and is_instance_valid(_pursuer) and _pursuer.has_method("reset_pursuer"):
 		_pursuer.call("reset_pursuer", RESPONSE_SPAWN)
-	if _alarm != null and is_instance_valid(_alarm):
-		_alarm.reset_alarm()
+	_restore_civic_reporting_service()
 	_update_hud()
 
 func _on_evasion() -> void:
@@ -303,12 +335,15 @@ func _unbind_scene() -> void:
 		if _touch_ui.replay_pressed.is_connected(replay_callable):
 			_touch_ui.replay_pressed.disconnect(replay_callable)
 
-	if _scene_controller != null and is_instance_valid(_scene_controller) and _alarm != null and is_instance_valid(_alarm):
+	if _scene_controller != null and is_instance_valid(_scene_controller):
 		var interactables = _scene_controller.get("_interactables")
 		if interactables is Array:
-			interactables.erase(_alarm)
+			if _alarm != null and is_instance_valid(_alarm):
+				interactables.erase(_alarm)
+			if _report_access != null and is_instance_valid(_report_access):
+				interactables.erase(_report_access)
 
-	for node in [_alarm, search_anchor, _wanted_label]:
+	for node in [_alarm, _report_access, search_anchor, _wanted_label]:
 		if node != null and is_instance_valid(node):
 			node.queue_free()
 
@@ -317,6 +352,7 @@ func _unbind_scene() -> void:
 	_pursuer = null
 	_touch_ui = null
 	_alarm = null
+	_report_access = null
 	search_anchor = null
 	_wanted_label = null
 	_bound = false

--- a/godot/tests/field_hacking_report_suppression_test.gd
+++ b/godot/tests/field_hacking_report_suppression_test.gd
@@ -57,6 +57,14 @@ func _run() -> void:
 	if float(access.get("interaction_radius")) > 2.5:
 		await _fail("Field Hacking access radius is too broad for a physical/local Access Path")
 		return
+	var access_label := access.get_node_or_null("StatusLabel") as Label3D
+	var alarm_label := alarm.get_node_or_null("StatusLabel") as Label3D
+	if access_label == null or alarm_label == null:
+		await _fail("Civic reporting infrastructure lacks local status labels")
+		return
+	if access_label.pixel_size < 0.01 or alarm_label.pixel_size < 0.01:
+		await _fail("Civic Field Hacking feedback is too small at the production camera distance")
+		return
 
 	# Access Is the Puzzle: physically reach the service point, then interference is immediate.
 	player.global_position = access.global_position + Vector3(0.8, 0.0, 0.0)
@@ -68,8 +76,7 @@ func _run() -> void:
 	if bool(alarm.get("report_enabled")):
 		await _fail("Successful Field Hacking did not suppress the local civic Report path")
 		return
-	var access_label := access.get_node_or_null("StatusLabel") as Label3D
-	if access_label == null or not access_label.text.contains("REPORT LINK JAMMED"):
+	if not access_label.text.contains("REPORT LINK JAMMED"):
 		await _fail("Compromised civic reporting state lacks readable local feedback")
 		return
 
@@ -89,8 +96,7 @@ func _run() -> void:
 	if not bool(alarm.get("report_enabled")):
 		await _fail("Replay did not restore civic reporting service")
 		return
-	var restored_label := access.get_node_or_null("StatusLabel") as Label3D
-	if restored_label == null or not restored_label.text.contains("SERVICE TAP"):
+	if not access_label.text.contains("SERVICE TAP"):
 		await _fail("Replay did not restore readable civic access state")
 		return
 

--- a/godot/tests/field_hacking_report_suppression_test.gd
+++ b/godot/tests/field_hacking_report_suppression_test.gd
@@ -1,0 +1,108 @@
+extends SceneTree
+
+var _scene_under_test: Node = null
+var _runtime: Node = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _finish(exit_code: int) -> void:
+	if is_instance_valid(_scene_under_test):
+		_scene_under_test.queue_free()
+		await process_frame
+		await process_frame
+	quit(exit_code)
+
+func _fail(message: String) -> void:
+	push_error("[FIELD_HACKING_REPORT_SUPPRESSION] %s" % message)
+	await _finish(1)
+
+func _state(authority) -> String:
+	return String(authority.call("get_wanted_state_name"))
+
+func _heat(authority) -> int:
+	return int(authority.call("get_heat_level"))
+
+func _run() -> void:
+	_runtime = root.get_node_or_null("BurnsideWantedRuntime")
+	if _runtime == null:
+		await _fail("BurnsideWantedRuntime autoload is absent")
+		return
+
+	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
+	if packed == null:
+		await _fail("Could not load scrap_test_block.tscn")
+		return
+
+	_scene_under_test = packed.instantiate()
+	root.add_child(_scene_under_test)
+	await process_frame
+	await physics_frame
+	_runtime.call("bind_to_scene", _scene_under_test)
+	await process_frame
+
+	var player := _scene_under_test.get_node_or_null("Runner") as Node3D
+	var alarm := _scene_under_test.get_node_or_null("CivicServiceAlarm")
+	var access := _scene_under_test.get_node_or_null("CivicReportAccess")
+	var authority = _runtime.get("wanted_authority")
+	if player == null or alarm == null or authority == null:
+		await _fail("Production scene is missing Runner, CivicServiceAlarm, or WantedAuthority")
+		return
+	if access == null:
+		await _fail("Physical civic report Access Path is absent")
+		return
+	if not access.has_method("reset_access"):
+		await _fail("Civic report Access Path lacks deterministic recovery")
+		return
+	if float(access.get("interaction_radius")) > 2.5:
+		await _fail("Field Hacking access radius is too broad for a physical/local Access Path")
+		return
+
+	# Access Is the Puzzle: physically reach the service point, then interference is immediate.
+	player.global_position = access.global_position + Vector3(0.8, 0.0, 0.0)
+	access.call("update_player_distance", player.global_position)
+	_scene_under_test.set("_active_target", access)
+	if not bool(_runtime.call("handle_action_pressed")):
+		await _fail("Local civic service access did not execute Field Hacking interference")
+		return
+	if bool(alarm.get("report_enabled")):
+		await _fail("Successful Field Hacking did not suppress the local civic Report path")
+		return
+	var access_label := access.get_node_or_null("StatusLabel") as Label3D
+	if access_label == null or not access_label.text.contains("REPORT LINK JAMMED"):
+		await _fail("Compromised civic reporting state lacks readable local feedback")
+		return
+
+	# The same incident now fails to create Wanted because its Report path was prevented.
+	player.global_position = alarm.global_position + Vector3(0.8, 0.0, 0.0)
+	alarm.call("update_player_distance", player.global_position)
+	_scene_under_test.set("_active_target", alarm)
+	if not bool(_runtime.call("handle_action_pressed")):
+		await _fail("Compromised civic alarm could not be triggered")
+		return
+	if _heat(authority) != 0 or _state(authority) != "CLEAR":
+		await _fail("Suppressed Report incorrectly created Wanted state")
+		return
+
+	# Replay/service recovery restores both the access point and ordinary Report behavior.
+	_runtime.call("reset_runtime")
+	if not bool(alarm.get("report_enabled")):
+		await _fail("Replay did not restore civic reporting service")
+		return
+	var restored_label := access.get_node_or_null("StatusLabel") as Label3D
+	if restored_label == null or not restored_label.text.contains("SERVICE TAP"):
+		await _fail("Replay did not restore readable civic access state")
+		return
+
+	player.global_position = alarm.global_position + Vector3(0.8, 0.0, 0.0)
+	alarm.call("update_player_distance", player.global_position)
+	_scene_under_test.set("_active_target", alarm)
+	if not bool(_runtime.call("handle_action_pressed")):
+		await _fail("Restored civic alarm could not be triggered")
+		return
+	if _heat(authority) != 1 or _state(authority) != "CONTACT":
+		await _fail("Restored civic Report path did not create Heat 1 + Contact")
+		return
+
+	print("[FIELD_HACKING_REPORT_SUPPRESSION] PASS")
+	await _finish(0)

--- a/godot/tests/wanted_heat1_render_capture.gd
+++ b/godot/tests/wanted_heat1_render_capture.gd
@@ -9,8 +9,11 @@ var _player: Node3D = null
 var _pursuer: Node3D = null
 var _camera: Camera3D = null
 var _alarm: Node = null
+var _report_access: Node = null
 var _touch_ui: Node = null
 var _label: Label = null
+var _access_label: Label3D = null
+var _alarm_label: Label3D = null
 var _authority = null
 var _captures: Array[Dictionary] = []
 
@@ -51,10 +54,13 @@ func _run() -> void:
 	_pursuer = _scene.get_node_or_null("PursuerPrototype") as Node3D
 	_camera = _scene.get_node_or_null("ChinatownCamera3D") as Camera3D
 	_alarm = _scene.get_node_or_null("CivicServiceAlarm")
+	_report_access = _scene.get_node_or_null("CivicReportAccess")
 	_touch_ui = _scene.get_node_or_null("CanvasLayer/TouchControlsUI")
 	_label = _scene.get_node_or_null("CanvasLayer/WantedStatusLabel") as Label
+	_access_label = _report_access.get_node_or_null("StatusLabel") as Label3D if _report_access != null else null
+	_alarm_label = _alarm.get_node_or_null("StatusLabel") as Label3D if _alarm != null else null
 	_authority = _runtime.get("wanted_authority")
-	if _player == null or _pursuer == null or _camera == null or _alarm == null or _touch_ui == null or _label == null or _authority == null:
+	if _player == null or _pursuer == null or _camera == null or _alarm == null or _report_access == null or _touch_ui == null or _label == null or _access_label == null or _alarm_label == null or _authority == null:
 		_fail("Rendered proof is missing a production dependency")
 		return
 
@@ -100,13 +106,77 @@ func _run() -> void:
 		_fail(capture_error)
 		return
 
+	# FIELD HACKING: physically reach the local service tap through retained arbitration.
+	_runtime.call("reset_runtime")
+	_player.global_position = _report_access.global_position + Vector3(0.8, 0.0, 0.0)
+	_report_access.call("update_player_distance", _player.global_position)
+	_alarm.call("update_player_distance", _player.global_position)
+	_scene.call("_evaluate_target_selection")
+	if _scene.get("_active_target") != _report_access:
+		_fail("Physical civic service tap is not selectable through retained interaction arbitration")
+		return
+	_touch_ui.action_button_pressed.emit()
+	if bool(_alarm.get("report_enabled")) or not _access_label.text.contains("REPORT LINK JAMMED"):
+		_fail("Rendered Field Hacking setup did not compromise the local Report link")
+		return
+
+	# Trigger the same incident while compromised. The alarm faults locally and Wanted stays quiet.
+	_player.global_position = _alarm.global_position + Vector3(0.8, 0.0, 0.0)
+	_alarm.call("update_player_distance", _player.global_position)
+	_report_access.call("update_player_distance", _player.global_position)
+	_scene.call("_evaluate_target_selection")
+	if _scene.get("_active_target") != _alarm:
+		_fail("Compromised civic alarm is not selectable through retained interaction arbitration")
+		return
+	_touch_ui.action_button_pressed.emit()
+	if int(_authority.call("get_heat_level")) != 0 or String(_authority.call("get_wanted_state_name")) != "CLEAR" or _label.visible:
+		_fail("Compromised civic Report incorrectly created Wanted state")
+		return
+	if not _alarm_label.text.contains("ALARM FAULT"):
+		_fail("Compromised civic incident lacks readable local fault feedback")
+		return
+	_player.global_position = (_alarm.global_position + _report_access.global_position) * 0.5 + Vector3(0.8, 0.0, 0.0)
+	_camera.call("reset_camera_instant", _player)
+	capture_error = await _capture("04_field_hack_report_suppressed.png", "REPORT_SUPPRESSED")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+
+	# RECOVERY: replay restores service and the same incident creates ordinary Heat 1 again.
+	_runtime.call("reset_runtime")
+	if not bool(_alarm.get("report_enabled")) or not _access_label.text.contains("SERVICE TAP"):
+		_fail("Rendered recovery did not restore civic reporting service")
+		return
+	_player.global_position = _alarm.global_position + Vector3(0.8, 0.0, 0.0)
+	_alarm.call("update_player_distance", _player.global_position)
+	_report_access.call("update_player_distance", _player.global_position)
+	_scene.call("_evaluate_target_selection")
+	if _scene.get("_active_target") != _alarm:
+		_fail("Restored civic alarm is not selectable through retained interaction arbitration")
+		return
+	_touch_ui.action_button_pressed.emit()
+	if int(_authority.call("get_heat_level")) != 1 or String(_authority.call("get_wanted_state_name")) != "CONTACT":
+		_fail("Restored civic Report path did not create Heat 1 + Contact")
+		return
+	_camera.call("reset_camera_instant", _player)
+	capture_error = await _capture("05_restored_report_contact.png", "CONTACT_RESTORED")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+
+	_runtime.call("reset_runtime")
+	if int(_authority.call("get_heat_level")) != 0 or String(_authority.call("get_wanted_state_name")) != "CLEAR" or _label.visible:
+		_fail("Rendered proof cleanup did not restore quiet CLEAR state")
+		return
+
 	var report := {
-		"schema_version": 1,
+		"schema_version": 2,
 		"source_sha": OS.get_environment("SOURCE_SHA"),
 		"godot_version": Engine.get_version_info().get("string", "unknown"),
 		"display_server": DisplayServer.get_name(),
 		"renderer": RenderingServer.get_video_adapter_name(),
 		"real_playable_scene": true,
+		"field_hacking_access_path": "CivicReportAccess",
 		"captures": _captures,
 		"final_heat": int(_authority.call("get_heat_level")),
 		"final_state": String(_authority.call("get_wanted_state_name")),
@@ -139,6 +209,9 @@ func _capture(file_name: String, expected_state: String) -> String:
 		"heat": int(_authority.call("get_heat_level")),
 		"hud_visible": _label.visible,
 		"hud_text": _label.text,
+		"access_text": _access_label.text,
+		"alarm_text": _alarm_label.text,
+		"report_enabled": bool(_alarm.get("report_enabled")),
 		"player_position": [_player.global_position.x, _player.global_position.y, _player.global_position.z],
 		"pursuer_position": [_pursuer.global_position.x, _pursuer.global_position.y, _pursuer.global_position.z],
 	})


### PR DESCRIPTION
Closes #122

## Player-facing result

Adds one bounded Field Hacking composition on the existing Gears block:

`PHYSICAL SERVICE ACCESS -> REPORT LINK JAMMED -> CIVIC INCIDENT -> ALARM FAULT -> NO WANTED`

Replay/service recovery restores the ordinary path:

`SERVICE RESTORED -> CIVIC INCIDENT -> REPORT SENT -> HEAT 1 + CONTACT`

## Scope

- Adds one local `CivicReportAccess` service tap beside the existing Civic Utility infrastructure.
- Reuses the existing `CivicServiceAlarm.report_enabled` seam.
- Field Hacking suppresses the alarm's **future Report path** only.
- `WantedAuthority` is unchanged.
- Already-valid Wanted state cannot be erased by hacking.
- Existing mission pursuit remains authoritative when active.
- No generalized hacking framework, remote omnipotent targeting, Heat 2–5, surveillance network, new acreage, minimap, companion-command framework, or audio-production changes.

## Exact frozen feature head

`0567635aeb48a09e8a2b174b2eee125f71d1b492`

## Verification already passed on that exact head

- Heat-1 knowledge contract
- retained real-scene Heat-1 tracer
- Field Hacking report-suppression tracer
- Wanted HUD lane regression
- retained desktop authority regression
- windowed X11 runtime capture proving:
  - normal Report -> Heat 1 + Contact
  - Contact -> Search -> Clear retained
  - physical service access -> `REPORT LINK JAMMED`
  - same civic incident -> `ALARM FAULT`, Heat 0 / CLEAR
  - replay -> `SERVICE TAP`
  - same incident -> `REPORT SENT`, Heat 1 / Contact
- visual inspection of the new suppressed/restored frames
- readability RED/GREEN regression for local civic feedback
- mobile touch routing
- desktop controls
- desktop alias ownership
- desktop vehicle authority
- desktop interaction cancel
- Web export
- static hosting smoke
- browser artifact upload

The PR-only canonical compatibility matrix remains the merge gate and should run against this frozen head.