### PR TITLE
Burnside Production 03 — Civic Repossession / Wanted-Field-Hacking Composition

### DIFF
--- a/.github/workflows/burnside-production-03.yml
+++ b/.github/workflows/burnside-production-03.yml
@@ -10,6 +10,7 @@ on:
       - "godot/scripts/missions/civic_repossession_mission.gd"
       - "godot/scripts/missions/civic_repossession_runtime.gd"
       - "godot/tests/civic_repossession_mission_contract_test.gd"
+      - "godot/tests/civic_repossession_mission_contract_runner.gd"
       - "godot/tests/civic_repossession_wanted_composition_test.gd"
       - ".github/workflows/burnside-production-03.yml"
   pull_request:
@@ -19,6 +20,7 @@ on:
       - "godot/scripts/missions/civic_repossession_mission.gd"
       - "godot/scripts/missions/civic_repossession_runtime.gd"
       - "godot/tests/civic_repossession_mission_contract_test.gd"
+      - "godot/tests/civic_repossession_mission_contract_runner.gd"
       - "godot/tests/civic_repossession_wanted_composition_test.gd"
       - ".github/workflows/burnside-production-03.yml"
 
@@ -63,6 +65,16 @@ jobs:
         run: |
           set -euo pipefail
           "$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path godot --quit
+
+      - name: Run Mission 02 model contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/civic_repossession_mission_contract_runner.gd
 
       - name: Run Production 03 mission/Wanted composition tracer
         shell: bash

--- a/.github/workflows/burnside-production-03.yml
+++ b/.github/workflows/burnside-production-03.yml
@@ -1,0 +1,95 @@
+name: Burnside Production 03
+
+on:
+  push:
+    branches:
+      - "chatgpt/burnside-production-03-mission-wanted-composition"
+    paths:
+      - "godot/scripts/world/wanted_heat1_runtime.gd"
+      - "godot/scripts/interactions/civic_service_alarm.gd"
+      - "godot/scripts/missions/civic_repossession_mission.gd"
+      - "godot/scripts/missions/civic_repossession_runtime.gd"
+      - "godot/tests/civic_repossession_mission_contract_test.gd"
+      - "godot/tests/civic_repossession_wanted_composition_test.gd"
+      - ".github/workflows/burnside-production-03.yml"
+  pull_request:
+    paths:
+      - "godot/scripts/world/wanted_heat1_runtime.gd"
+      - "godot/scripts/interactions/civic_service_alarm.gd"
+      - "godot/scripts/missions/civic_repossession_mission.gd"
+      - "godot/scripts/missions/civic_repossession_runtime.gd"
+      - "godot/tests/civic_repossession_mission_contract_test.gd"
+      - "godot/tests/civic_repossession_wanted_composition_test.gd"
+      - ".github/workflows/burnside-production-03.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  mission-wanted-composition:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GODOT_RELEASE: "4.7.1-stable"
+      GODOT_BIN: "${{ github.workspace }}/.godot-bin/Godot_v4.7.1-stable_linux.x86_64"
+      SOURCE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+
+      - name: Verify exact source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+
+      - name: Install Godot 4.7.1 editor
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            --output godot.zip \
+            https://github.com/godotengine/godot/releases/download/${GODOT_RELEASE}/Godot_v${GODOT_RELEASE}_linux.x86_64.zip
+          echo "c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba  godot.zip" | sha256sum --check --strict
+          mkdir -p .godot-bin
+          unzip -q godot.zip -d .godot-bin
+          chmod +x "$GODOT_BIN"
+
+      - name: Prime Godot metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path godot --quit
+
+      - name: Run Production 03 mission/Wanted composition tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/civic_repossession_wanted_composition_test.gd
+
+      - name: Run retained Field Hacking report suppression tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/field_hacking_report_suppression_test.gd
+
+      - name: Run retained real-scene Heat-1 tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/wanted_heat1_scene_test.gd

--- a/.github/workflows/burnside-production-03.yml
+++ b/.github/workflows/burnside-production-03.yml
@@ -12,6 +12,7 @@ on:
       - "godot/tests/civic_repossession_mission_contract_test.gd"
       - "godot/tests/civic_repossession_mission_contract_runner.gd"
       - "godot/tests/civic_repossession_wanted_composition_test.gd"
+      - "godot/tests/civic_repossession_render_capture.gd"
       - ".github/workflows/burnside-production-03.yml"
   pull_request:
     paths:
@@ -22,6 +23,7 @@ on:
       - "godot/tests/civic_repossession_mission_contract_test.gd"
       - "godot/tests/civic_repossession_mission_contract_runner.gd"
       - "godot/tests/civic_repossession_wanted_composition_test.gd"
+      - "godot/tests/civic_repossession_render_capture.gd"
       - ".github/workflows/burnside-production-03.yml"
 
 permissions:
@@ -105,3 +107,24 @@ jobs:
             --rendering-method gl_compatibility \
             --path godot \
             --script res://tests/wanted_heat1_scene_test.gd
+
+      - name: Capture windowed Mission 02 composition proof
+        shell: bash
+        run: |
+          set -euo pipefail
+          timeout 120s xvfb-run -a \
+            "$GODOT_BIN" \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/civic_repossession_render_capture.gd
+          test -s godot/verification/production03/01_mission02_report_sent_contact.png
+          test -s godot/verification/production03/02_mission02_report_suppressed_clean_take.png
+          test -s godot/verification/production03/render_report.json
+
+      - name: Upload rendered Mission 02 composition proof
+        uses: actions/upload-artifact@v4
+        with:
+          name: burnside-production03-proof-${{ env.SOURCE_SHA }}
+          path: godot/verification/production03/
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/burnside-production-03.yml
+++ b/.github/workflows/burnside-production-03.yml
@@ -3,6 +3,7 @@ name: Burnside Production 03
 on:
   push:
     branches:
+      - "main"
       - "chatgpt/burnside-production-03-mission-wanted-composition"
     paths:
       - "godot/scripts/world/wanted_heat1_runtime.gd"

--- a/.github/workflows/burnside-production-03.yml
+++ b/.github/workflows/burnside-production-03.yml
@@ -12,6 +12,7 @@ on:
       - "godot/tests/civic_repossession_mission_contract_test.gd"
       - "godot/tests/civic_repossession_mission_contract_runner.gd"
       - "godot/tests/civic_repossession_wanted_composition_test.gd"
+      - "godot/tests/civic_repossession_pretriggered_suppression_test.gd"
       - "godot/tests/civic_repossession_render_capture.gd"
       - ".github/workflows/burnside-production-03.yml"
   pull_request:
@@ -23,6 +24,7 @@ on:
       - "godot/tests/civic_repossession_mission_contract_test.gd"
       - "godot/tests/civic_repossession_mission_contract_runner.gd"
       - "godot/tests/civic_repossession_wanted_composition_test.gd"
+      - "godot/tests/civic_repossession_pretriggered_suppression_test.gd"
       - "godot/tests/civic_repossession_render_capture.gd"
       - ".github/workflows/burnside-production-03.yml"
 
@@ -77,6 +79,16 @@ jobs:
             --rendering-method gl_compatibility \
             --path godot \
             --script res://tests/civic_repossession_mission_contract_runner.gd
+
+      - name: Run pre-triggered suppressed Mission 02 regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/civic_repossession_pretriggered_suppression_test.gd
 
       - name: Run Production 03 mission/Wanted composition tracer
         shell: bash

--- a/docs/superpowers/plans/2026-09-01-burnside-production-03-mission-wanted-composition.md
+++ b/docs/superpowers/plans/2026-09-01-burnside-production-03-mission-wanted-composition.md
@@ -1,0 +1,199 @@
+# Burnside Production 03 Mission/Wanted Composition Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Mission 02 — Civic Repossession use the existing civic Report/Field-Hacking/Wanted sandbox so jamming the local report link creates a clean Hauler theft while a live report creates normal Heat 1 + Contact/Search/Evasion.
+
+**Architecture:** Keep `BurnsideWantedRuntime` as the single open-world authority adapter. Add only a narrow mission-facing report/state seam there; reuse `CivicServiceAlarm` for the theft report attempt; adapt Mission 02's small state machine/runtime to branch on real Wanted state instead of starting the legacy pursuit. Mission 01/03, audio, saves, Gears geography, and generalized police/hacking architecture remain untouched.
+
+**Tech Stack:** Godot 4.7.1 Stable, GDScript, GitHub Actions/Xvfb verification.
+
+**Spec:** GitHub Issue #124 — Burnside Production 03 — Civic Repossession / Wanted-Field-Hacking Mission Composition.
+
+## Global Constraints
+
+- Base exact remote `main`: `d96eb0cd8918a79f346829d59d2bebbf471ce639`; gameplay parent `7a5c36598c6d950d832f71c42e41eaacfb7b75b2` is already runtime-verified.
+- Work only on `chatgpt/burnside-production-03-mission-wanted-composition` until reviewed/merged.
+- No new framework, acreage, Heat 2–5, generalized witnesses/surveillance, vehicle-recognition system, save schema, or audio-system changes.
+- Mission completion must never clear valid Wanted knowledge.
+- Production code follows RED -> observed expected failure -> minimal GREEN.
+- The connected chat environment has no local Git worktree; local dirty/upstream state is therefore UNKNOWN. Remote mutation is isolated to the exact-base feature branch and must not be represented as local-worktree proof.
+
+---
+
+### Task 1: RED — Mission 02 must compose the existing civic Report/Wanted seam
+
+**Files:**
+- Create: `godot/tests/civic_repossession_wanted_composition_test.gd`
+- Create: `.github/workflows/burnside-production-03.yml`
+
+**Interfaces:**
+- Consumes current autoload `BurnsideWantedRuntime`, production scene `res://scenes/prototype/scrap_test_block.tscn`, `MissionCivicRepossessionRuntime`, `CivicServiceAlarm`, `CivicReportAccess`, and real `ScrapHauler`.
+- Requires future runtime methods `request_civic_report(observed_position: Vector3) -> bool`, `get_heat_level() -> int`, and `get_wanted_state_name() -> String`.
+
+- [ ] **Step 1: Write the failing production-scene tracer**
+
+The test must instantiate the real production scene and fail until the new mission-facing Wanted seam exists. Minimum assertions:
+
+```gdscript
+if not _runtime.has_method("request_civic_report"):
+    await _fail("Mission-facing civic report seam is absent")
+    return
+if not _runtime.has_method("get_heat_level") or not _runtime.has_method("get_wanted_state_name"):
+    await _fail("Mission-facing Wanted read seam is absent")
+    return
+```
+
+After the seam exists, the same tracer must exercise two fresh/replayed paths:
+
+```text
+LIVE REPORT: unlock Mission 02 -> mount real ScrapHauler -> Heat 1 + CONTACT -> Mission 02 remains ESCAPE -> force legitimate Contact loss/Search expiry through existing authority seam -> Mission 02 reaches DELIVERY.
+JAMMED REPORT: replay -> unlock Mission 02 -> physically jam CivicReportAccess -> mount real ScrapHauler -> Heat 0/CLEAR -> Mission 02 reaches DELIVERY without legacy pursuit.
+```
+
+It must also assert that `current_pursuit_state` stays the retained legacy CALM value after Mission-02 Hauler mount on both paths, proving Mission 02 no longer calls `trigger_disturbance_alert()`.
+
+- [ ] **Step 2: Add a branch/PR workflow that runs the RED tracer plus retained Production-01/02 contracts**
+
+Use Godot 4.7.1 with the same pinned download/hash pattern as `.github/workflows/burnside-wanted-119.yml`. Run:
+
+```bash
+$GODOT_BIN --headless --rendering-method gl_compatibility --path godot --script res://tests/civic_repossession_wanted_composition_test.gd
+$GODOT_BIN --headless --rendering-method gl_compatibility --path godot --script res://tests/field_hacking_report_suppression_test.gd
+$GODOT_BIN --headless --rendering-method gl_compatibility --path godot --script res://tests/wanted_heat1_scene_test.gd
+```
+
+- [ ] **Step 3: Push the RED-only test/workflow commit and verify expected failure**
+
+Expected focused failure:
+
+```text
+[CIVIC_REPOSSESSION_WANTED_COMPOSITION] Mission-facing civic report seam is absent
+```
+
+No gameplay file may change before this failure is observed on the exact RED head.
+
+---
+
+### Task 2: GREEN — Expose the smallest civic-report/Wanted adapter seam
+
+**Files:**
+- Modify: `godot/scripts/interactions/civic_service_alarm.gd`
+- Modify: `godot/scripts/world/wanted_heat1_runtime.gd`
+- Test: `godot/tests/civic_repossession_wanted_composition_test.gd`
+- Retain: `godot/tests/field_hacking_report_suppression_test.gd`
+
+**Interfaces:**
+- `CivicServiceAlarm.trigger_report(observed_position: Vector3) -> bool` performs the same one-shot alarm state transition currently owned by `begin_interaction`, preserving `report_enabled` suppression.
+- `BurnsideWantedRuntime.request_civic_report(observed_position: Vector3) -> bool` delegates to the bound alarm only.
+- `BurnsideWantedRuntime.get_heat_level() -> int` and `get_wanted_state_name() -> String` are read-only adapters over `wanted_authority`.
+
+- [ ] **Step 1: Add/extend RED assertions for direct alarm-trigger equivalence**
+
+The tracer must prove a jammed alarm `trigger_report()` emits no Wanted and a restored/live alarm creates Heat 1 + Contact using the existing `_on_report_requested` path.
+
+- [ ] **Step 2: Implement `CivicServiceAlarm.trigger_report()` minimally**
+
+`begin_interaction()` should validate proximity then call the shared one-shot method. The shared method sets `is_triggered`, updates the label/state, emits `report_requested` only when `report_enabled`, emits `interaction_completed`, and returns `false` if already triggered.
+
+- [ ] **Step 3: Implement the three narrow `BurnsideWantedRuntime` methods**
+
+They must return safe `false`/`0`/`CLEAR` values when unbound rather than exposing private nodes or generalized event APIs.
+
+- [ ] **Step 4: Run focused + retained Field-Hacking/Wanted tests**
+
+Expected: adapter-specific assertions GREEN; Mission-02 composition assertions may remain RED until Task 3.
+
+---
+
+### Task 3: GREEN — Migrate only Mission 02 from forced legacy pursuit to real Wanted state
+
+**Files:**
+- Modify: `godot/scripts/missions/civic_repossession_mission.gd`
+- Modify: `godot/scripts/missions/civic_repossession_runtime.gd`
+- Modify: `godot/tests/civic_repossession_mission_contract_test.gd`
+- Test: `godot/tests/civic_repossession_wanted_composition_test.gd`
+
+**Interfaces:**
+- Add `CivicRepossessionMission.on_clean_take() -> bool`, valid only from `ESCAPE`, which advances directly to `DELIVERY`, records no fabricated route choice, and gives clear report-suppression copy.
+- `civic_repossession_runtime.gd` obtains `/root/BurnsideWantedRuntime`, calls `request_civic_report(_scrap_hauler.global_position)` exactly once on accepted Hauler mount, then branches on `get_heat_level()`/`get_wanted_state_name()`.
+
+- [ ] **Step 1: Update the pure mission contract first and observe RED**
+
+Add a second fixture:
+
+```gdscript
+var quiet = mission_script.new()
+quiet.unlock_after_scrap_job()
+quiet.on_vehicle_mounted("ScrapHauler")
+if not quiet.on_clean_take():
+    return "Report-suppressed Hauler theft did not advance to delivery"
+if quiet.phase != mission_script.Phase.DELIVERY:
+    return "Clean Hauler theft did not enter DELIVERY"
+```
+
+The existing loud/evasion fixture remains and must still reach DELIVERY through `on_evasion_complete()`.
+
+- [ ] **Step 2: Implement `on_clean_take()` with no new phase enum**
+
+Keep `LOCKED/GET_HAULER/ESCAPE/DELIVERY/FAILED/COMPLETE`; the quiet path is `GET_HAULER -> ESCAPE -> DELIVERY` synchronously after the report outcome is known.
+
+- [ ] **Step 3: Replace Mission-02 legacy-pursuit coupling in the runtime**
+
+Remove Mission 02's call to `trigger_disturbance_alert()` and its dependency on root `current_pursuit_state` for normal escape completion. On Hauler mount:
+
+```text
+mission.on_vehicle_mounted -> BurnsideWantedRuntime.request_civic_report(hauler position) ->
+if Heat == 0 and state == CLEAR: mission.on_clean_take + show garage zone
+else: remain ESCAPE and let BurnsideWantedRuntime own Contact/Search/Evasion
+```
+
+During `ESCAPE`, when the open-world runtime reports Heat 0/CLEAR after a loud report, call the existing `on_evasion_complete()` and show the garage zone. Do not reset or mutate Wanted from Mission 02.
+
+- [ ] **Step 4: Preserve Signal Gate mission bookkeeping only**
+
+Keep `_signal_gate.gate_triggered -> mission.on_gate_triggered()` while Mission 02 is ESCAPE. Do not add new pursuer routing behavior in this ticket.
+
+- [ ] **Step 5: Run focused model + production-scene tests**
+
+Expected: both live-report and jammed-report Mission-02 paths GREEN; legacy `current_pursuit_state` remains CALM on Mission-02 theft.
+
+---
+
+### Task 4: Exact-head verification, review, merge protection, exact-main proof
+
+**Files:**
+- Modify only if concrete verification/review findings require repair.
+- Do not update `HANDOFF.md` or Issue #55 before the gameplay merge is verified on main.
+
+**Interfaces:**
+- Frozen feature head is the exact SHA after all repairs and before final review.
+
+- [ ] **Step 1: Run focused Production-03 workflow on exact feature head**
+
+Require GREEN for the new tracer plus retained Production-01/02 tests.
+
+- [ ] **Step 2: Open the PR and run current PR compatibility workflows**
+
+Verify Mission 01/03, mobile touch routing, desktop controls/aliases/vehicle authority, interaction cancel, replay, current camera contracts, current legacy compatibility matrix, Web export/browser smoke, and any path-triggered Wanted tests.
+
+- [ ] **Step 3: Add windowed X11 proof if the focused workflow lacks sufficient player-facing evidence**
+
+Capture/read both mission outcomes at retained production camera/HUD scale:
+
+```text
+REPORT SENT -> HEAT 1 // CONTACT/SEARCH -> eventual DELIVERY
+REPORT LINK JAMMED / ALARM FAULT -> CLEAN TAKE -> DELIVERY
+```
+
+- [ ] **Step 4: Freeze the exact head and perform Standards + #124 spec review**
+
+Reject scope leak into Mission 01/03, audio, generalized Wanted/hacking, saves, or acreage. Repair only concrete findings and rerun affected gates.
+
+- [ ] **Step 5: Merge with exact-head protection and verify exact merged main**
+
+Use `expected_head_sha` on merge. Verify the resulting main SHA, required main-push Web Playtest workflow, and public playtest source stamp if the existing publication workflow runs.
+
+- [ ] **Step 6: Only after exact-main verification, update continuity**
+
+Refresh Issue #55/HANDOFF only with verified facts, close #124 as completed, and record the exact frozen feature head + merged main SHA.

--- a/godot/scripts/interactions/civic_service_alarm.gd
+++ b/godot/scripts/interactions/civic_service_alarm.gd
@@ -26,12 +26,16 @@ func can_interact(player_pos: Vector3) -> bool:
 func begin_interaction(player_pos: Vector3) -> bool:
 	if not can_interact(player_pos):
 		return false
+	return trigger_report(player_pos)
 
+func trigger_report(observed_position: Vector3) -> bool:
+	if is_triggered:
+		return false
 	is_triggered = true
 	_update_label()
 	state_changed.emit("TRIGGERED")
 	if report_enabled:
-		report_requested.emit(report_source, player_pos, contact_source)
+		report_requested.emit(report_source, observed_position, contact_source)
 	interaction_completed.emit()
 	return true
 

--- a/godot/scripts/missions/civic_repossession_mission.gd
+++ b/godot/scripts/missions/civic_repossession_mission.gd
@@ -46,6 +46,14 @@ func on_vehicle_mounted(vehicle_name: String) -> bool:
 	contact_line = "MAYOR BURN // Excellent. You are now driving a municipal accounting error. Try not to itemize yourself."
 	return true
 
+func on_clean_take() -> bool:
+	if phase != Phase.ESCAPE:
+		return false
+	phase = Phase.DELIVERY
+	objective = "OBJECTIVE // CLEAN TAKE // RETURN THE SCRAP HAULER TO BURN'S GARAGE"
+	contact_line = "MAYOR BURN // No report, no pursuit. Bring the accounting error home."
+	return true
+
 func on_gate_triggered() -> bool:
 	if phase != Phase.ESCAPE:
 		return false

--- a/godot/scripts/missions/civic_repossession_runtime.gd
+++ b/godot/scripts/missions/civic_repossession_runtime.gd
@@ -1,11 +1,10 @@
 extends Node
 
 ## Thin authored adapter for Mission/Narrative 02. Existing production systems
-## retain authority over vehicles, pursuit, Signal Gate, camera, radio and replay.
+## retain authority over vehicles, Wanted, Signal Gate, camera, radio and replay.
 
 const MissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
 const ScrapJobMissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
-const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
 const LEGACY_RETURN_ZONE_POSITION := Vector3(7.0, 0.08, 8.0)
 const DISTRICT_RETURN_ZONE_SOCKET_PATH := "GearsDistrictSlice01B/MissionDestinationSocket"
 const RETURN_ZONE_RADIUS := 2.6
@@ -15,6 +14,8 @@ var _root_controller: Node = null
 var _mission_one_runtime = null
 var _scrap_hauler = null
 var _signal_gate = null
+var _wanted_runtime: Node = null
+var _awaiting_wanted_clear: bool = false
 var _bound: bool = false
 
 var _return_zone: MeshInstance3D = null
@@ -49,18 +50,13 @@ func _process(_delta: float) -> void:
 	and _scrap_hauler.get("occupant") != null:
 		_on_hauler_mounted(_scrap_hauler.get("occupant"))
 
-	var root_pursuit_state := int(_root_controller.get("current_pursuit_state"))
 	var changed := false
 	if mission.phase == MissionScript.Phase.ESCAPE \
-	and root_pursuit_state == int(ScrapTestBlockScript.PursuitState.INTERCEPTED):
-		changed = mission.on_intercepted() or changed
-	elif mission.phase == MissionScript.Phase.FAILED \
-	and root_pursuit_state == int(ScrapTestBlockScript.PursuitState.PURSUIT_ACTIVE):
-		changed = mission.on_retry_started() or changed
-	elif mission.phase == MissionScript.Phase.ESCAPE \
-	and root_pursuit_state == int(ScrapTestBlockScript.PursuitState.EVADED):
+	and _awaiting_wanted_clear \
+	and _wanted_is_clear():
 		if mission.on_evasion_complete():
 			changed = true
+			_awaiting_wanted_clear = false
 			_set_return_zone_visible(true)
 
 	if mission.phase == MissionScript.Phase.DELIVERY \
@@ -81,8 +77,14 @@ func _try_bind_runtime() -> void:
 	_mission_one_runtime = _root_controller.get_node_or_null("MissionScrapJobRuntime")
 	_scrap_hauler = _root_controller.get("scrap_hauler")
 	_signal_gate = _root_controller.get("signal_gate")
+	_wanted_runtime = get_node_or_null("/root/BurnsideWantedRuntime")
 	var mission_hud := _root_controller.get_node_or_null("CanvasLayer/TouchControlsUI/SafeAreaRoot/MissionHUD")
 	if _mission_one_runtime == null or _scrap_hauler == null or _signal_gate == null or mission_hud == null:
+		return
+	if _wanted_runtime == null \
+	or not _wanted_runtime.has_method("request_civic_report") \
+	or not _wanted_runtime.has_method("get_heat_level") \
+	or not _wanted_runtime.has_method("get_wanted_state_name"):
 		return
 
 	_mission_title = mission_hud.find_child("MissionTitle", true, false) as Label
@@ -95,7 +97,7 @@ func _try_bind_runtime() -> void:
 	_signal_gate.gate_triggered.connect(_on_signal_gate_triggered)
 	_create_return_zone()
 	_bound = true
-	print("[MISSION_NARRATIVE_02] Runtime bound to retained Scrap Hauler/pursuit systems")
+	print("[MISSION_NARRATIVE_02] Runtime bound to retained Scrap Hauler/open-world Wanted systems")
 
 func _on_hauler_mounted(_player) -> void:
 	if not _bound:
@@ -103,10 +105,24 @@ func _on_hauler_mounted(_player) -> void:
 	if not mission.on_vehicle_mounted(_scrap_hauler.name):
 		return
 	_refresh_hud()
-	# Pursuit remains controller-owned. This only asks the existing disturbance
-	# authority to begin from its canonical CALM state.
-	if _root_controller.has_method("trigger_disturbance_alert"):
-		_root_controller.call("trigger_disturbance_alert")
+
+	# The theft creates one bounded civic Report attempt through the same local
+	# service path used by free roam. Field Hacking can suppress this future Report;
+	# the mission never creates or clears authority knowledge itself.
+	var report_attempted := bool(_wanted_runtime.call("request_civic_report", _scrap_hauler.global_position))
+	if _wanted_is_clear():
+		if report_attempted and mission.on_clean_take():
+			_set_return_zone_visible(true)
+			_refresh_hud()
+		return
+
+	_awaiting_wanted_clear = true
+
+func _wanted_is_clear() -> bool:
+	if _wanted_runtime == null:
+		return false
+	return int(_wanted_runtime.call("get_heat_level")) == 0 \
+	and String(_wanted_runtime.call("get_wanted_state_name")) == "CLEAR"
 
 func _on_signal_gate_triggered() -> void:
 	if mission.on_gate_triggered():
@@ -198,6 +214,7 @@ func _restore_mission_one_hud() -> void:
 
 func _reset_for_full_replay() -> void:
 	mission = MissionScript.new()
+	_awaiting_wanted_clear = false
 	_set_return_zone_visible(false)
 	_restore_mission_one_hud()
 	print("[MISSION_NARRATIVE_02] Full replay detected; Civic Repossession relocked")

--- a/godot/scripts/missions/civic_repossession_runtime.gd
+++ b/godot/scripts/missions/civic_repossession_runtime.gd
@@ -82,9 +82,12 @@ func _try_bind_runtime() -> void:
 	if _mission_one_runtime == null or _scrap_hauler == null or _signal_gate == null or mission_hud == null:
 		return
 	if _wanted_runtime == null \
+	or not _wanted_runtime.has_method("bind_to_scene") \
 	or not _wanted_runtime.has_method("request_civic_report") \
 	or not _wanted_runtime.has_method("get_heat_level") \
 	or not _wanted_runtime.has_method("get_wanted_state_name"):
+		return
+	if not bool(_wanted_runtime.call("bind_to_scene", _root_controller)):
 		return
 
 	_mission_title = mission_hud.find_child("MissionTitle", true, false) as Label
@@ -108,10 +111,12 @@ func _on_hauler_mounted(_player) -> void:
 
 	# The theft creates one bounded civic Report attempt through the same local
 	# service path used by free roam. Field Hacking can suppress this future Report;
-	# the mission never creates or clears authority knowledge itself.
-	var report_attempted := bool(_wanted_runtime.call("request_civic_report", _scrap_hauler.global_position))
+	# the mission never creates or clears authority knowledge itself. A bound civic
+	# path that remains CLEAR after the attempt is a clean take even if the one-shot
+	# alarm was already faulted by earlier sandbox play.
+	_wanted_runtime.call("request_civic_report", _scrap_hauler.global_position)
 	if _wanted_is_clear():
-		if report_attempted and mission.on_clean_take():
+		if mission.on_clean_take():
 			_set_return_zone_visible(true)
 			_refresh_hud()
 		return

--- a/godot/scripts/world/wanted_heat1_runtime.gd
+++ b/godot/scripts/world/wanted_heat1_runtime.gd
@@ -146,6 +146,17 @@ func handle_action_pressed() -> bool:
 	_alarm.update_player_distance(actor.global_position)
 	return _alarm.begin_interaction(actor.global_position)
 
+func request_civic_report(observed_position: Vector3) -> bool:
+	if not _bound or _alarm == null or not is_instance_valid(_alarm):
+		return false
+	return _alarm.trigger_report(observed_position)
+
+func get_heat_level() -> int:
+	return wanted_authority.get_heat_level() if wanted_authority != null else 0
+
+func get_wanted_state_name() -> String:
+	return wanted_authority.get_wanted_state_name() if wanted_authority != null else "CLEAR"
+
 func process_wanted(delta: float) -> void:
 	if not _bound or _scene_controller == null or _pursuer == null:
 		return

--- a/godot/tests/civic_repossession_mission_contract_runner.gd
+++ b/godot/tests/civic_repossession_mission_contract_runner.gd
@@ -1,0 +1,15 @@
+extends SceneTree
+
+const CivicRepossessionContract = preload("res://tests/civic_repossession_mission_contract_test.gd")
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _run() -> void:
+	var error := CivicRepossessionContract.verify()
+	if not error.is_empty():
+		push_error("[MISSION_NARRATIVE_02_CONTRACT] %s" % error)
+		quit(1)
+		return
+	print("[MISSION_NARRATIVE_02_CONTRACT] PASS")
+	quit(0)

--- a/godot/tests/civic_repossession_mission_contract_test.gd
+++ b/godot/tests/civic_repossession_mission_contract_test.gd
@@ -94,4 +94,20 @@ static func verify() -> String:
 	if not shortcut.on_return_zone_entered():
 		return "Shortcut fixture did not complete delivery"
 
+	var quiet = mission_script.new()
+	if not quiet.unlock_after_scrap_job():
+		return "Quiet-take fixture did not unlock"
+	if not quiet.on_vehicle_mounted("ScrapHauler"):
+		return "Quiet-take fixture did not accept Hauler"
+	if not quiet.has_method("on_clean_take"):
+		return "Clean-take mission transition is absent"
+	if not bool(quiet.call("on_clean_take")):
+		return "Report-suppressed Hauler theft did not advance to delivery"
+	if quiet.phase != mission_script.Phase.DELIVERY:
+		return "Clean Hauler theft did not enter DELIVERY"
+	if quiet.route_choice != mission_script.RouteChoice.UNDECIDED:
+		return "Clean Hauler theft fabricated a pursuit route choice"
+	if "RETURN" not in quiet.objective or "HAULER" not in quiet.objective:
+		return "Clean Hauler theft does not expose the garage delivery objective"
+
 	return ""

--- a/godot/tests/civic_repossession_pretriggered_suppression_test.gd
+++ b/godot/tests/civic_repossession_pretriggered_suppression_test.gd
@@ -1,0 +1,117 @@
+extends SceneTree
+
+const CivicMissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
+const ScrapJobMissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
+
+var _scene: Node = null
+var _runtime: Node = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _fail(message: String) -> void:
+	push_error("[CIVIC_REPOSSESSION_PRETRIGGERED_SUPPRESSION] %s" % message)
+	if is_instance_valid(_scene):
+		_scene.queue_free()
+	quit(1)
+
+func _complete_mission_one() -> String:
+	var mission_one_runtime := _scene.get_node_or_null("MissionScrapJobRuntime")
+	var civic_runtime := _scene.get_node_or_null("CivicRepossessionRuntime")
+	var tuner = _scene.get("signal_tuner")
+	var panel = _scene.get("corroded_panel")
+	if mission_one_runtime == null or civic_runtime == null or tuner == null or panel == null:
+		return "Mission fixture dependencies are missing"
+	tuner.set("current_state", SignalTuner.TunerState.LOCKED)
+	panel.set("current_step", CorrodedPanel.Step.EXTRACTED)
+	var mission = mission_one_runtime.mission
+	if mission.phase == ScrapJobMissionScript.Phase.BRIEFING:
+		mission.start()
+	if mission.phase == ScrapJobMissionScript.Phase.GET_BIKE:
+		mission.on_courier_bike_mounted()
+	if mission.phase == ScrapJobMissionScript.Phase.TRAVERSE_TO_TUNER:
+		mission.on_tuner_arrived()
+	if mission.phase == ScrapJobMissionScript.Phase.SPOOF_SIGNAL:
+		mission.on_signal_locked()
+	if mission.phase == ScrapJobMissionScript.Phase.EXTRACT_CORE:
+		mission.on_core_extracted()
+	if mission.phase == ScrapJobMissionScript.Phase.PURSUIT_COMPLICATION:
+		mission.on_pursuit_active()
+	if mission.phase == ScrapJobMissionScript.Phase.ROUTE_DECISION:
+		mission.on_escape_complete()
+	if mission.phase != ScrapJobMissionScript.Phase.COMPLETE:
+		return "Mission 01 fixture could not complete"
+	mission_one_runtime.call("_refresh_hud")
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.GET_HAULER:
+		return "Mission 02 did not unlock"
+	return ""
+
+func _run() -> void:
+	_runtime = root.get_node_or_null("BurnsideWantedRuntime")
+	if _runtime == null:
+		_fail("BurnsideWantedRuntime is missing")
+		return
+	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
+	if packed == null:
+		_fail("Production scene is missing")
+		return
+	_scene = packed.instantiate()
+	root.add_child(_scene)
+	await process_frame
+	await physics_frame
+	await process_frame
+	if not bool(_runtime.call("bind_to_scene", _scene)):
+		_fail("Wanted runtime did not bind")
+		return
+	var setup_error := await _complete_mission_one()
+	if not setup_error.is_empty():
+		_fail(setup_error)
+		return
+
+	var civic_runtime := _scene.get_node_or_null("CivicRepossessionRuntime")
+	var player := _scene.get_node_or_null("Runner") as Node3D
+	var access := _scene.get_node_or_null("CivicReportAccess")
+	var alarm := _scene.get_node_or_null("CivicServiceAlarm")
+	var hauler = _scene.get("scrap_hauler")
+	if civic_runtime == null or player == null or access == null or alarm == null or hauler == null:
+		_fail("Production fixture is incomplete")
+		return
+
+	# Jam the local report path through retained action routing.
+	player.global_position = access.global_position + Vector3(0.8, 0.0, 0.0)
+	access.call("update_player_distance", player.global_position)
+	_scene.set("_active_target", access)
+	if not bool(_runtime.call("handle_action_pressed")):
+		_fail("Could not jam civic report link")
+		return
+
+	# Trip the same one-shot alarm while jammed before Mission 02 theft. This is
+	# valid sandbox play and must not consume the later clean-take outcome.
+	player.global_position = alarm.global_position + Vector3(0.8, 0.0, 0.0)
+	alarm.call("update_player_distance", player.global_position)
+	_scene.set("_active_target", alarm)
+	if not bool(_runtime.call("handle_action_pressed")):
+		_fail("Could not trip jammed civic alarm")
+		return
+	if int(_runtime.call("get_heat_level")) != 0 or String(_runtime.call("get_wanted_state_name")) != "CLEAR":
+		_fail("Jammed pre-trigger incorrectly created Wanted")
+		return
+	if not bool(alarm.get("is_triggered")) or bool(alarm.get("report_enabled")):
+		_fail("Jammed pre-trigger did not leave the expected one-shot alarm fault state")
+		return
+
+	hauler.mounted.emit(player)
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.DELIVERY:
+		_fail("Pre-triggered suppressed report stranded Mission 02 instead of producing CLEAN TAKE")
+		return
+	if int(_runtime.call("get_heat_level")) != 0 or String(_runtime.call("get_wanted_state_name")) != "CLEAR":
+		_fail("Pre-triggered suppressed clean take fabricated Wanted")
+		return
+
+	print("[CIVIC_REPOSSESSION_PRETRIGGERED_SUPPRESSION] PASS")
+	_scene.queue_free()
+	await process_frame
+	_runtime.call("reset_runtime")
+	quit(0)

--- a/godot/tests/civic_repossession_render_capture.gd
+++ b/godot/tests/civic_repossession_render_capture.gd
@@ -1,0 +1,243 @@
+extends SceneTree
+
+const OUTPUT_DIR := "res://verification/production03"
+const SCENE_PATH := "res://scenes/prototype/scrap_test_block.tscn"
+const CivicMissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
+const ScrapJobMissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
+const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
+
+var _runtime: Node = null
+var _scene: Node = null
+var _captures: Array[Dictionary] = []
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _fail(message: String) -> void:
+	push_error("[CIVIC_REPOSSESSION_RENDER] %s" % message)
+	quit(1)
+
+func _free_scene() -> void:
+	if is_instance_valid(_scene):
+		_scene.queue_free()
+		await process_frame
+		await process_frame
+	_scene = null
+	if _runtime != null and _runtime.has_method("reset_runtime"):
+		_runtime.call("reset_runtime")
+
+func _fresh_scene() -> Node:
+	await _free_scene()
+	var packed := load(SCENE_PATH) as PackedScene
+	if packed == null:
+		return null
+	_scene = packed.instantiate()
+	root.add_child(_scene)
+	await process_frame
+	await physics_frame
+	await process_frame
+	if not bool(_runtime.call("bind_to_scene", _scene)):
+		return null
+	await process_frame
+	return _scene
+
+func _complete_mission_one(scene: Node) -> String:
+	var mission_one_runtime := scene.get_node_or_null("MissionScrapJobRuntime")
+	var civic_runtime := scene.get_node_or_null("CivicRepossessionRuntime")
+	var tuner = scene.get("signal_tuner")
+	var panel = scene.get("corroded_panel")
+	if mission_one_runtime == null or civic_runtime == null or tuner == null or panel == null:
+		return "Mission fixture dependencies are missing"
+	tuner.set("current_state", SignalTuner.TunerState.LOCKED)
+	panel.set("current_step", CorrodedPanel.Step.EXTRACTED)
+	var mission = mission_one_runtime.mission
+	if mission.phase == ScrapJobMissionScript.Phase.BRIEFING:
+		mission.start()
+	if mission.phase == ScrapJobMissionScript.Phase.GET_BIKE:
+		mission.on_courier_bike_mounted()
+	if mission.phase == ScrapJobMissionScript.Phase.TRAVERSE_TO_TUNER:
+		mission.on_tuner_arrived()
+	if mission.phase == ScrapJobMissionScript.Phase.SPOOF_SIGNAL:
+		mission.on_signal_locked()
+	if mission.phase == ScrapJobMissionScript.Phase.EXTRACT_CORE:
+		mission.on_core_extracted()
+	if mission.phase == ScrapJobMissionScript.Phase.PURSUIT_COMPLICATION:
+		mission.on_pursuit_active()
+	if mission.phase == ScrapJobMissionScript.Phase.ROUTE_DECISION:
+		mission.on_escape_complete()
+	if mission.phase != ScrapJobMissionScript.Phase.COMPLETE:
+		return "Mission 01 fixture could not complete"
+	mission_one_runtime.call("_refresh_hud")
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.GET_HAULER:
+		return "Mission 02 did not unlock"
+	return ""
+
+func _mission_ui(scene: Node) -> Dictionary:
+	var hud := scene.get_node_or_null("CanvasLayer/TouchControlsUI/SafeAreaRoot/MissionHUD")
+	if hud == null:
+		return {}
+	return {
+		"title": hud.find_child("MissionTitle", true, false) as Label,
+		"objective": hud.find_child("ObjectiveLabel", true, false) as Label,
+		"contact": hud.find_child("ContactLabel", true, false) as Label,
+		"wanted": scene.get_node_or_null("CanvasLayer/WantedStatusLabel") as Label,
+	}
+
+func _capture(file_name: String, scene: Node, labels: Dictionary, access: Node, alarm: Node, expected_outcome: String) -> String:
+	await process_frame
+	await process_frame
+	var image: Image = root.get_texture().get_image()
+	if image == null or image.is_empty():
+		return "Rendered viewport is empty for %s" % file_name
+	var save_error := image.save_png(OUTPUT_DIR + "/" + file_name)
+	if save_error != OK:
+		return "Could not save %s: %s" % [file_name, save_error]
+	var access_label := access.get_node_or_null("StatusLabel") as Label3D
+	var alarm_label := alarm.get_node_or_null("StatusLabel") as Label3D
+	var wanted_label := labels["wanted"] as Label
+	var title := labels["title"] as Label
+	var objective := labels["objective"] as Label
+	var contact := labels["contact"] as Label
+	_captures.append({
+		"file": file_name,
+		"outcome": expected_outcome,
+		"legacy_pursuit_state": int(scene.get("current_pursuit_state")),
+		"heat": int(_runtime.call("get_heat_level")),
+		"wanted_state": String(_runtime.call("get_wanted_state_name")),
+		"wanted_visible": wanted_label.visible,
+		"wanted_text": wanted_label.text,
+		"mission_title": title.text,
+		"objective": objective.text,
+		"contact": contact.text,
+		"access_text": access_label.text if access_label != null else "",
+		"alarm_text": alarm_label.text if alarm_label != null else "",
+		"report_enabled": bool(alarm.get("report_enabled")),
+	})
+	return ""
+
+func _run() -> void:
+	var output_abs := ProjectSettings.globalize_path(OUTPUT_DIR)
+	var dir_error := DirAccess.make_dir_recursive_absolute(output_abs)
+	if dir_error != OK and dir_error != ERR_ALREADY_EXISTS:
+		_fail("Could not create output directory: %s" % dir_error)
+		return
+
+	_runtime = root.get_node_or_null("BurnsideWantedRuntime")
+	if _runtime == null:
+		_fail("BurnsideWantedRuntime autoload is missing")
+		return
+
+	# LIVE REPORT: Mission 02 shares the ordinary Heat-1 authority while the
+	# historical mission pursuit stays CALM.
+	var live_scene := await _fresh_scene()
+	if live_scene == null:
+		_fail("Could not load/bind live-report production scene")
+		return
+	var setup_error := await _complete_mission_one(live_scene)
+	if not setup_error.is_empty():
+		_fail(setup_error)
+		return
+	var live_civic := live_scene.get_node_or_null("CivicRepossessionRuntime")
+	var live_hauler = live_scene.get("scrap_hauler")
+	var live_player := live_scene.get_node_or_null("Runner") as Node3D
+	var live_alarm := live_scene.get_node_or_null("CivicServiceAlarm")
+	var live_access := live_scene.get_node_or_null("CivicReportAccess")
+	var live_camera := live_scene.get_node_or_null("ChinatownCamera3D") as Camera3D
+	var live_labels := _mission_ui(live_scene)
+	if live_civic == null or live_hauler == null or live_player == null or live_alarm == null or live_access == null or live_camera == null or live_labels.is_empty():
+		_fail("Live-report render fixture is incomplete")
+		return
+	live_hauler.global_position = live_alarm.global_position + Vector3(2.0, 0.0, 0.0)
+	live_player.global_position = live_alarm.global_position + Vector3(0.8, 0.0, 0.0)
+	live_hauler.mounted.emit(live_player)
+	await process_frame
+	if live_civic.mission.phase != CivicMissionScript.Phase.ESCAPE \
+	or int(_runtime.call("get_heat_level")) != 1 \
+	or String(_runtime.call("get_wanted_state_name")) != "CONTACT" \
+	or int(live_scene.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.CALM):
+		_fail("Live-report Mission 02 render state is incorrect")
+		return
+	var live_wanted := live_labels["wanted"] as Label
+	var live_objective := live_labels["objective"] as Label
+	if not live_wanted.visible or not live_wanted.text.contains("HEAT 1") or not live_objective.text.contains("LOSE THE PURSUER"):
+		_fail("Live-report Mission/Wanted HUD is not readable")
+		return
+	live_camera.call("reset_camera_instant", live_player)
+	var capture_error := await _capture("01_mission02_report_sent_contact.png", live_scene, live_labels, live_access, live_alarm, "REPORT_SENT_CONTACT")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+
+	# JAMMED REPORT: physically use the local service access, then take the same
+	# Hauler. The local alarm faults, Wanted stays quiet, and Mission 02 exposes the
+	# clean-delivery objective immediately.
+	var quiet_scene := await _fresh_scene()
+	if quiet_scene == null:
+		_fail("Could not load/bind clean-take production scene")
+		return
+	setup_error = await _complete_mission_one(quiet_scene)
+	if not setup_error.is_empty():
+		_fail(setup_error)
+		return
+	var quiet_civic := quiet_scene.get_node_or_null("CivicRepossessionRuntime")
+	var quiet_hauler = quiet_scene.get("scrap_hauler")
+	var quiet_player := quiet_scene.get_node_or_null("Runner") as Node3D
+	var quiet_alarm := quiet_scene.get_node_or_null("CivicServiceAlarm")
+	var quiet_access := quiet_scene.get_node_or_null("CivicReportAccess")
+	var quiet_camera := quiet_scene.get_node_or_null("ChinatownCamera3D") as Camera3D
+	var quiet_labels := _mission_ui(quiet_scene)
+	if quiet_civic == null or quiet_hauler == null or quiet_player == null or quiet_alarm == null or quiet_access == null or quiet_camera == null or quiet_labels.is_empty():
+		_fail("Clean-take render fixture is incomplete")
+		return
+	quiet_player.global_position = quiet_access.global_position + Vector3(0.8, 0.0, 0.0)
+	quiet_access.call("update_player_distance", quiet_player.global_position)
+	quiet_scene.set("_active_target", quiet_access)
+	if not bool(_runtime.call("handle_action_pressed")) or bool(quiet_alarm.get("report_enabled")):
+		_fail("Clean-take render fixture could not jam the local Report link")
+		return
+	quiet_hauler.global_position = quiet_alarm.global_position + Vector3(2.0, 0.0, 0.0)
+	quiet_hauler.mounted.emit(quiet_player)
+	await process_frame
+	if quiet_civic.mission.phase != CivicMissionScript.Phase.DELIVERY \
+	or int(_runtime.call("get_heat_level")) != 0 \
+	or String(_runtime.call("get_wanted_state_name")) != "CLEAR" \
+	or int(quiet_scene.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.CALM):
+		_fail("Clean-take Mission 02 render state is incorrect")
+		return
+	var quiet_wanted := quiet_labels["wanted"] as Label
+	var quiet_objective := quiet_labels["objective"] as Label
+	var quiet_access_label := quiet_access.get_node_or_null("StatusLabel") as Label3D
+	var quiet_alarm_label := quiet_alarm.get_node_or_null("StatusLabel") as Label3D
+	if quiet_wanted.visible \
+	or not quiet_objective.text.contains("CLEAN TAKE") \
+	or quiet_access_label == null or not quiet_access_label.text.contains("REPORT LINK JAMMED") \
+	or quiet_alarm_label == null or not quiet_alarm_label.text.contains("ALARM FAULT"):
+		_fail("Clean-take Mission/civic feedback is not readable")
+		return
+	quiet_player.global_position = (quiet_alarm.global_position + quiet_access.global_position) * 0.5 + Vector3(0.8, 0.0, 0.0)
+	quiet_camera.call("reset_camera_instant", quiet_player)
+	capture_error = await _capture("02_mission02_report_suppressed_clean_take.png", quiet_scene, quiet_labels, quiet_access, quiet_alarm, "REPORT_SUPPRESSED_CLEAN_TAKE")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+
+	var report := {
+		"schema_version": 1,
+		"source_sha": OS.get_environment("SOURCE_SHA"),
+		"godot_version": Engine.get_version_info().get("string", "unknown"),
+		"display_server": DisplayServer.get_name(),
+		"renderer": RenderingServer.get_video_adapter_name(),
+		"real_playable_scene": true,
+		"captures": _captures,
+	}
+	var report_file := FileAccess.open(OUTPUT_DIR + "/render_report.json", FileAccess.WRITE)
+	if report_file == null:
+		_fail("Could not write Production 03 render report")
+		return
+	report_file.store_string(JSON.stringify(report, "\t"))
+	report_file.close()
+
+	print("[CIVIC_REPOSSESSION_RENDER] PASS: %s" % OUTPUT_DIR)
+	await _free_scene()
+	quit(0)

--- a/godot/tests/civic_repossession_wanted_composition_test.gd
+++ b/godot/tests/civic_repossession_wanted_composition_test.gd
@@ -1,0 +1,234 @@
+extends SceneTree
+
+const CivicMissionScript = preload("res://scripts/missions/civic_repossession_mission.gd")
+const ScrapJobMissionScript = preload("res://scripts/missions/scrap_job_mission.gd")
+const ScrapTestBlockScript = preload("res://scripts/prototype/scrap_test_block.gd")
+
+var _runtime: Node = null
+var _scene_under_test: Node = null
+var _stage: String = "init"
+
+func _init() -> void:
+	call_deferred("_watchdog")
+	call_deferred("_run")
+
+func _watchdog() -> void:
+	await create_timer(20.0).timeout
+	push_error("[CIVIC_REPOSSESSION_WANTED_COMPOSITION] WATCHDOG TIMEOUT stage=%s" % _stage)
+	quit(1)
+
+func _finish(exit_code: int) -> void:
+	_stage = "finish"
+	await _free_scene()
+	quit(exit_code)
+
+func _fail(message: String) -> void:
+	push_error("[CIVIC_REPOSSESSION_WANTED_COMPOSITION] %s (stage=%s)" % [message, _stage])
+	await _finish(1)
+
+func _heat() -> int:
+	return int(_runtime.call("get_heat_level"))
+
+func _state() -> String:
+	return String(_runtime.call("get_wanted_state_name"))
+
+func _free_scene() -> void:
+	if is_instance_valid(_scene_under_test):
+		_scene_under_test.queue_free()
+		await process_frame
+		await process_frame
+	_scene_under_test = null
+	if _runtime != null and _runtime.has_method("reset_runtime"):
+		_runtime.call("reset_runtime")
+
+func _fresh_scene() -> Node:
+	await _free_scene()
+	var packed := load("res://scenes/prototype/scrap_test_block.tscn") as PackedScene
+	if packed == null:
+		return null
+	_scene_under_test = packed.instantiate()
+	root.add_child(_scene_under_test)
+	await process_frame
+	await physics_frame
+	await process_frame
+	_runtime.call("bind_to_scene", _scene_under_test)
+	await process_frame
+	return _scene_under_test
+
+func _complete_mission_one(scene: Node) -> String:
+	var mission_one_runtime := scene.get_node_or_null("MissionScrapJobRuntime")
+	var civic_runtime := scene.get_node_or_null("CivicRepossessionRuntime")
+	var tuner = scene.get("signal_tuner")
+	var panel = scene.get("corroded_panel")
+	if mission_one_runtime == null or civic_runtime == null or tuner == null or panel == null:
+		return "Production mission runtimes or retained Mission-01 interactions are missing"
+
+	# Keep retained solved-state consistent so Mission 01 cannot interpret this fixture
+	# as a full replay and immediately restart after authored completion.
+	tuner.set("current_state", SignalTuner.TunerState.LOCKED)
+	panel.set("current_step", CorrodedPanel.Step.EXTRACTED)
+
+	var mission = mission_one_runtime.mission
+	if mission.phase == ScrapJobMissionScript.Phase.BRIEFING:
+		mission.start()
+	if mission.phase == ScrapJobMissionScript.Phase.GET_BIKE:
+		mission.on_courier_bike_mounted()
+	if mission.phase == ScrapJobMissionScript.Phase.TRAVERSE_TO_TUNER:
+		mission.on_tuner_arrived()
+	if mission.phase == ScrapJobMissionScript.Phase.SPOOF_SIGNAL:
+		mission.on_signal_locked()
+	if mission.phase == ScrapJobMissionScript.Phase.EXTRACT_CORE:
+		mission.on_core_extracted()
+	if mission.phase == ScrapJobMissionScript.Phase.PURSUIT_COMPLICATION:
+		mission.on_pursuit_active()
+	if mission.phase == ScrapJobMissionScript.Phase.ROUTE_DECISION:
+		mission.on_escape_complete()
+
+	if mission.phase != ScrapJobMissionScript.Phase.COMPLETE:
+		return "Mission 01 fixture could not reach COMPLETE"
+	mission_one_runtime.call("_refresh_hud")
+	await process_frame
+	if civic_runtime.mission.phase != CivicMissionScript.Phase.GET_HAULER:
+		return "Mission 01 completion did not unlock Civic Repossession"
+	return ""
+
+func _force_legitimate_evasion() -> String:
+	var authority = _runtime.get("wanted_authority")
+	if authority == null:
+		return "WantedAuthority is absent"
+	if String(authority.call("get_wanted_state_name")) != "CONTACT":
+		return "Evasion fixture did not begin from Contact"
+	if not bool(authority.call(
+		"lose_contact",
+		authority.call("get_last_known_position"),
+		authority.call("get_last_known_direction"),
+		"production03_test_contact_break"
+	)):
+		return "Authority rejected a valid Contact -> Search transition"
+	if String(authority.call("get_wanted_state_name")) != "SEARCH":
+		return "Contact loss did not enter Search"
+	var search_seconds := float(authority.get("search_evasion_seconds"))
+	if not bool(authority.call("advance_search", search_seconds + 0.1)):
+		return "Search timeout did not produce Evasion"
+	if int(authority.call("get_heat_level")) != 0 or String(authority.call("get_wanted_state_name")) != "CLEAR":
+		return "Legitimate Evasion did not clear Wanted"
+	return ""
+
+func _run() -> void:
+	_runtime = root.get_node_or_null("BurnsideWantedRuntime")
+	if _runtime == null:
+		await _fail("BurnsideWantedRuntime autoload is absent")
+		return
+
+	# Intentional RED gate. Mission 02 must not reach into private alarm/authority
+	# internals; Production 03 adds only this narrow public composition seam.
+	if not _runtime.has_method("request_civic_report"):
+		await _fail("Mission-facing civic report seam is absent")
+		return
+	if not _runtime.has_method("get_heat_level") or not _runtime.has_method("get_wanted_state_name"):
+		await _fail("Mission-facing Wanted read seam is absent")
+		return
+
+	_stage = "live_report"
+	var live_scene := await _fresh_scene()
+	if live_scene == null:
+		await _fail("Could not load production scrap_test_block scene")
+		return
+	var setup_error := await _complete_mission_one(live_scene)
+	if not setup_error.is_empty():
+		await _fail(setup_error)
+		return
+
+	var live_civic := live_scene.get_node_or_null("CivicRepossessionRuntime")
+	var live_hauler = live_scene.get("scrap_hauler")
+	if live_civic == null or live_hauler == null:
+		await _fail("Civic Repossession runtime or Scrap Hauler is absent")
+		return
+
+	live_hauler.mounted.emit(live_scene.get_node("Runner"))
+	await process_frame
+	if int(live_scene.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.CALM):
+		await _fail("Mission 02 Hauler theft still starts legacy pursuit directly")
+		return
+	if _heat() != 1 or _state() != "CONTACT":
+		await _fail("Live civic theft Report did not produce Heat 1 + Contact")
+		return
+	if live_civic.mission.phase != CivicMissionScript.Phase.ESCAPE:
+		await _fail("Live-report Hauler theft did not remain in ESCAPE while Wanted is active")
+		return
+
+	var evasion_error := _force_legitimate_evasion()
+	if not evasion_error.is_empty():
+		await _fail(evasion_error)
+		return
+	await process_frame
+	if live_civic.mission.phase != CivicMissionScript.Phase.DELIVERY:
+		await _fail("Legitimate open-world Evasion did not advance Civic Repossession to DELIVERY")
+		return
+
+	_stage = "jammed_report"
+	var jam_scene := await _fresh_scene()
+	if jam_scene == null:
+		await _fail("Could not reload production scene for jammed path")
+		return
+	setup_error = await _complete_mission_one(jam_scene)
+	if not setup_error.is_empty():
+		await _fail(setup_error)
+		return
+
+	var jam_civic := jam_scene.get_node_or_null("CivicRepossessionRuntime")
+	var jam_hauler = jam_scene.get("scrap_hauler")
+	var player := jam_scene.get_node_or_null("Runner") as Node3D
+	var access := jam_scene.get_node_or_null("CivicReportAccess")
+	var alarm := jam_scene.get_node_or_null("CivicServiceAlarm")
+	if jam_civic == null or jam_hauler == null or player == null or access == null or alarm == null:
+		await _fail("Jammed-path production fixture is missing Mission 02, Hauler, player, or civic infrastructure")
+		return
+
+	player.global_position = access.global_position + Vector3(0.8, 0.0, 0.0)
+	access.call("update_player_distance", player.global_position)
+	jam_scene.set("_active_target", access)
+	if not bool(_runtime.call("handle_action_pressed")):
+		await _fail("Physical civic service access did not jam the report link")
+		return
+	if bool(alarm.get("report_enabled")):
+		await _fail("Field Hacking did not suppress the civic report path before Hauler theft")
+		return
+
+	jam_hauler.mounted.emit(player)
+	await process_frame
+	if int(jam_scene.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.CALM):
+		await _fail("Jammed Mission 02 theft fabricated a legacy pursuit")
+		return
+	if _heat() != 0 or _state() != "CLEAR":
+		await _fail("Suppressed Mission 02 theft Report incorrectly created Wanted")
+		return
+	if jam_civic.mission.phase != CivicMissionScript.Phase.DELIVERY:
+		await _fail("Report-suppressed Hauler theft did not advance directly to DELIVERY")
+		return
+
+	# Mission completion is not an authority reset. Restore civic service directly,
+	# create another valid incident while Mission 02 is already in DELIVERY, then
+	# deliver the Hauler and prove the valid Wanted state survives completion.
+	_runtime.call("reset_runtime")
+	if not bool(_runtime.call("request_civic_report", player.global_position)):
+		await _fail("Restored civic service could not create a post-theft valid Report")
+		return
+	if _heat() != 1 or _state() != "CONTACT":
+		await _fail("Post-theft valid Report did not create Heat 1 + Contact")
+		return
+	var return_zone := jam_scene.get_node_or_null("CivicRepossessionReturnZone") as Node3D
+	if return_zone == null:
+		await _fail("Civic Repossession return zone is absent")
+		return
+	jam_hauler.global_position = return_zone.global_position
+	await process_frame
+	if jam_civic.mission.phase != CivicMissionScript.Phase.COMPLETE:
+		await _fail("Garage delivery did not complete Civic Repossession")
+		return
+	if _heat() != 1 or _state() != "CONTACT":
+		await _fail("Mission completion silently cleared valid Wanted knowledge")
+		return
+
+	print("[CIVIC_REPOSSESSION_WANTED_COMPOSITION] PASS")
+	await _finish(0)

--- a/godot/tests/civic_repossession_wanted_composition_test.gd
+++ b/godot/tests/civic_repossession_wanted_composition_test.gd
@@ -166,6 +166,39 @@ func _run() -> void:
 		await _fail("Legitimate open-world Evasion did not advance Civic Repossession to DELIVERY")
 		return
 
+	_stage = "preexisting_wanted"
+	var preexisting_scene := await _fresh_scene()
+	if preexisting_scene == null:
+		await _fail("Could not reload production scene for pre-existing Wanted path")
+		return
+	setup_error = await _complete_mission_one(preexisting_scene)
+	if not setup_error.is_empty():
+		await _fail(setup_error)
+		return
+	var preexisting_civic := preexisting_scene.get_node_or_null("CivicRepossessionRuntime")
+	var preexisting_hauler = preexisting_scene.get("scrap_hauler")
+	var preexisting_player := preexisting_scene.get_node_or_null("Runner") as Node3D
+	if preexisting_civic == null or preexisting_hauler == null or preexisting_player == null:
+		await _fail("Pre-existing Wanted fixture is missing Mission 02, Hauler, or player")
+		return
+	if not bool(_runtime.call("request_civic_report", preexisting_player.global_position)):
+		await _fail("Pre-existing Wanted fixture could not create a valid civic Report")
+		return
+	if _heat() != 1 or _state() != "CONTACT":
+		await _fail("Pre-existing Wanted fixture did not begin at Heat 1 + Contact")
+		return
+	preexisting_hauler.mounted.emit(preexisting_player)
+	await process_frame
+	if int(preexisting_scene.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.CALM):
+		await _fail("Mission 02 with pre-existing Wanted started the retired legacy pursuit")
+		return
+	if _heat() != 1 or _state() != "CONTACT":
+		await _fail("Mission 02 start/mount erased or replaced pre-existing Wanted knowledge")
+		return
+	if preexisting_civic.mission.phase != CivicMissionScript.Phase.ESCAPE:
+		await _fail("Mission 02 with pre-existing Wanted did not remain in ESCAPE")
+		return
+
 	_stage = "jammed_report"
 	var jam_scene := await _fresh_scene()
 	if jam_scene == null:

--- a/godot/tests/touch_controls_event_routing_test.gd
+++ b/godot/tests/touch_controls_event_routing_test.gd
@@ -75,6 +75,17 @@ func _run() -> void:
 		await _fail("Main scene is missing TouchControlsUI or Runner")
 		return
 
+	var wanted_runtime := root.get_node_or_null("BurnsideWantedRuntime")
+	if wanted_runtime == null \
+	or not wanted_runtime.has_method("bind_to_scene") \
+	or not wanted_runtime.has_method("get_heat_level") \
+	or not wanted_runtime.has_method("get_wanted_state_name"):
+		await _fail("BurnsideWantedRuntime Mission 02 composition seam is unavailable")
+		return
+	if not bool(wanted_runtime.call("bind_to_scene", _scene_under_test)):
+		await _fail("BurnsideWantedRuntime did not bind to the retained production scene")
+		return
+
 	var runtime := _scene_under_test.get_node_or_null("MissionScrapJobRuntime")
 	if runtime == null or not bool(runtime.get("_bound")):
 		await _fail("Mission/Narrative 01 runtime did not bind to retained gameplay systems")
@@ -270,27 +281,37 @@ func _run() -> void:
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
 		await _fail("Real Scrap Hauler mounted signal did not start Civic Repossession escape")
 		return
-	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.DISTURBANCE_ALERT):
-		await _fail("Hauler theft did not enter the retained disturbance/pursuit authority")
+	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.CALM):
+		await _fail("Mission 02 Hauler theft started the retired legacy pursuit path")
 		return
-
-	_stage = "mission2_intercept"
-	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.INTERCEPTED)
-	await process_frame
-	if civic_runtime.mission.phase != CivicMissionScript.Phase.FAILED or "RETRY PURSUIT" not in objective.text:
-		await _fail("Controller-authoritative interception did not fail Civic Repossession")
-		return
-	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.PURSUIT_ACTIVE)
-	await process_frame
-	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
-		await _fail("Controller-authoritative fast retry did not resume Civic Repossession escape")
+	if int(wanted_runtime.call("get_heat_level")) != 1 \
+	or String(wanted_runtime.call("get_wanted_state_name")) != "CONTACT":
+		await _fail("Live Civic Repossession theft did not produce Heat 1 + CONTACT")
 		return
 
 	_stage = "mission2_evasion"
-	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.EVADED)
+	var wanted_authority = wanted_runtime.get("wanted_authority")
+	if wanted_authority == null:
+		await _fail("Civic Repossession could not read the retained Wanted authority fixture")
+		return
+	if not bool(wanted_authority.call(
+		"lose_contact",
+		wanted_authority.call("get_last_known_position"),
+		wanted_authority.call("get_last_known_direction"),
+		"mobile_touch_mission2_contact_break"
+	)):
+		await _fail("Mission 02 live-report path could not enter Search through legitimate Contact loss")
+		return
+	if String(wanted_runtime.call("get_wanted_state_name")) != "SEARCH":
+		await _fail("Mission 02 Contact loss did not enter Search")
+		return
+	var search_seconds := float(wanted_authority.get("search_evasion_seconds"))
+	if not bool(wanted_authority.call("advance_search", search_seconds + 0.1)):
+		await _fail("Mission 02 Search did not produce legitimate Evasion")
+		return
 	await process_frame
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.DELIVERY:
-		await _fail("Controller-authoritative evasion did not advance Civic Repossession to delivery")
+		await _fail("Open-world Wanted Evasion did not advance Civic Repossession to delivery")
 		return
 	if not return_zone.visible:
 		await _fail("Civic Repossession return zone did not become visible for delivery")
@@ -364,15 +385,8 @@ func _run() -> void:
 	if city_runtime.mission.phase != CityMissionScript.Phase.ESCAPE:
 		await _fail("Authored HS-7 Echo completion did not start Mission 03 escape")
 		return
-	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.EVADED):
-		await _fail("Mission 03 mutated or consumed stale Mission 02 evasion before retained de-escalation")
-		return
-	# Model the retained pursuer's authoritative de-escalation-completed transition.
-	# Only after CALM may Mission 03 ask the root controller for its fresh chase.
-	_scene_under_test.set("current_pursuit_state", ScrapTestBlockScript.PursuitState.CALM)
-	await process_frame
 	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.DISTURBANCE_ALERT):
-		await _fail("Mission 03 did not start a fresh retained pursuit after prior de-escalation reached CALM")
+		await _fail("Mission 03 did not start its retained pursuit from the post-Mission-02 CALM authority")
 		return
 
 	_stage = "mission3_intercept"
@@ -401,6 +415,7 @@ func _run() -> void:
 		return
 
 	_stage = "full_replay"
+	wanted_runtime.call("reset_runtime")
 	_scene_under_test.call("reset_slice")
 	await process_frame
 	await process_frame
@@ -415,6 +430,10 @@ func _run() -> void:
 		return
 	if return_zone.visible:
 		await _fail("Full replay left the Civic Repossession return zone visible")
+		return
+	if int(wanted_runtime.call("get_heat_level")) != 0 \
+	or String(wanted_runtime.call("get_wanted_state_name")) != "CLEAR":
+		await _fail("Full replay did not restore the open-world Wanted baseline")
 		return
 	if title.text != "SCRAP JOB 01 // CITY PROPERTY" or "COURIER BIKE" not in objective.text:
 		await _fail("Full replay did not restore Mission 01 shared HUD ownership")
@@ -453,8 +472,12 @@ func _run() -> void:
 	if civic_runtime.mission.phase != CivicMissionScript.Phase.ESCAPE:
 		await _fail("Civic Repossession stranded after Mission 01 completed with the Hauler already occupied")
 		return
-	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.DISTURBANCE_ALERT):
-		await _fail("Pre-mounted Hauler reconciliation did not enter retained pursuit authority")
+	if int(_scene_under_test.get("current_pursuit_state")) != int(ScrapTestBlockScript.PursuitState.CALM):
+		await _fail("Pre-mounted Hauler reconciliation incorrectly started the retired legacy pursuit")
+		return
+	if int(wanted_runtime.call("get_heat_level")) != 1 \
+	or String(wanted_runtime.call("get_wanted_state_name")) != "CONTACT":
+		await _fail("Pre-mounted Hauler reconciliation did not create the civic Heat 1 + CONTACT report")
 		return
 	if city_runtime.mission.phase != CityMissionScript.Phase.LOCKED:
 		await _fail("Mission 03 unlocked during Civic Repossession pre-mounted recovery")


### PR DESCRIPTION
## Summary

Composes the existing Production-01 Heat-1 Wanted runtime and Production-02 local Field-Hacking report suppression into authored Mission 02 — Civic Repossession.

Player-facing result:

- jam the local civic report link before taking the Scrap Hauler -> report suppressed -> clean take -> garage delivery;
- leave the report link live -> theft creates Heat 1 + Contact -> normal Contact/Search/Evasion -> garage delivery.

Mission 02 no longer starts its historical parallel `trigger_disturbance_alert()` chase. Mission completion does not clear valid Wanted knowledge.

## Scope

- narrow `CivicServiceAlarm.trigger_report()` seam;
- narrow Mission-facing `BurnsideWantedRuntime` civic-report + read-only Wanted seam;
- Mission 02 clean-take transition;
- Mission 02 runtime migration to ordinary open-world Wanted state;
- focused Production-03 contract/workflow and retained Production-01/02 gates.

No Heat 2–5, generalized witnesses/surveillance, generalized hacking/crime/mission framework, new acreage, save schema, or audio-system changes.

## TDD evidence

- RED `83db6712ada7101b8b701ae513724cf7d84b0d91`: `Mission-facing civic report seam is absent`.
- Adapter GREEN moved the real-scene tracer to the intended next RED: `Mission 02 Hauler theft still starts legacy pursuit directly`.
- Pure Mission-02 RED `f98fc62af8945a3045a6380eb7481813d52e3ae0`: `Clean-take mission transition is absent`.
- Exact head `5073619496a1561569fe2de6f31565222907afd7`: Mission-02 model contract, Production-03 real-scene composition tracer, retained Field-Hacking tracer, and retained real-scene Heat-1 tracer all GREEN.

## Verification still required before merge

PR compatibility workflows, retained mobile/desktop/vehicle/interaction/camera/mission gates, rendered runtime/perceptual proof, frozen Standards + #124 review, exact-head merge protection, and exact-main verification.

Closes #124