### PR TITLE
Burnside Production 06 — Gears Surveyed Service Cut / Durable Map-Knowledge Tracer

### DIFF
--- a/.github/workflows/burnside-production-06.yml
+++ b/.github/workflows/burnside-production-06.yml
@@ -1,0 +1,203 @@
+name: Burnside Production 06
+
+on:
+  push:
+    branches:
+      - "main"
+      - "feat/burnside-production-06-surveyed-service-cut"
+    paths:
+      - "contracts/burnside_production_06_surveyed_service_cut_spec.md"
+      - "docs/superpowers/plans/2026-09-02-burnside-production-06-surveyed-service-cut.md"
+      - "godot/scripts/progress/surveyed_route_progress_store.gd"
+      - "godot/scripts/world/gears_surveyed_service_cut_runtime.gd"
+      - "godot/scripts/ui/gears_local_route_sheet.gd"
+      - "godot/scripts/input/touch_controls.gd"
+      - "godot/scripts/world/gears_scrapper_tool_runtime.gd"
+      - "godot/scripts/visual/gears_district_slice_01b.gd"
+      - "godot/scenes/prototype/scrap_test_block.tscn"
+      - "godot/scenes/world/gears_district_slice_01b.tscn"
+      - "godot/tests/gears_surveyed_route_progress_store_test.gd"
+      - "godot/tests/gears_surveyed_service_cut_test.gd"
+      - "godot/tests/gears_surveyed_service_cut_input_test.gd"
+      - "godot/tests/gears_surveyed_service_cut_render_capture.gd"
+      - "godot/tests/gears_surveyed_route_web_probe.gd"
+      - "godot/tests/gears_surveyed_route_web_probe.tscn"
+      - ".github/workflows/burnside-production-06.yml"
+  pull_request:
+    paths:
+      - "contracts/burnside_production_06_surveyed_service_cut_spec.md"
+      - "docs/superpowers/plans/2026-09-02-burnside-production-06-surveyed-service-cut.md"
+      - "godot/scripts/progress/surveyed_route_progress_store.gd"
+      - "godot/scripts/world/gears_surveyed_service_cut_runtime.gd"
+      - "godot/scripts/ui/gears_local_route_sheet.gd"
+      - "godot/scripts/input/touch_controls.gd"
+      - "godot/scripts/world/gears_scrapper_tool_runtime.gd"
+      - "godot/scripts/visual/gears_district_slice_01b.gd"
+      - "godot/scenes/prototype/scrap_test_block.tscn"
+      - "godot/scenes/world/gears_district_slice_01b.tscn"
+      - "godot/tests/gears_surveyed_route_progress_store_test.gd"
+      - "godot/tests/gears_surveyed_service_cut_test.gd"
+      - "godot/tests/gears_surveyed_service_cut_input_test.gd"
+      - "godot/tests/gears_surveyed_service_cut_render_capture.gd"
+      - "godot/tests/gears_surveyed_route_web_probe.gd"
+      - "godot/tests/gears_surveyed_route_web_probe.tscn"
+      - ".github/workflows/burnside-production-06.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  surveyed-service-cut:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GODOT_RELEASE: "4.7.1-stable"
+      GODOT_BIN: "${{ github.workspace }}/.godot-bin/Godot_v4.7.1-stable_linux.x86_64"
+      SOURCE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+
+      - name: Verify exact source
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+
+      - name: Install Godot 4.7.1 editor
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            --output godot.zip \
+            https://github.com/godotengine/godot/releases/download/${GODOT_RELEASE}/Godot_v${GODOT_RELEASE}_linux.x86_64.zip
+          echo "c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba  godot.zip" | sha256sum --check --strict
+          mkdir -p .godot-bin
+          unzip -q godot.zip -d .godot-bin
+          chmod +x "$GODOT_BIN"
+
+      - name: Prime Godot metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path godot --quit
+          test -s godot/.godot/global_script_class_cache.cfg
+
+      - name: Run Production 06 mapped-knowledge persistence tracer
+        id: p06_progress
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_surveyed_route_progress_store_test.gd
+
+      - name: Run Production 06 service-cut survey tracer
+        id: p06_survey
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_surveyed_service_cut_test.gd
+
+      - name: Run Production 06 Map input/modal tracer
+        id: p06_input
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_surveyed_service_cut_input_test.gd
+
+      - name: Run retained Production 05 input tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_scrapper_tool_input_test.gd
+
+      - name: Run retained Production 05 input-lock tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_scrapper_tool_input_lock_test.gd
+
+      - name: Run retained Production 05 environment tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_scrapper_tool_environment_test.gd
+
+      - name: Run retained Production 05 pursuer tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_scrapper_tool_pursuer_test.gd
+
+      - name: Run retained Production 05 Mission 02 ordering tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_scrapper_tool_mission_ordering_test.gd
+
+      - name: Run retained Production 04 Gears work-zone tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_work_zone_incident_test.gd
+
+      - name: Run retained Production 04 Mission 02 ordering regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/gears_work_zone_mission_ordering_test.gd
+
+      - name: Run retained Production 03 pre-triggered suppression regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/civic_repossession_pretriggered_suppression_test.gd
+
+      - name: Run retained Production 03 mission/Wanted composition tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/civic_repossession_wanted_composition_test.gd
+
+      - name: Run retained Production 02 Field-Hacking tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/field_hacking_report_suppression_test.gd
+
+      - name: Run retained Production 01 Heat-1 tracer
+        shell: bash
+        run: |
+          set -euo pipefail
+          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+            --script res://tests/wanted_heat1_scene_test.gd
+
+      - name: Require Production 06 GREEN
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "progress=${{ steps.p06_progress.outcome }}"
+          echo "survey=${{ steps.p06_survey.outcome }}"
+          echo "input=${{ steps.p06_input.outcome }}"
+          test "${{ steps.p06_progress.outcome }}" = "success"
+          test "${{ steps.p06_survey.outcome }}" = "success"
+          test "${{ steps.p06_input.outcome }}" = "success"

--- a/.github/workflows/burnside-production-06.yml
+++ b/.github/workflows/burnside-production-06.yml
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+          timeout --signal=TERM 20s "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
             --script res://tests/gears_surveyed_route_progress_store_test.gd
 
       - name: Run Production 06 service-cut survey tracer
@@ -101,7 +101,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+          timeout --signal=TERM 20s "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
             --script res://tests/gears_surveyed_service_cut_test.gd
 
       - name: Run Production 06 Map input/modal tracer
@@ -110,7 +110,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
+          timeout --signal=TERM 20s "$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot \
             --script res://tests/gears_surveyed_service_cut_input_test.gd
 
       - name: Run retained Production 05 input tracer

--- a/.github/workflows/burnside-production-06.yml
+++ b/.github/workflows/burnside-production-06.yml
@@ -398,36 +398,97 @@ jobs:
           import json
           import os
           from pathlib import Path
+          from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
           from playwright.sync_api import sync_playwright
 
           expected_route = "gears.service_alley_north_connector"
           expected_storage = "user://p06_web_reload_probe.json"
           url = "http://127.0.0.1:8096/"
           profile = Path(os.environ["RUNNER_TEMP"]) / "p06-chromium-profile"
+          verification_dir = Path("godot/verification/production06")
 
-          def observe(p, expected_title):
+          def write_diagnostic(page, label, console_messages, page_errors, request_failures):
+              try:
+                  state = page.evaluate("window.P06_WEB_PROBE || null")
+              except Exception as exc:
+                  state = {"evaluation_error": str(exc)}
+              try:
+                  body_text = page.locator("body").inner_text(timeout=5_000)
+              except Exception as exc:
+                  body_text = "<body read failed: %s>" % exc
+              try:
+                  title = page.title()
+              except Exception as exc:
+                  title = "<title read failed: %s>" % exc
+              try:
+                  user_agent = page.evaluate("navigator.userAgent")
+              except Exception as exc:
+                  user_agent = "<user agent read failed: %s>" % exc
+              diagnostic = {
+                  "label": label,
+                  "source_sha": os.environ["SOURCE_SHA"],
+                  "verification_target": os.environ.get("P06_MATRIX_SOURCE", "head"),
+                  "url": page.url,
+                  "title": title,
+                  "state": state,
+                  "body_text": body_text[:4000],
+                  "browser_user_agent": user_agent,
+                  "console": console_messages[-200:],
+                  "page_errors": page_errors[-100:],
+                  "request_failures": request_failures[-100:],
+              }
+              path = verification_dir / ("web_%s_diagnostic.json" % label)
+              path.write_text(json.dumps(diagnostic, indent=2, sort_keys=True) + "\n")
+              try:
+                  page.screenshot(path=str(verification_dir / ("web_%s.png" % label)), full_page=True)
+              except Exception as exc:
+                  diagnostic["screenshot_error"] = str(exc)
+                  path.write_text(json.dumps(diagnostic, indent=2, sort_keys=True) + "\n")
+              print("P06_BROWSER_DIAGNOSTIC %s" % json.dumps(diagnostic, sort_keys=True))
+              return diagnostic
+
+          def observe(p, expected_title, label):
               context = p.chromium.launch_persistent_context(
                   str(profile),
                   headless=True,
                   args=["--disable-dev-shm-usage"],
               )
+              console_messages = []
+              page_errors = []
+              request_failures = []
               try:
                   page = context.pages[0] if context.pages else context.new_page()
-                  page.goto(url, wait_until="domcontentloaded", timeout=60_000)
-                  page.wait_for_function(
-                      "expected => document.title === expected",
-                      arg=expected_title,
-                      timeout=60_000,
+                  page.on("console", lambda msg: console_messages.append({"type": msg.type, "text": msg.text}))
+                  page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+                  page.on(
+                      "requestfailed",
+                      lambda request: request_failures.append({
+                          "url": request.url,
+                          "failure": request.failure,
+                      }),
                   )
-                  state = page.evaluate("window.P06_WEB_PROBE")
-                  user_agent = page.evaluate("navigator.userAgent")
-                  observed_url = page.url
+                  page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+                  try:
+                      page.wait_for_function(
+                          "expected => document.title === expected || document.title === 'P06_FAIL'",
+                          arg=expected_title,
+                          timeout=60_000,
+                      )
+                  except PlaywrightTimeoutError:
+                      write_diagnostic(page, label, console_messages, page_errors, request_failures)
+                      raise
+                  diagnostic = write_diagnostic(page, label, console_messages, page_errors, request_failures)
+                  if diagnostic["title"] == "P06_FAIL":
+                      raise AssertionError("Probe reported P06_FAIL: %s" % diagnostic["state"])
+                  state = diagnostic["state"]
+                  user_agent = diagnostic["browser_user_agent"]
+                  observed_url = diagnostic["url"]
                   return state, user_agent, observed_url
               finally:
                   context.close()
 
           with sync_playwright() as p:
-              pass_a, user_agent_a, observed_url_a = observe(p, "P06_WRITE_OK")
+              pass_a, user_agent_a, observed_url_a = observe(p, "P06_WRITE_OK", "pass_a")
               assert pass_a["status"] == "P06_WRITE_OK", pass_a
               assert pass_a["route_id"] == expected_route, pass_a
               assert pass_a["storage_path"] == expected_storage, pass_a
@@ -436,7 +497,7 @@ jobs:
               assert pass_a["write_count"] == 1, pass_a
               assert pass_a["write_blocked"] is False, pass_a
 
-              pass_b, user_agent_b, observed_url_b = observe(p, "P06_RELOAD_OK")
+              pass_b, user_agent_b, observed_url_b = observe(p, "P06_RELOAD_OK", "pass_b")
               assert pass_b["status"] == "P06_RELOAD_OK", pass_b
               assert pass_b["route_id"] == expected_route, pass_b
               assert pass_b["storage_path"] == expected_storage, pass_b
@@ -458,17 +519,34 @@ jobs:
                   "manual_persistence_mutation": False,
                   "storage_backend_under_test": "Godot user:// Web filesystem",
               }
-              output = Path("godot/verification/production06/web_persistence_report.json")
+              output = verification_dir / "web_persistence_report.json"
               output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
               print(json.dumps(report, indent=2, sort_keys=True))
           PY
         env:
           P06_MATRIX_SOURCE: ${{ matrix.source }}
 
+      - name: Print Web persistence failure diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          echo "=== p06 web server log ==="
+          cat p06-web-server.log
+          echo "=== p06 browser diagnostics ==="
+          for file in godot/verification/production06/web_*_diagnostic.json; do
+            test -f "$file" && { echo "--- $file"; cat "$file"; }
+          done
+
       - name: Upload Web persistence proof
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: burnside-production06-web-persistence-${{ matrix.source }}-${{ env.SOURCE_SHA }}
-          path: godot/verification/production06/web_persistence_report.json
+          path: |
+            godot/verification/production06/web_persistence_report.json
+            godot/verification/production06/web_*_diagnostic.json
+            godot/verification/production06/web_*.png
+            p06-web-server.log
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/burnside-production-06.yml
+++ b/.github/workflows/burnside-production-06.yml
@@ -447,7 +447,7 @@ jobs:
               print("P06_BROWSER_DIAGNOSTIC %s" % json.dumps(diagnostic, sort_keys=True))
               return diagnostic
 
-          def observe(p, expected_title, label):
+          def observe(p, expected_status, label):
               context = p.chromium.launch_persistent_context(
                   str(profile),
                   headless=True,
@@ -470,17 +470,17 @@ jobs:
                   page.goto(url, wait_until="domcontentloaded", timeout=60_000)
                   try:
                       page.wait_for_function(
-                          "expected => document.title === expected || document.title === 'P06_FAIL'",
-                          arg=expected_title,
+                          "expected => window.P06_WEB_PROBE?.status === expected || window.P06_WEB_PROBE?.status === 'P06_FAIL'",
+                          arg=expected_status,
                           timeout=60_000,
                       )
                   except PlaywrightTimeoutError:
                       write_diagnostic(page, label, console_messages, page_errors, request_failures)
                       raise
                   diagnostic = write_diagnostic(page, label, console_messages, page_errors, request_failures)
-                  if diagnostic["title"] == "P06_FAIL":
-                      raise AssertionError("Probe reported P06_FAIL: %s" % diagnostic["state"])
                   state = diagnostic["state"]
+                  if isinstance(state, dict) and state.get("status") == "P06_FAIL":
+                      raise AssertionError("Probe reported P06_FAIL: %s" % state)
                   user_agent = diagnostic["browser_user_agent"]
                   observed_url = diagnostic["url"]
                   return state, user_agent, observed_url

--- a/.github/workflows/burnside-production-06.yml
+++ b/.github/workflows/burnside-production-06.yml
@@ -236,3 +236,239 @@ jobs:
           path: godot/verification/production06/
           if-no-files-found: error
           retention-days: 14
+
+  web-persistence:
+    name: Web persistence (${{ matrix.source }})
+    needs: surveyed-service-cut
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ${{ fromJSON(github.event_name == 'pull_request' && '["merge","head"]' || '["head"]') }}
+    env:
+      GODOT_VERSION: "4.7.1"
+      GODOT_RELEASE: "4.7.1-stable"
+      GODOT_BIN: "${{ github.workspace }}/.godot-bin/Godot_v4.7.1-stable_linux.x86_64"
+      WEB_PROJECT: "${{ github.workspace }}/.godot-p06-web-project"
+      SOURCE_SHA: ${{ matrix.source == 'head' && github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+    steps:
+      - name: Checkout verified source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 1
+
+      - name: Verify exact source
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          printf 'verification target: %s\n' "${{ matrix.source }}"
+          printf 'expected source SHA: %s\n' "$SOURCE_SHA"
+          printf 'checked out SHA: %s\n' "$actual_sha"
+          test "$actual_sha" = "$SOURCE_SHA"
+
+      - name: Cache Godot editor and export templates
+        id: godot-cache-web
+        uses: actions/cache@v4
+        with:
+          path: |
+            .godot-bin
+            ~/.local/share/godot/export_templates/4.7.1.stable
+          key: godot-4.7.1-linux-web-templates-v1
+
+      - name: Install Godot 4.7.1 editor
+        if: steps.godot-cache-web.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            --output godot.zip \
+            https://github.com/godotengine/godot/releases/download/${GODOT_RELEASE}/Godot_v${GODOT_RELEASE}_linux.x86_64.zip
+          echo "c7ff14fd28472c8d4f193043de30278dcf7e5241a1dcf7566b02e27addaa33ba  godot.zip" | sha256sum --check --strict
+          mkdir -p .godot-bin
+          unzip -q godot.zip -d .godot-bin
+          chmod +x "$GODOT_BIN"
+
+      - name: Install Godot 4.7.1 export templates
+        if: steps.godot-cache-web.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            --output export_templates.tpz \
+            https://github.com/godotengine/godot/releases/download/${GODOT_RELEASE}/Godot_v${GODOT_RELEASE}_export_templates.tpz
+          template_dir="$HOME/.local/share/godot/export_templates/${GODOT_VERSION}.stable"
+          rm -rf "$template_dir"
+          mkdir -p "$template_dir" "${RUNNER_TEMP}/godot-export-templates"
+          unzip -q export_templates.tpz -d "${RUNNER_TEMP}/godot-export-templates"
+          cp -R "${RUNNER_TEMP}/godot-export-templates/templates/." "$template_dir/"
+          test -s "$template_dir/web_release.zip"
+
+      - name: Verify Godot install
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x "$GODOT_BIN"
+          "$GODOT_BIN" --version
+          test -s "$HOME/.local/share/godot/export_templates/${GODOT_VERSION}.stable/web_release.zip"
+
+      - name: Prepare isolated Web persistence project
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$WEB_PROJECT"
+          cp -a godot "$WEB_PROJECT"
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          project = Path(os.environ["WEB_PROJECT"]) / "project.godot"
+          text = project.read_text()
+          feature = 'config/features=PackedStringArray("4.7", "Forward Plus")'
+          if feature not in text:
+              raise SystemExit("Expected Forward Plus project feature was not found")
+          text = text.replace(feature, 'config/features=PackedStringArray("4.7", "GL Compatibility")', 1)
+
+          main_scene = 'run/main_scene="res://scenes/prototype/scrap_test_block.tscn"'
+          if main_scene not in text:
+              raise SystemExit("Expected production main scene was not found")
+          text = text.replace(main_scene, 'run/main_scene="res://tests/gears_surveyed_route_web_probe.tscn"', 1)
+
+          rendering = "[rendering]\n"
+          if rendering not in text:
+              raise SystemExit("[rendering] section not found")
+          text = text.replace(
+              rendering,
+              rendering
+              + 'renderer/rendering_method="gl_compatibility"\n'
+              + 'renderer/rendering_method.mobile="gl_compatibility"\n'
+              + 'textures/vram_compression/import_etc2_astc=true\n',
+              1,
+          )
+          project.write_text(text)
+          PY
+          "$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path "$WEB_PROJECT" --quit
+          test -s "$WEB_PROJECT/.godot/global_script_class_cache.cfg"
+
+      - name: Export isolated Web persistence probe
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf build/p06-web
+          mkdir -p build/p06-web
+          "$GODOT_BIN" \
+            --headless \
+            --rendering-method gl_compatibility \
+            --path "$WEB_PROJECT" \
+            --export-release "Web Playtest" \
+            "$GITHUB_WORKSPACE/build/p06-web/index.html"
+          test -s build/p06-web/index.html
+          test -s build/p06-web/index.js
+          test -s build/p06-web/index.wasm
+          test -s build/p06-web/index.pck
+
+      - name: Install Chromium automation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m pip install --disable-pip-version-check playwright==1.55.0
+          python3 -m playwright install --with-deps chromium
+
+      - name: Prove same-origin browser relaunch persistence
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m http.server 8096 --directory build/p06-web >p06-web-server.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+          for _ in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:8096/index.html >/dev/null; then
+              break
+            fi
+            sleep 0.5
+          done
+          curl --fail --silent --show-error --output /dev/null http://127.0.0.1:8096/index.html
+
+          rm -rf "${RUNNER_TEMP}/p06-chromium-profile"
+          mkdir -p godot/verification/production06
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from playwright.sync_api import sync_playwright
+
+          expected_route = "gears.service_alley_north_connector"
+          expected_storage = "user://p06_web_reload_probe.json"
+          url = "http://127.0.0.1:8096/"
+          profile = Path(os.environ["RUNNER_TEMP"]) / "p06-chromium-profile"
+
+          def observe(p, expected_title):
+              context = p.chromium.launch_persistent_context(
+                  str(profile),
+                  headless=True,
+                  args=["--disable-dev-shm-usage"],
+              )
+              try:
+                  page = context.pages[0] if context.pages else context.new_page()
+                  page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+                  page.wait_for_function(
+                      "expected => document.title === expected",
+                      arg=expected_title,
+                      timeout=60_000,
+                  )
+                  state = page.evaluate("window.P06_WEB_PROBE")
+                  user_agent = page.evaluate("navigator.userAgent")
+                  observed_url = page.url
+                  return state, user_agent, observed_url
+              finally:
+                  context.close()
+
+          with sync_playwright() as p:
+              pass_a, user_agent_a, observed_url_a = observe(p, "P06_WRITE_OK")
+              assert pass_a["status"] == "P06_WRITE_OK", pass_a
+              assert pass_a["route_id"] == expected_route, pass_a
+              assert pass_a["storage_path"] == expected_storage, pass_a
+              assert pass_a["load_status"] == "CLEAN", pass_a
+              assert pass_a["surveyed"] is True, pass_a
+              assert pass_a["write_count"] == 1, pass_a
+              assert pass_a["write_blocked"] is False, pass_a
+
+              pass_b, user_agent_b, observed_url_b = observe(p, "P06_RELOAD_OK")
+              assert pass_b["status"] == "P06_RELOAD_OK", pass_b
+              assert pass_b["route_id"] == expected_route, pass_b
+              assert pass_b["storage_path"] == expected_storage, pass_b
+              assert pass_b["load_status"] == "LOADED", pass_b
+              assert pass_b["surveyed"] is True, pass_b
+              assert pass_b["write_count"] == 0, pass_b
+              assert pass_b["write_blocked"] is False, pass_b
+              assert observed_url_a == observed_url_b == url, (observed_url_a, observed_url_b)
+
+              report = {
+                  "source_sha": os.environ["SOURCE_SHA"],
+                  "verification_target": os.environ.get("P06_MATRIX_SOURCE", "head"),
+                  "origin": url,
+                  "browser_user_agent_pass_a": user_agent_a,
+                  "browser_user_agent_pass_b": user_agent_b,
+                  "pass_a": pass_a,
+                  "pass_b": pass_b,
+                  "same_persistent_profile_relaunched": True,
+                  "manual_persistence_mutation": False,
+                  "storage_backend_under_test": "Godot user:// Web filesystem",
+              }
+              output = Path("godot/verification/production06/web_persistence_report.json")
+              output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+              print(json.dumps(report, indent=2, sort_keys=True))
+          PY
+        env:
+          P06_MATRIX_SOURCE: ${{ matrix.source }}
+
+      - name: Upload Web persistence proof
+        uses: actions/upload-artifact@v4
+        with:
+          name: burnside-production06-web-persistence-${{ matrix.source }}-${{ env.SOURCE_SHA }}
+          path: godot/verification/production06/web_persistence_report.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/burnside-production-06.yml
+++ b/.github/workflows/burnside-production-06.yml
@@ -12,6 +12,7 @@ on:
       - "godot/scripts/world/gears_surveyed_service_cut_runtime.gd"
       - "godot/scripts/ui/gears_local_route_sheet.gd"
       - "godot/scripts/input/touch_controls.gd"
+      - "godot/scripts/input/gears_surveyed_route_touch_controls.gd"
       - "godot/scripts/world/gears_scrapper_tool_runtime.gd"
       - "godot/scripts/visual/gears_district_slice_01b.gd"
       - "godot/scenes/prototype/scrap_test_block.tscn"
@@ -31,6 +32,7 @@ on:
       - "godot/scripts/world/gears_surveyed_service_cut_runtime.gd"
       - "godot/scripts/ui/gears_local_route_sheet.gd"
       - "godot/scripts/input/touch_controls.gd"
+      - "godot/scripts/input/gears_surveyed_route_touch_controls.gd"
       - "godot/scripts/world/gears_scrapper_tool_runtime.gd"
       - "godot/scripts/visual/gears_district_slice_01b.gd"
       - "godot/scenes/prototype/scrap_test_block.tscn"
@@ -201,3 +203,36 @@ jobs:
           test "${{ steps.p06_progress.outcome }}" = "success"
           test "${{ steps.p06_survey.outcome }}" = "success"
           test "${{ steps.p06_input.outcome }}" = "success"
+
+      - name: Capture windowed Production 06 proof
+        shell: bash
+        run: |
+          set -euo pipefail
+          SOURCE_SHA="$SOURCE_SHA" timeout 120s xvfb-run -a "$GODOT_BIN" \
+            --rendering-method gl_compatibility \
+            --path godot \
+            --script res://tests/gears_surveyed_service_cut_render_capture.gd
+          test -s godot/verification/production06/01_pre_survey_route_sheet.png
+          test -s godot/verification/production06/02_open_unsurveyed_service_cut.png
+          test -s godot/verification/production06/03_first_crossing_learned.png
+          test -s godot/verification/production06/04_post_survey_route_sheet.png
+          test -s godot/verification/production06/05_replay_known_jammed.png
+          test -s godot/verification/production06/06_reopened_known_route.png
+          test -s godot/verification/production06/render_report.json
+          python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          report = json.loads(Path("godot/verification/production06/render_report.json").read_text())
+          assert report["source_sha"] == os.environ["SOURCE_SHA"]
+          assert report["real_playable_scene"] is True
+          assert report["route_id"] == "gears.service_alley_north_connector"
+          assert len(report["captures"]) == 6
+          PY
+
+      - name: Upload Production 06 rendered proof
+        uses: actions/upload-artifact@v4
+        with:
+          name: burnside-production06-proof-${{ env.SOURCE_SHA }}
+          path: godot/verification/production06/
+          if-no-files-found: error
+          retention-days: 14

--- a/contracts/burnside_production_06_surveyed_service_cut_spec.md
+++ b/contracts/burnside_production_06_surveyed_service_cut_spec.md
@@ -1,0 +1,318 @@
+# Burnside Production 06 — Gears Surveyed Service Cut / Durable Map-Knowledge Tracer
+
+**Status:** `DESIGN_LOCKED__IMPLEMENTATION_AUTHORIZED`
+
+**Authority:** issue #134, product anchor #55, Burnside Open-World Production Contract #118.
+
+**Starting repository baseline:** `main@cd4cdbe3180c6a372ffa1cfb1cd69bdfaf256961`
+
+**Exact retained Production-05 gameplay/public baseline:** `702678cb66ab7544b43644cfa29baf5361c68dc1`
+
+## Goal
+
+Add the first narrow Durable Mapped Knowledge tracer without turning Burnside into an omniscient GPS game or introducing a generalized save/navigation framework.
+
+The player-facing promise is:
+
+> If I physically discover and traverse the real `ServiceAlley <-> NorthConnector` service cut, the Gears local route sheet remembers that learned geography across Replay and normal application/Web reload, while the current Production-05 physical access state remains separately truthful.
+
+Target feeling:
+
+> “I found a way through the city that wasn’t obvious before. Now I know it, and Burnside knows that I know it.”
+
+## Scope boundary
+
+Production 06 owns exactly:
+
+- one stable surveyed-route ID: `gears.service_alley_north_connector`;
+- one traversal qualifier for the retained `ServiceAlley <-> NorthConnector` seam;
+- one narrow versioned mapped-knowledge persistence file;
+- one on-demand Gears local route sheet;
+- one desktop Map key (`M`);
+- one safe-area touch Map control;
+- one visual/text discovery confirmation;
+- focused native, rendered, Web-persistence, and retained-regression proof.
+
+Production 06 does **not** own:
+
+- generalized minimap/GPS/pathfinding;
+- route graph or Service Network framework;
+- racing lines, breadcrumbs, or turn-by-turn guidance;
+- broad fog-of-war;
+- mission/inventory/vehicle/checkpoint/cloud persistence;
+- save slots;
+- vehicle claiming/condition;
+- further combat/Health/Armor/damage;
+- Heat 2–5;
+- witnesses/surveillance;
+- Silent Core mapping;
+- FB-13/HS-7 navigation;
+- PR #44 camera work;
+- AudioManager, audio registries, actor audio, or audio assets.
+
+## Existing implementation authority
+
+Retained Production-05 implementation remains authoritative for physical access:
+
+- `GearsScrapperToolRuntime.AccessState.JAMMED`
+- `GearsScrapperToolRuntime.AccessState.FORCED_OPEN`
+- `GearsScrapperToolRuntime.get_access_state_name()`
+- `GearsScrapperToolRuntime.is_service_access_blocking()`
+- Replay/reset returns the physical barrier to `JAMMED`.
+
+Production 06 must query that state. It must not duplicate or replace it.
+
+The retained Gears district geometry remains authoritative for route shape:
+
+- `GearsDistrictSlice01B/ServiceAlley`
+- `GearsDistrictSlice01B/NorthConnector`
+- `GearsDistrictSlice01B/NorthRoad`
+- `GearsDistrictSlice01B/IndustrialIntersection`
+
+The route sheet derives its displayed geometry from those authored collision surfaces rather than inventing a second map geometry source.
+
+## Architecture
+
+### `SurveyedRouteProgressStore`
+
+Create one narrow RefCounted persistence boundary in `godot/scripts/progress/surveyed_route_progress_store.gd`.
+
+Responsibilities:
+
+- schema version `1` only;
+- stable production file `user://burnside_mapped_knowledge.json`;
+- `surveyed_routes` array/set of stable string IDs;
+- idempotent `mark_surveyed(route_id)`;
+- query `is_surveyed(route_id)`;
+- load once on construction/configuration;
+- write only supported version-1 documents;
+- malformed or unsupported/newer data enters read-only/fail-safe mode and is never silently overwritten;
+- test storage is automatically isolated from production owner progress, with an explicit storage-path override seam for deterministic persistence tests.
+
+Canonical version-1 payload:
+
+```json
+{
+  "version": 1,
+  "surveyed_routes": [
+    "gears.service_alley_north_connector"
+  ]
+}
+```
+
+No other durable state belongs in this file during Production 06.
+
+### Test-storage isolation
+
+The store must never let automated Godot test scripts read/write the production owner path by default.
+
+If Godot command-line arguments identify execution of a `res://tests/...` script, the default path resolves to an isolated test file under `user://tests/`.
+
+Focused Production-06 persistence tests may supply an explicit deterministic override path. Tests must delete only their own override files.
+
+### `GearsSurveyedServiceCutRuntime`
+
+Create one root-level runtime sibling mounted from the retained Gears district composition seam after Production 05.
+
+Responsibilities:
+
+- own only Production-06 route-survey transient state;
+- query the real Production-05 access runtime;
+- sample actual player position during production runtime;
+- reject discontinuous/teleport-like samples;
+- recognize a legitimate traversal between exclusive authored ServiceAlley and NorthConnector regions;
+- require access to be physically `FORCED_OPEN` before a traversal can qualify;
+- require minimum continuous travel distance before completion;
+- record the surveyed route exactly once through `SurveyedRouteProgressStore`;
+- keep mapped knowledge through Replay/reset while clearing only transient traversal state;
+- create/manage the bounded route-sheet modal and Map control;
+- never mutate Wanted, Report, Mission02, pursuer, worker/crawler, or Scrapper authority.
+
+### Traversal qualification
+
+Survey qualification uses actual authored surface footprints plus bounded continuity checks.
+
+A sample may begin traversal only when the player occupies an exclusive side of the route:
+
+- `ServiceAlley` footprint and not `NorthConnector` -> `ALLEY` side;
+- `NorthConnector` footprint and not `ServiceAlley` -> `CONNECTOR` side.
+
+The runtime then requires:
+
+1. Production-05 access is `FORCED_OPEN`;
+2. subsequent samples remain continuous, with no single horizontal sample jump above the teleport-rejection threshold;
+3. accumulated horizontal travel reaches the minimum traversal distance;
+4. the player reaches the opposite exclusive side;
+5. the route is not already surveyed.
+
+Any rejected discontinuity resets transient traversal qualification and does not grant knowledge.
+
+Merely observing geometry, merely forcing the barrier, or directly relocating between route sides must not survey the route.
+
+### `GearsLocalRouteSheet`
+
+Create one bounded Control presentation in `godot/scripts/ui/gears_local_route_sheet.gd`.
+
+Responsibilities:
+
+- draw ordinary known Gears context from the retained authored `NorthRoad` and `IndustrialIntersection` footprints;
+- before survey, omit ServiceAlley/NorthConnector geometry entirely;
+- after survey, draw the real authored ServiceAlley and NorthConnector footprints/connection;
+- display `KNOWN · ACCESS JAMMED` when surveyed knowledge exists but P05 is currently `JAMMED`;
+- display `KNOWN · ACCESS OPEN` when surveyed knowledge exists and P05 is `FORCED_OPEN`;
+- never display a jammed route as physically open;
+- expose small semantic getters for deterministic tests.
+
+This is a route sheet, not a minimap. It has no player arrow, waypoint, route planning, pathfinding, zoom, destination selection, or world-space line.
+
+## Map input and ownership
+
+### Desktop
+
+`M` is the dedicated Map action. Live source inspection found no retained `M` binding conflict in the current touch/input owner.
+
+### Touch
+
+Production 06 creates one small `MapButton` in the retained `SafeAreaRoot/RightTouchArea` top-right lane, away from the existing Action/Tool/vehicle buttons.
+
+### Availability
+
+The Map action may open only when:
+
+- current UI mode is `FOOT_TRAVERSAL`;
+- retained gesture/interactions do not own input;
+- the player is not already input-locked by another system.
+
+The Map action is unavailable while driving.
+
+### Modal ownership
+
+While the route sheet is open:
+
+- player locomotion is input-locked;
+- generic Action emission is suppressed;
+- Tool Action emission is suppressed;
+- the Map control remains available to close the sheet;
+- full-screen modal pointer capture prevents touch leakage into gameplay controls;
+- closing restores the exact pre-map player input-lock value and ordinary dedicated action availability;
+- one key/touch activation produces one open/close transition only.
+
+`TouchControlsUI` receives only the smallest modal gate required to suppress its existing Action and Tool Action emissions. Production 06 must not turn it into a generalized modal framework.
+
+## Replay/reset semantics
+
+Replay/reset must:
+
+- retain `surveyed_routes` mapped knowledge;
+- reset P05 physical access to `JAMMED` through the retained P05 owner;
+- clear only P06 transient traversal arming/distance/sample state;
+- close the route sheet if open;
+- restore map/input ownership cleanly.
+
+A valid post-Replay state is:
+
+`SURVEYED + JAMMED`.
+
+That state must render as known-but-currently-blocked.
+
+## Existing gameplay authority
+
+Production 06 may not create or clear:
+
+- Heat;
+- Contact;
+- Search;
+- Recognition;
+- Reports;
+- Mission02 progression;
+- pursuer active/stagger state;
+- local worker/crawler knowledge.
+
+Surveying is player knowledge only.
+
+## Visual feedback
+
+On first successful survey only, show a restrained text confirmation such as:
+
+`ROUTE SURVEYED · SERVICE ALLEY CUT MAPPED`
+
+No new audio is required or authorized for the first implementation.
+
+## Required focused tests
+
+### Semantics / persistence
+
+1. clean store -> route unknown;
+2. route sheet hides the service cut while unknown;
+3. observing/standing in one route side -> no survey;
+4. forcing `JAMMED -> FORCED_OPEN` alone -> no survey;
+5. direct discontinuous teleport between route sides -> no survey;
+6. legitimate continuous traversal -> survey recorded exactly once;
+7. repeated traversal -> no duplicate state/write;
+8. route sheet reveals the service cut after survey;
+9. Replay retains mapped knowledge while P05 physical access returns to `JAMMED`;
+10. `SURVEYED + JAMMED` -> known/blocked presentation;
+11. forcing the known route open -> access presentation becomes usable without rewriting knowledge;
+12. fresh store/runtime instance reloads the surveyed route;
+13. malformed payload fails safely and is not overwritten;
+14. newer unsupported version fails safely and is not overwritten;
+15. tests use isolated deterministic storage.
+
+### Input / UI
+
+1. desktop `M` opens/closes once;
+2. touch Map opens/closes once;
+3. gesture/input lock suppresses Map opening;
+4. driving suppresses Map opening;
+5. map modal suppresses generic Action;
+6. map modal suppresses Tool Action;
+7. closing restores dedicated actions without double-fire;
+8. safe-area Map control remains inside the resolved safe area.
+
+### Retained regressions
+
+Preserve at minimum:
+
+- Production-05 input and retained input-lock tracers;
+- Production-05 service-access/environment tracer;
+- Production-05 pursuer stagger tracer;
+- Production-05 Mission02 ordering tracer;
+- Production-04 work-zone local reaction/report tracer;
+- Production-04 Mission02 ordering regression;
+- Production-03 pre-triggered suppression + mission/Wanted composition;
+- Production-02 Field-Hacking report suppression;
+- Production-01 Heat-1 tracer;
+- current camera, desktop, touch, vehicle, and interaction contracts.
+
+## Rendered proof
+
+Capture six exact-head images:
+
+1. pre-survey route sheet with service cut absent;
+2. P05 access forced open while route remains unsurveyed;
+3. first legitimate survey confirmation;
+4. post-survey route sheet with accurate cut visible;
+5. Replay state with known route + jammed access;
+6. same known route after reopening access, showing current usable state.
+
+## Web persistence proof
+
+Production 06 adds a tiny exported Web persistence probe that uses the actual `SurveyedRouteProgressStore` against `user://`.
+
+The CI browser proof must:
+
+1. serve the exported probe from localhost/same origin;
+2. first load: write the stable surveyed route and report success;
+3. reload the same origin/runtime storage;
+4. second load: read the route as surveyed without rewriting it;
+5. fail if the browser filesystem is not persistent or the route is absent after reload.
+
+Godot Web maps `user://` to browser IndexedDB; this proof is required in addition to native persistence tests and ordinary Web export/static-hosting smoke.
+
+## Completion gate
+
+Production 06 may merge only after:
+
+`RED observed -> GREEN focused semantics/UI -> rendered proof -> retained regressions -> literal-head Web -> same-origin reload proof -> synthetic-merge Web -> frozen Standards + #134/spec review -> merge -> exact-main Web/public verification -> continuity update`.
+
+Build success alone is not completion.

--- a/docs/superpowers/plans/2026-09-02-burnside-production-06-surveyed-service-cut.md
+++ b/docs/superpowers/plans/2026-09-02-burnside-production-06-surveyed-service-cut.md
@@ -1,0 +1,378 @@
+# Burnside Production 06 Surveyed Service Cut Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the retained `ServiceAlley <-> NorthConnector` cut legitimately surveyable, persist exactly that mapped-knowledge fact, and expose it through one truthful Gears local route sheet across Replay and browser/application reload.
+
+**Architecture:** Add one narrow `SurveyedRouteProgressStore`, one root-level `GearsSurveyedServiceCutRuntime`, and one bounded `GearsLocalRouteSheet`. Reuse authored P05 access state and retained Gears geometry; add only the smallest `TouchControlsUI` modal gate needed for Map ownership. Verification gets its own P06 CI workflow while the retained Godot Web workflow supplies literal-head/synthetic-merge export and the canonical compatibility matrix.
+
+**Tech Stack:** Godot 4.7.1 / GDScript, `FileAccess` + JSON under `user://`, Godot Control `_draw`, GitHub Actions, exported Godot Web + Chromium/Playwright persistence probe.
+
+**Spec:** `contracts/burnside_production_06_surveyed_service_cut_spec.md`
+
+## Global Constraints
+
+- Stable route ID: `gears.service_alley_north_connector`.
+- Production mapped-knowledge path: `user://burnside_mapped_knowledge.json`.
+- Schema version: `1`; only `surveyed_routes` belongs in P06 durable state.
+- Unsupported/newer/malformed persisted data is never silently overwritten.
+- Test storage must be isolated from owner progress.
+- Survey requires physical `FORCED_OPEN` access plus continuous legitimate traversal; observation, forcing access alone, and teleport/discontinuous placement do not count.
+- Replay resets P05 physical access but does not erase P06 mapped knowledge.
+- Route sheet derives geometry from retained authored surfaces; it may not invent a route graph, GPS, pathfinding, racing line, breadcrumbs, player arrow, or turn-by-turn guidance.
+- Map desktop key is `M`; Map is unavailable while driving or while retained interaction/gesture/input ownership is already locked.
+- Map modal suppresses locomotion, generic Action, and Tool Action and restores exact prior ownership when closed.
+- Do not touch AudioManager, audio registries/assets, PR #44 camera work, Wanted authority, Report semantics, Mission02 authority, pursuer authority, or worker/crawler knowledge except to run regressions.
+
+---
+
+### Task 1: RED — Production-06 Contract Harness
+
+**Files:**
+- Create: `godot/tests/gears_surveyed_route_progress_store_test.gd`
+- Create: `godot/tests/gears_surveyed_service_cut_test.gd`
+- Create: `godot/tests/gears_surveyed_service_cut_input_test.gd`
+- Create: `.github/workflows/burnside-production-06.yml`
+
+**Interfaces:**
+- Consumes: retained production scene `res://scenes/prototype/scrap_test_block.tscn`, `GearsScrapperToolRuntime.get_access_state_name()`, `GearsScrapperToolRuntime._force_access_open()`, `TouchControlsUI` modes/signals.
+- Produces test expectations for: `SurveyedRouteProgressStore`, root `GearsSurveyedServiceCutRuntime`, `GearsLocalRouteSheet`, `map_action_pressed`, `MapButton`, `set_map_modal_active(bool)`.
+
+- [ ] **Step 1: Write the failing persistence test**
+
+The test must load `res://scripts/progress/surveyed_route_progress_store.gd`, configure an explicit `user://tests/p06_progress_store_test.json`, and require this behavior:
+
+```gdscript
+var store = ProgressStoreScript.new()
+store.configure(TEST_PATH)
+assert(not store.is_surveyed(ROUTE_ID))
+assert(store.mark_surveyed(ROUTE_ID))
+assert(store.is_surveyed(ROUTE_ID))
+assert(store.get_write_count() == 1)
+assert(not store.mark_surveyed(ROUTE_ID))
+assert(store.get_write_count() == 1)
+var reloaded = ProgressStoreScript.new()
+reloaded.configure(TEST_PATH)
+assert(reloaded.is_surveyed(ROUTE_ID))
+```
+
+It must additionally write malformed JSON and `{ "version": 99, ... }`, preserve exact original bytes after attempted `mark_surveyed`, and prove `is_write_blocked()`.
+
+- [ ] **Step 2: Write the failing service-cut semantics test**
+
+Load the real production scene, wait for deferred Gears mounts, require `GearsSurveyedServiceCutRuntime`, and drive its deterministic sample seam:
+
+```gdscript
+survey.call("reset_transient_state")
+assert(not survey.call("is_route_surveyed"))
+survey.call("sample_player_position", entry_position)
+assert(not survey.call("is_route_surveyed"))
+scrapper.call("_force_access_open")
+assert(not survey.call("is_route_surveyed"))
+survey.call("sample_player_position", entry_position)
+survey.call("sample_player_position", midpoint_a)
+survey.call("sample_player_position", midpoint_b)
+survey.call("sample_player_position", connector_position)
+assert(survey.call("is_route_surveyed"))
+assert(survey.call("get_survey_record_count") == 1)
+```
+
+A separate sequence must jump directly from entry to connector and remain unsurveyed. Replay must keep surveyed knowledge while P05 returns to `JAMMED`.
+
+- [ ] **Step 3: Write the failing input/modal test**
+
+Require `map_action_pressed`, `MapButton`, and `GearsLocalRouteSheet`. Connect Action/Tool/Map counters; verify touch Map and synthetic desktop `M` each toggle once, gesture lock and driving reject opening, modal blocks `trigger_action()` / `trigger_tool_action()`, and closing restores the pre-map player input-lock state and Tool availability.
+
+- [ ] **Step 4: Add the P06 workflow and run RED**
+
+Workflow commands:
+
+```bash
+"$GODOT_BIN" --headless --editor --rendering-method gl_compatibility --path godot --quit
+"$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_surveyed_route_progress_store_test.gd
+"$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_surveyed_service_cut_test.gd
+"$GODOT_BIN" --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_surveyed_service_cut_input_test.gd
+```
+
+Expected RED: missing P06 progress/runtime/input surfaces, not syntax/harness errors.
+
+- [ ] **Step 5: Commit RED**
+
+```bash
+git add godot/tests/gears_surveyed_route_progress_store_test.gd godot/tests/gears_surveyed_service_cut_test.gd godot/tests/gears_surveyed_service_cut_input_test.gd .github/workflows/burnside-production-06.yml
+git commit -m "test: define Production 06 surveyed-route RED"
+```
+
+---
+
+### Task 2: GREEN — Narrow Durable Mapped-Knowledge Store
+
+**Files:**
+- Create: `godot/scripts/progress/surveyed_route_progress_store.gd`
+- Test: `godot/tests/gears_surveyed_route_progress_store_test.gd`
+
+**Interfaces:**
+- Produces: `configure(path_override := "") -> void`, `is_surveyed(route_id: String) -> bool`, `mark_surveyed(route_id: String) -> bool`, `get_surveyed_routes() -> PackedStringArray`, `get_write_count() -> int`, `get_load_status() -> String`, `is_write_blocked() -> bool`, `get_storage_path() -> String`.
+
+- [ ] **Step 1: Keep the persistence test RED and implement the minimum store**
+
+Core constants and shape:
+
+```gdscript
+class_name SurveyedRouteProgressStore
+extends RefCounted
+
+const SCHEMA_VERSION := 1
+const PRODUCTION_PATH := "user://burnside_mapped_knowledge.json"
+
+var _surveyed_routes: Dictionary = {}
+var _storage_path := ""
+var _write_blocked := false
+var _write_count := 0
+var _load_status := "UNCONFIGURED"
+```
+
+`configure()` chooses the explicit override first; otherwise, if any command-line argument contains `res://tests/`, resolve an isolated `user://tests/p06_<test-script-basename>.json`; otherwise use `PRODUCTION_PATH`.
+
+Load only JSON dictionaries whose integer `version == 1` and whose `surveyed_routes` is an array of strings. Missing file is `CLEAN`. Malformed/unsupported payload sets `_write_blocked = true` and leaves bytes untouched.
+
+`mark_surveyed()` returns `false` when already known or write-blocked. For a new route, persist the canonical version-1 document first; roll back the in-memory insertion on write failure; increment `_write_count` only on successful file write.
+
+- [ ] **Step 2: Run the persistence test to GREEN**
+
+```bash
+Godot --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_surveyed_route_progress_store_test.gd
+```
+
+Expected: `PASS`, malformed/newer raw bytes unchanged, one write for first survey, zero duplicate writes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add godot/scripts/progress/surveyed_route_progress_store.gd godot/tests/gears_surveyed_route_progress_store_test.gd
+git commit -m "feat: persist surveyed route knowledge"
+```
+
+---
+
+### Task 3: GREEN — Legitimate Service-Cut Traversal Runtime
+
+**Files:**
+- Create: `godot/scripts/world/gears_surveyed_service_cut_runtime.gd`
+- Modify: `godot/scripts/visual/gears_district_slice_01b.gd`
+- Test: `godot/tests/gears_surveyed_service_cut_test.gd`
+
+**Interfaces:**
+- Consumes: `SurveyedRouteProgressStore`, P05 `GearsScrapperToolRuntime`, real `ServiceAlleyEntrySocket`, `ServiceAlley`, `NorthConnector` authored surfaces, `Runner`.
+- Produces: `configure(root_controller, district, progress_store := null) -> bool`, `sample_player_position(position: Vector3) -> void`, `is_route_surveyed() -> bool`, `get_survey_record_count() -> int`, `get_route_id() -> String`, `reset_transient_state() -> void`, `get_progress_store()`.
+
+- [ ] **Step 1: Implement only the traversal state machine needed by RED**
+
+Use:
+
+```gdscript
+const ROUTE_ID := "gears.service_alley_north_connector"
+const MAX_SAMPLE_JUMP_M := 3.0
+const MIN_TRAVERSAL_DISTANCE_M := 12.0
+const ENTRY_RADIUS_M := 2.5
+const CONNECTOR_RADIUS_M := 3.2
+```
+
+Arm only when P05 access reports `FORCED_OPEN` and the player reaches one endpoint. Each subsequent horizontal sample must be within the authored ServiceAlley/NorthConnector corridor plus a small tolerance and must not jump farther than `MAX_SAMPLE_JUMP_M`. Accumulate travel. Reaching the opposite endpoint with sufficient distance calls `mark_surveyed(ROUTE_ID)` once. A discontinuity or leaving the route corridor resets transient qualification.
+
+Production `_physics_process` samples `_player.global_position`; the public `sample_player_position` exists only as a deterministic seam over the same state machine.
+
+- [ ] **Step 2: Mount one root runtime after P05**
+
+In `gears_district_slice_01b.gd` preload the new script, add `call_deferred("_mount_production_06_surveyed_service_cut")`, instantiate root sibling `GearsSurveyedServiceCutRuntime`, and configure it with root + district. Do not move P04/P05 authority.
+
+- [ ] **Step 3: Run service-cut semantics to GREEN**
+
+```bash
+Godot --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_surveyed_service_cut_test.gd
+```
+
+Expected: view/force alone no survey, teleport no survey, continuous crossing one survey, duplicate crossing no duplicate write, Replay retains knowledge while P05 is jammed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add godot/scripts/world/gears_surveyed_service_cut_runtime.gd godot/scripts/visual/gears_district_slice_01b.gd godot/tests/gears_surveyed_service_cut_test.gd
+git commit -m "feat: survey the Gears service cut"
+```
+
+---
+
+### Task 4: GREEN — Bounded Gears Route Sheet and Map Ownership
+
+**Files:**
+- Create: `godot/scripts/ui/gears_local_route_sheet.gd`
+- Modify: `godot/scripts/world/gears_surveyed_service_cut_runtime.gd`
+- Modify: `godot/scripts/input/touch_controls.gd`
+- Test: `godot/tests/gears_surveyed_service_cut_input_test.gd`
+
+**Interfaces:**
+- `GearsLocalRouteSheet.configure(district) -> bool`
+- `GearsLocalRouteSheet.set_route_state(surveyed: bool, access_state: String) -> void`
+- `GearsLocalRouteSheet.is_service_cut_visible() -> bool`
+- `GearsLocalRouteSheet.get_access_status_text() -> String`
+- `TouchControlsUI.map_action_pressed`
+- `TouchControlsUI.set_map_modal_active(active: bool) -> void`
+- `TouchControlsUI.is_map_modal_active() -> bool`
+- Runtime: `toggle_map() -> bool`, `is_map_open() -> bool`, `get_route_sheet()`, `get_map_button()`.
+
+- [ ] **Step 1: Implement the route sheet from authored geometry**
+
+`GearsLocalRouteSheet` is a `Control` that reads BoxShape3D bounds from `NorthRoad`, `IndustrialIntersection`, `ServiceAlley`, and `NorthConnector`. `_draw()` always draws the first two context surfaces. It draws ServiceAlley/NorthConnector only when `surveyed == true`. Status text is exactly `UNKNOWN ROUTE`, `KNOWN · ACCESS JAMMED`, or `KNOWN · ACCESS OPEN`.
+
+- [ ] **Step 2: Add minimal map modal gate to `TouchControlsUI`**
+
+Add:
+
+```gdscript
+signal map_action_pressed
+var _map_modal_active := false
+
+func set_map_modal_active(active: bool) -> void:
+    _map_modal_active = active
+    _refresh_tool_action_button()
+
+func is_map_modal_active() -> bool:
+    return _map_modal_active
+```
+
+Make `_on_action_button_clicked()` emit only when `_map_modal_active == false`. Add `and not _map_modal_active` to `_tool_action_can_emit()`. In keyboard `_input`, suppress E/F gameplay emission while the map modal is active, and emit `map_action_pressed` once for a non-echo `KEY_M` press.
+
+- [ ] **Step 3: Let the P06 runtime own Map UI**
+
+At configure time, create `MapButton` under `SafeAreaRoot/RightTouchArea`, plus a full-screen mouse-filter-STOP modal containing `GearsLocalRouteSheet`, title/status labels, and a small close hint. Put MapButton above the modal z-order so the same touch control can close it.
+
+`toggle_map()` opens only on foot when no gesture/input lock already owns the player. Opening stores the previous `Runner.is_input_locked`, sets it true, and calls `set_map_modal_active(true)`. Closing calls `set_map_modal_active(false)` and restores the exact saved lock value. Map remains unavailable while driving. Replay closes it and clears only transient survey state.
+
+- [ ] **Step 4: Run input/modal test to GREEN**
+
+```bash
+Godot --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_surveyed_service_cut_input_test.gd
+```
+
+Expected: one toggle per M/touch activation, gesture/driving rejection, Action/Tool suppression while open, exact restoration on close, safe-area containment.
+
+- [ ] **Step 5: Run retained P05 input tests immediately**
+
+```bash
+Godot --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_scrapper_tool_input_test.gd
+Godot --headless --rendering-method gl_compatibility --path godot --script res://tests/gears_scrapper_tool_input_lock_test.gd
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add godot/scripts/ui/gears_local_route_sheet.gd godot/scripts/world/gears_surveyed_service_cut_runtime.gd godot/scripts/input/touch_controls.gd godot/tests/gears_surveyed_service_cut_input_test.gd
+git commit -m "feat: add Gears surveyed-route sheet"
+```
+
+---
+
+### Task 5: Runtime, Rendered, and Browser Persistence Proof
+
+**Files:**
+- Create: `godot/tests/gears_surveyed_service_cut_render_capture.gd`
+- Create: `godot/tests/gears_surveyed_route_web_probe.gd`
+- Create: `godot/tests/gears_surveyed_route_web_probe.tscn`
+- Modify: `.github/workflows/burnside-production-06.yml`
+
+**Interfaces:**
+- Consumes actual P06 runtime/store/sheet and the real production scene.
+- Produces six PNGs + `render_report.json` under `godot/verification/production06/`; browser titles `P06_WRITE_OK`, `P06_RELOAD_OK`, or `P06_FAIL`.
+
+- [ ] **Step 1: Add six-state rendered capture**
+
+Capture exactly:
+
+```text
+01_route_sheet_pre_survey.png
+02_access_open_route_unsurveyed.png
+03_route_surveyed_confirmation.png
+04_route_sheet_surveyed_open.png
+05_replay_known_route_jammed.png
+06_known_route_reopened.png
+```
+
+Each state must assert its semantics before saving the image. The report records route surveyed state, P05 access state, sheet visibility/status, and source conditions.
+
+- [ ] **Step 2: Add the actual-store Web probe**
+
+`gears_surveyed_route_web_probe.gd` uses explicit isolated path `user://p06_web_reload_probe.json` and actual `SurveyedRouteProgressStore`. If route is absent, mark it and set window title/label `P06_WRITE_OK`. If already present on a fresh page load, set `P06_RELOAD_OK`. On any persistence error, set `P06_FAIL`.
+
+- [ ] **Step 3: Extend P06 CI for render + browser reload proof**
+
+In the focused job run the six-state render capture under Xvfb and upload `godot/verification/production06/`.
+
+In a separate Web persistence job:
+
+```bash
+cp -a godot "$WEB_PROJECT"
+# patch the isolated copy's project.godot run/main_scene to res://tests/gears_surveyed_route_web_probe.tscn
+Godot --headless --editor --rendering-method gl_compatibility --path "$WEB_PROJECT" --quit
+Godot --headless --rendering-method gl_compatibility --path "$WEB_PROJECT" --export-release "Web Playtest" "$GITHUB_WORKSPACE/build/p06-web/index.html"
+python3 -m http.server 8096 --directory build/p06-web &
+python3 -m playwright install chromium
+```
+
+Browser proof uses one Chromium context/profile and same `http://127.0.0.1:8096/` origin:
+
+```python
+page.goto(url)
+page.wait_for_function("document.title === 'P06_WRITE_OK'")
+page.reload()
+page.wait_for_function("document.title === 'P06_RELOAD_OK'")
+```
+
+Fail if either state is not reached.
+
+- [ ] **Step 4: Run retained focused regressions in P06 workflow**
+
+Run P05 input/input-lock/environment/pursuer/Mission02 ordering; P04 work-zone + ordering; P03 suppression + Wanted composition; P02 Field-Hacking; P01 Heat-1.
+
+- [ ] **Step 5: Commit proof harness**
+
+```bash
+git add godot/tests/gears_surveyed_service_cut_render_capture.gd godot/tests/gears_surveyed_route_web_probe.gd godot/tests/gears_surveyed_route_web_probe.tscn .github/workflows/burnside-production-06.yml
+git commit -m "test: verify Production 06 runtime and Web persistence"
+```
+
+---
+
+### Task 6: Exact-Head Review, Merge, Exact-Main/Public, Continuity
+
+**Files:**
+- Review all P06 changed files against `contracts/burnside_production_06_surveyed_service_cut_spec.md` and issue #134.
+- Update only continuity files whose routing/status actually changes after merge.
+
+**Interfaces:**
+- Consumes: P06 workflow run, retained `godot-web-playtest.yml` PR runs, PR diff, issue #134.
+- Produces: frozen reviewed P06 head, merged exact-main SHA, public `playtest-web/PLAYTEST_BUILD.txt` stamp, continuity closure.
+
+- [ ] **Step 1: Require exact-head GREEN**
+
+Require successful P06 focused/render/Web-persistence workflow plus retained Godot Web workflow literal-head export, synthetic-merge export, static-host smoke, desktop/touch regressions, camera contracts, and canonical compatibility matrix.
+
+- [ ] **Step 2: Freeze and run Standards + spec review**
+
+Inspect every changed path and PR diff. Reject any generalized save/navigation framework, unearned map disclosure, access-state lie, input leakage, authority mutation, or Audio/camera scope expansion. Repair on branch and re-run exact-head gates if any defect exists.
+
+- [ ] **Step 3: Merge only the reviewed SHA**
+
+Use the repository's retained merge method and GitHub expected-head protection. Record both final reviewed feature head and merge SHA.
+
+- [ ] **Step 4: Require exact-main verification**
+
+Require P06 main-push workflow and `Godot Web Playtest` main-push workflow to run against the exact merge SHA. Verify `playtest-web/PLAYTEST_BUILD.txt` equals that same gameplay/public SHA after publication.
+
+- [ ] **Step 5: Update continuity and close issue**
+
+Only after exact-main/public verification, update `HANDOFF.md`, product continuity/status surfaces that are actually stale, and issue #134 with exact SHAs/run evidence. Close #134 as completed. If continuity is docs-only, preserve the exact gameplay/public SHA separately from the newer docs-only main SHA.
+
+- [ ] **Step 6: Final report**
+
+Report exact verified repo/main/feature/public SHAs, player-facing behavior, test/workflow evidence, and only concrete remaining risks. Do not call broader navigation/persistence/Durable Progress complete.

--- a/godot/scenes/prototype/scrap_test_block.tscn
+++ b/godot/scenes/prototype/scrap_test_block.tscn
@@ -8,7 +8,7 @@
 
 [ext_resource type="PackedScene" uid="uid://c_corroded_panel_001" path="res://scenes/interactions/corroded_panel.tscn" id="4_panel"]
 
-[ext_resource type="Script" path="res://scripts/input/touch_controls.gd" id="5_ui"]
+[ext_resource type="Script" path="res://scripts/input/gears_surveyed_route_touch_controls.gd" id="5_ui"]
 
 [ext_resource type="Script" path="res://scripts/audio/audio_manager.gd" id="6_audio"]
 

--- a/godot/scripts/input/gears_surveyed_route_touch_controls.gd
+++ b/godot/scripts/input/gears_surveyed_route_touch_controls.gd
@@ -5,6 +5,7 @@ signal map_action_pressed
 signal ui_mode_changed(mode: int)
 
 var _map_modal_active := false
+var _map_action_available := true
 var _action_disabled_before_map := false
 
 func set_map_modal_active(active: bool) -> void:
@@ -20,8 +21,11 @@ func set_map_modal_active(active: bool) -> void:
 func is_map_modal_active() -> bool:
 	return _map_modal_active
 
+func set_map_action_available(available: bool) -> void:
+	_map_action_available = available
+
 func _map_action_can_emit() -> bool:
-	return current_mode == UIMode.FOOT_TRAVERSAL and not is_interaction_input_locked()
+	return _map_action_available and current_mode == UIMode.FOOT_TRAVERSAL and not is_interaction_input_locked()
 
 func trigger_map_action() -> void:
 	if _map_action_can_emit():

--- a/godot/scripts/input/gears_surveyed_route_touch_controls.gd
+++ b/godot/scripts/input/gears_surveyed_route_touch_controls.gd
@@ -5,11 +5,16 @@ signal map_action_pressed
 signal ui_mode_changed(mode: int)
 
 var _map_modal_active := false
+var _action_disabled_before_map := false
 
 func set_map_modal_active(active: bool) -> void:
+	if active == _map_modal_active:
+		return
+	if active:
+		_action_disabled_before_map = action_button != null and action_button.disabled
 	_map_modal_active = active
 	if action_button:
-		action_button.disabled = active
+		action_button.disabled = true if active else _action_disabled_before_map
 	_refresh_tool_action_button()
 
 func is_map_modal_active() -> bool:

--- a/godot/scripts/input/gears_surveyed_route_touch_controls.gd
+++ b/godot/scripts/input/gears_surveyed_route_touch_controls.gd
@@ -1,0 +1,50 @@
+class_name GearsSurveyedRouteTouchControls
+extends TouchControlsUI
+
+signal map_action_pressed
+signal ui_mode_changed(mode: int)
+
+var _map_modal_active := false
+
+func set_map_modal_active(active: bool) -> void:
+	_map_modal_active = active
+	if action_button:
+		action_button.disabled = active
+	_refresh_tool_action_button()
+
+func is_map_modal_active() -> bool:
+	return _map_modal_active
+
+func _map_action_can_emit() -> bool:
+	return current_mode == UIMode.FOOT_TRAVERSAL and not is_interaction_input_locked()
+
+func trigger_map_action() -> void:
+	if _map_action_can_emit():
+		map_action_pressed.emit()
+
+func _on_action_button_clicked() -> void:
+	if _map_modal_active:
+		return
+	super._on_action_button_clicked()
+
+func _tool_action_can_emit() -> bool:
+	return not _map_modal_active and super._tool_action_can_emit()
+
+func set_mode(mode: UIMode) -> void:
+	super.set_mode(mode)
+	ui_mode_changed.emit(int(mode))
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventKey:
+		var key_ev := event as InputEventKey
+		if key_ev.pressed and not key_ev.echo and _is_key(key_ev, KEY_M):
+			if _map_action_can_emit():
+				map_action_pressed.emit()
+				if get_viewport():
+					get_viewport().set_input_as_handled()
+			return
+		if _map_modal_active and key_ev.pressed and (_is_key(key_ev, KEY_E) or _is_key(key_ev, KEY_F)):
+			if get_viewport():
+				get_viewport().set_input_as_handled()
+			return
+	super._input(event)

--- a/godot/scripts/progress/surveyed_route_progress_store.gd
+++ b/godot/scripts/progress/surveyed_route_progress_store.gd
@@ -1,0 +1,130 @@
+class_name SurveyedRouteProgressStore
+extends RefCounted
+
+const SCHEMA_VERSION := 1
+const PRODUCTION_PATH := "user://burnside_mapped_knowledge.json"
+const TEST_DIRECTORY := "user://tests"
+
+var _storage_path: String = ""
+var _surveyed_routes: Dictionary = {}
+var _write_blocked: bool = false
+var _write_count: int = 0
+var _load_status: String = "UNCONFIGURED"
+
+func configure(storage_path_override: String = "") -> void:
+	_storage_path = storage_path_override if not storage_path_override.is_empty() else _resolve_default_storage_path()
+	_surveyed_routes.clear()
+	_write_blocked = false
+	_write_count = 0
+	_load_status = "CLEAN"
+	_load_from_disk()
+
+func _resolve_default_storage_path() -> String:
+	for arg in OS.get_cmdline_args():
+		var text := String(arg)
+		if text.contains("res://tests/") and text.ends_with(".gd"):
+			var basename := text.get_file().get_basename()
+			return "%s/p06_%s.json" % [TEST_DIRECTORY, basename]
+	return PRODUCTION_PATH
+
+func _load_from_disk() -> void:
+	if _storage_path.is_empty() or not FileAccess.file_exists(_storage_path):
+		_load_status = "CLEAN"
+		return
+
+	var file := FileAccess.open(_storage_path, FileAccess.READ)
+	if file == null:
+		_write_blocked = true
+		_load_status = "READ_ERROR"
+		return
+	var raw := file.get_as_text()
+	file.close()
+
+	var parsed = JSON.parse_string(raw)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		_write_blocked = true
+		_load_status = "MALFORMED"
+		return
+
+	var document: Dictionary = parsed
+	if not document.has("version"):
+		_write_blocked = true
+		_load_status = "MALFORMED"
+		return
+	var version_value = document["version"]
+	if typeof(version_value) != TYPE_INT and typeof(version_value) != TYPE_FLOAT:
+		_write_blocked = true
+		_load_status = "MALFORMED"
+		return
+	if int(version_value) != SCHEMA_VERSION or float(version_value) != float(SCHEMA_VERSION):
+		_write_blocked = true
+		_load_status = "UNSUPPORTED_VERSION"
+		return
+
+	if not document.has("surveyed_routes") or typeof(document["surveyed_routes"]) != TYPE_ARRAY:
+		_write_blocked = true
+		_load_status = "MALFORMED"
+		return
+	var routes: Array = document["surveyed_routes"]
+	for route_value in routes:
+		if typeof(route_value) != TYPE_STRING or String(route_value).is_empty():
+			_write_blocked = true
+			_surveyed_routes.clear()
+			_load_status = "MALFORMED"
+			return
+		_surveyed_routes[String(route_value)] = true
+	_load_status = "LOADED"
+
+func _ensure_parent_directory() -> bool:
+	var base_dir := _storage_path.get_base_dir()
+	if base_dir.is_empty():
+		return true
+	var absolute_dir := ProjectSettings.globalize_path(base_dir)
+	var error := DirAccess.make_dir_recursive_absolute(absolute_dir)
+	return error == OK or error == ERR_ALREADY_EXISTS
+
+func _persist_supported_document() -> bool:
+	if _write_blocked or _storage_path.is_empty() or not _ensure_parent_directory():
+		return false
+	var file := FileAccess.open(_storage_path, FileAccess.WRITE)
+	if file == null:
+		return false
+	var payload := {
+		"version": SCHEMA_VERSION,
+		"surveyed_routes": Array(get_surveyed_routes()),
+	}
+	file.store_string(JSON.stringify(payload) + "\n")
+	file.close()
+	_write_count += 1
+	return true
+
+func is_surveyed(route_id: String) -> bool:
+	return not route_id.is_empty() and _surveyed_routes.has(route_id)
+
+func mark_surveyed(route_id: String) -> bool:
+	if route_id.is_empty() or _write_blocked or is_surveyed(route_id):
+		return false
+	_surveyed_routes[route_id] = true
+	if not _persist_supported_document():
+		_surveyed_routes.erase(route_id)
+		return false
+	return true
+
+func get_surveyed_routes() -> PackedStringArray:
+	var routes := PackedStringArray()
+	for route_id in _surveyed_routes.keys():
+		routes.append(String(route_id))
+	routes.sort()
+	return routes
+
+func get_write_count() -> int:
+	return _write_count
+
+func get_load_status() -> String:
+	return _load_status
+
+func is_write_blocked() -> bool:
+	return _write_blocked
+
+func get_storage_path() -> String:
+	return _storage_path

--- a/godot/scripts/progress/surveyed_route_progress_store.gd
+++ b/godot/scripts/progress/surveyed_route_progress_store.gd
@@ -4,6 +4,7 @@ extends RefCounted
 const SCHEMA_VERSION := 1
 const PRODUCTION_PATH := "user://burnside_mapped_knowledge.json"
 const TEST_DIRECTORY := "user://tests"
+const STAGING_SUFFIX := ".tmp"
 
 var _storage_path: String = ""
 var _surveyed_routes: Dictionary = {}
@@ -83,18 +84,41 @@ func _ensure_parent_directory() -> bool:
 	var error := DirAccess.make_dir_recursive_absolute(absolute_dir)
 	return error == OK or error == ERR_ALREADY_EXISTS
 
+func _cleanup_staging_file(staging_path: String) -> void:
+	if staging_path.is_empty() or not FileAccess.file_exists(staging_path):
+		return
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(staging_path))
+
 func _persist_supported_document() -> bool:
 	if _write_blocked or _storage_path.is_empty() or not _ensure_parent_directory():
 		return false
-	var file := FileAccess.open(_storage_path, FileAccess.WRITE)
-	if file == null:
-		return false
+
 	var payload := {
 		"version": SCHEMA_VERSION,
 		"surveyed_routes": Array(get_surveyed_routes()),
 	}
-	file.store_string(JSON.stringify(payload) + "\n")
+	var staging_path := _storage_path + STAGING_SUFFIX
+	_cleanup_staging_file(staging_path)
+
+	var file := FileAccess.open(staging_path, FileAccess.WRITE)
+	if file == null:
+		return false
+	var wrote := file.store_string(JSON.stringify(payload) + "\n")
+	file.flush()
+	var write_error := file.get_error()
 	file.close()
+	if not wrote or write_error != OK:
+		_cleanup_staging_file(staging_path)
+		return false
+
+	var rename_error := DirAccess.rename_absolute(
+		ProjectSettings.globalize_path(staging_path),
+		ProjectSettings.globalize_path(_storage_path)
+	)
+	if rename_error != OK:
+		_cleanup_staging_file(staging_path)
+		return false
+
 	_write_count += 1
 	return true
 

--- a/godot/scripts/ui/gears_local_route_sheet.gd
+++ b/godot/scripts/ui/gears_local_route_sheet.gd
@@ -26,7 +26,7 @@ func configure(district: Node3D) -> bool:
 	_surface_bounds.clear()
 	for body_name in CONTEXT_SURFACES + SURVEYED_SURFACES:
 		var bounds := _read_box_surface_bounds(String(body_name))
-		if bounds.is_empty():
+		if not bounds.has_area():
 			return false
 		_surface_bounds[String(body_name)] = bounds
 	_world_bounds = _combined_world_bounds()

--- a/godot/scripts/ui/gears_local_route_sheet.gd
+++ b/godot/scripts/ui/gears_local_route_sheet.gd
@@ -1,0 +1,133 @@
+class_name GearsLocalRouteSheet
+extends Control
+
+const STATUS_UNKNOWN := "UNKNOWN ROUTE"
+const STATUS_JAMMED := "KNOWN · ACCESS JAMMED"
+const STATUS_OPEN := "KNOWN · ACCESS OPEN"
+const CONTEXT_SURFACES := ["NorthRoad", "IndustrialIntersection"]
+const SURVEYED_SURFACES := ["ServiceAlley", "NorthConnector"]
+const DRAW_PADDING := 30.0
+
+var _district: Node3D = null
+var _surface_bounds: Dictionary = {}
+var _surveyed := false
+var _access_state := "JAMMED"
+var _world_bounds := Rect2()
+var _configured := false
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	resized.connect(queue_redraw)
+
+func configure(district: Node3D) -> bool:
+	if district == null:
+		return false
+	_district = district
+	_surface_bounds.clear()
+	for body_name in CONTEXT_SURFACES + SURVEYED_SURFACES:
+		var bounds := _read_box_surface_bounds(String(body_name))
+		if bounds.is_empty():
+			return false
+		_surface_bounds[String(body_name)] = bounds
+	_world_bounds = _combined_world_bounds()
+	_configured = _world_bounds.has_area()
+	queue_redraw()
+	return _configured
+
+func _read_box_surface_bounds(body_name: String) -> Rect2:
+	if _district == null:
+		return Rect2()
+	var body := _district.get_node_or_null(body_name) as Node3D
+	var collider := _district.get_node_or_null("%s/CollisionShape3D" % body_name) as CollisionShape3D
+	if body == null or collider == null:
+		return Rect2()
+	var shape := collider.shape as BoxShape3D
+	if shape == null:
+		return Rect2()
+	var half := shape.size * 0.5
+	return Rect2(
+		Vector2(body.global_position.x - half.x, body.global_position.z - half.z),
+		Vector2(shape.size.x, shape.size.z)
+	)
+
+func _combined_world_bounds() -> Rect2:
+	var combined := Rect2()
+	var first := true
+	for value in _surface_bounds.values():
+		if not (value is Rect2):
+			continue
+		var rect := value as Rect2
+		if first:
+			combined = rect
+			first = false
+		else:
+			combined = combined.merge(rect)
+	return combined
+
+func set_route_state(surveyed: bool, access_state: String) -> void:
+	_surveyed = surveyed
+	_access_state = access_state
+	queue_redraw()
+
+func is_service_cut_visible() -> bool:
+	return _surveyed
+
+func get_access_status_text() -> String:
+	if not _surveyed:
+		return STATUS_UNKNOWN
+	return STATUS_OPEN if _access_state == "FORCED_OPEN" else STATUS_JAMMED
+
+func get_surface_world_bounds(surface_name: String) -> Rect2:
+	var value = _surface_bounds.get(surface_name, Rect2())
+	return value as Rect2 if value is Rect2 else Rect2()
+
+func _map_rect() -> Rect2:
+	return Rect2(
+		Vector2(DRAW_PADDING, DRAW_PADDING + 24.0),
+		Vector2(maxf(size.x - DRAW_PADDING * 2.0, 1.0), maxf(size.y - DRAW_PADDING * 2.0 - 54.0, 1.0))
+	)
+
+func _project_world_rect(world_rect: Rect2) -> Rect2:
+	if not _world_bounds.has_area():
+		return Rect2()
+	var target := _map_rect()
+	var scale_x := target.size.x / _world_bounds.size.x
+	var scale_y := target.size.y / _world_bounds.size.y
+	var scale := minf(scale_x, scale_y)
+	var drawn_size := _world_bounds.size * scale
+	var origin := target.position + (target.size - drawn_size) * 0.5
+	var local_position := origin + (world_rect.position - _world_bounds.position) * scale
+	return Rect2(local_position, world_rect.size * scale)
+
+func _draw_surface(surface_name: String, fill: Color, outline: Color, width: float = 2.0) -> void:
+	var world_rect := get_surface_world_bounds(surface_name)
+	if not world_rect.has_area():
+		return
+	var projected := _project_world_rect(world_rect)
+	draw_rect(projected, fill, true)
+	draw_rect(projected, outline, false, width)
+
+func _draw() -> void:
+	if not _configured:
+		return
+	var panel_rect := Rect2(Vector2.ZERO, size)
+	draw_rect(panel_rect, Color(0.035, 0.045, 0.05, 0.96), true)
+	draw_rect(panel_rect.grow(-1.0), Color(0.18, 0.36, 0.40, 0.95), false, 2.0)
+
+	var context_fill := Color(0.18, 0.23, 0.25, 0.65)
+	var context_outline := Color(0.48, 0.58, 0.60, 0.85)
+	for surface_name in CONTEXT_SURFACES:
+		_draw_surface(String(surface_name), context_fill, context_outline, 2.0)
+
+	if _surveyed:
+		var route_fill := Color(0.08, 0.36, 0.39, 0.82)
+		var route_outline := Color(0.20, 0.88, 0.92, 0.98)
+		for surface_name in SURVEYED_SURFACES:
+			_draw_surface(String(surface_name), route_fill, route_outline, 3.0)
+
+	var font := ThemeDB.fallback_font
+	draw_string(font, Vector2(DRAW_PADDING, 30.0), "GEARS · LOCAL ROUTE SHEET", HORIZONTAL_ALIGNMENT_LEFT, -1.0, 16, Color(0.78, 0.92, 0.94, 1.0))
+	var status_color := Color(0.96, 0.76, 0.30, 1.0) if get_access_status_text() == STATUS_JAMMED else Color(0.62, 0.90, 0.82, 1.0)
+	if not _surveyed:
+		status_color = Color(0.62, 0.68, 0.70, 1.0)
+	draw_string(font, Vector2(DRAW_PADDING, size.y - 18.0), get_access_status_text(), HORIZONTAL_ALIGNMENT_LEFT, -1.0, 15, status_color)

--- a/godot/scripts/visual/gears_district_slice_01b.gd
+++ b/godot/scripts/visual/gears_district_slice_01b.gd
@@ -6,6 +6,7 @@ extends Node3D
 
 const GearsWorkZoneIncidentScript = preload("res://scripts/world/gears_work_zone_incident.gd")
 const GearsScrapperToolRuntimeScript = preload("res://scripts/world/gears_scrapper_tool_runtime.gd")
+const GearsSurveyedServiceCutRuntimeScript = preload("res://scripts/world/gears_surveyed_service_cut_runtime.gd")
 const RETAINED_NORTH_EDGE_Z := -20.0
 const APPROVED_TOON_SHADER_PATH := "res://materials/gears_toon.gdshader"
 const ADDITIVE_EXTENSION_PATHS := [
@@ -16,6 +17,7 @@ const ADDITIVE_EXTENSION_PATHS := [
 func _ready() -> void:
 	call_deferred("_mount_production_04_work_zone")
 	call_deferred("_mount_production_05_scrapper_tool")
+	call_deferred("_mount_production_06_surveyed_service_cut")
 
 func _mount_production_04_work_zone() -> void:
 	var scene_root := get_parent()
@@ -45,6 +47,22 @@ func _mount_production_05_scrapper_tool() -> void:
 	if runtime == null:
 		return
 	runtime.name = "GearsScrapperToolRuntime"
+	scene_root.add_child(runtime)
+	if not bool(runtime.call("configure", scene_root, self)):
+		runtime.queue_free()
+
+func _mount_production_06_surveyed_service_cut() -> void:
+	var scene_root := get_parent()
+	if scene_root == null or not (scene_root is Node3D):
+		return
+	if scene_root.get_node_or_null("GearsSurveyedServiceCutRuntime") != null:
+		return
+	if scene_root.get_node_or_null("GearsScrapperToolRuntime") == null:
+		return
+	var runtime := GearsSurveyedServiceCutRuntimeScript.new() as Node3D
+	if runtime == null:
+		return
+	runtime.name = "GearsSurveyedServiceCutRuntime"
 	scene_root.add_child(runtime)
 	if not bool(runtime.call("configure", scene_root, self)):
 		runtime.queue_free()

--- a/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
+++ b/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
@@ -1,0 +1,189 @@
+class_name GearsSurveyedServiceCutRuntime
+extends Node3D
+
+const SurveyedRouteProgressStoreScript = preload("res://scripts/progress/surveyed_route_progress_store.gd")
+
+const ROUTE_ID := "gears.service_alley_north_connector"
+const MAX_SAMPLE_JUMP_M := 3.0
+const MIN_TRAVERSAL_DISTANCE_M := 12.0
+const ENTRY_RADIUS_M := 2.5
+const CONNECTOR_RADIUS_M := 3.2
+const CORRIDOR_TOLERANCE_M := 1.0
+
+enum TraversalSide {
+	NONE,
+	ALLEY,
+	CONNECTOR,
+}
+
+var _root_controller: Node = null
+var _district: Node3D = null
+var _player: Node3D = null
+var _scrapper_runtime: Node = null
+var _touch_ui: Node = null
+var _entry_socket: Node3D = null
+var _connector: Node3D = null
+var _service_alley_bounds: Dictionary = {}
+var _connector_bounds: Dictionary = {}
+var _progress_store = null
+
+var _configured := false
+var _armed_side := TraversalSide.NONE
+var _last_sample := Vector3.ZERO
+var _has_last_sample := false
+var _travel_distance_m := 0.0
+var _survey_record_count := 0
+
+func configure(root_controller: Node, district: Node3D, progress_store = null) -> bool:
+	if root_controller == null or district == null:
+		return false
+	_root_controller = root_controller
+	_district = district
+	_player = root_controller.get_node_or_null("Runner") as Node3D
+	_scrapper_runtime = root_controller.get_node_or_null("GearsScrapperToolRuntime")
+	_touch_ui = root_controller.get_node_or_null("CanvasLayer/TouchControlsUI")
+	_entry_socket = district.get_node_or_null("ServiceAlleyEntrySocket") as Node3D
+	_connector = district.get_node_or_null("NorthConnector") as Node3D
+	_service_alley_bounds = _surface_bounds("ServiceAlley")
+	_connector_bounds = _surface_bounds("NorthConnector")
+	if _player == null or _scrapper_runtime == null or _entry_socket == null or _connector == null:
+		return false
+	if _service_alley_bounds.is_empty() or _connector_bounds.is_empty():
+		return false
+	if not _scrapper_runtime.has_method("get_access_state_name"):
+		return false
+
+	_progress_store = progress_store
+	if _progress_store == null:
+		_progress_store = SurveyedRouteProgressStoreScript.new()
+		_progress_store.call("configure")
+	if _progress_store == null or not _progress_store.has_method("is_surveyed") or not _progress_store.has_method("mark_surveyed"):
+		return false
+
+	if _touch_ui != null and _touch_ui.has_signal("replay_pressed"):
+		if not _touch_ui.replay_pressed.is_connected(_on_replay_pressed):
+			_touch_ui.replay_pressed.connect(_on_replay_pressed)
+
+	reset_transient_state()
+	_configured = true
+	set_physics_process(true)
+	return true
+
+func _surface_bounds(body_name: String) -> Dictionary:
+	if _district == null:
+		return {}
+	var body := _district.get_node_or_null(body_name) as Node3D
+	var collider := _district.get_node_or_null("%s/CollisionShape3D" % body_name) as CollisionShape3D
+	if body == null or collider == null:
+		return {}
+	var shape := collider.shape as BoxShape3D
+	if shape == null:
+		return {}
+	var half := shape.size * 0.5
+	return {
+		"min_x": body.global_position.x - half.x,
+		"max_x": body.global_position.x + half.x,
+		"min_z": body.global_position.z - half.z,
+		"max_z": body.global_position.z + half.z,
+	}
+
+func _physics_process(_delta: float) -> void:
+	if not _configured or _player == null or is_route_surveyed():
+		return
+	sample_player_position(_player.global_position)
+
+func _horizontal_distance(a: Vector3, b: Vector3) -> float:
+	return Vector2(a.x, a.z).distance_to(Vector2(b.x, b.z))
+
+func _is_access_open() -> bool:
+	return _scrapper_runtime != null and String(_scrapper_runtime.call("get_access_state_name")) == "FORCED_OPEN"
+
+func _side_for_position(position: Vector3) -> int:
+	if _entry_socket != null and _horizontal_distance(position, _entry_socket.global_position) <= ENTRY_RADIUS_M:
+		return TraversalSide.ALLEY
+	if _connector != null and _horizontal_distance(position, _connector.global_position) <= CONNECTOR_RADIUS_M:
+		return TraversalSide.CONNECTOR
+	return TraversalSide.NONE
+
+func _point_in_bounds(position: Vector3, bounds: Dictionary, tolerance: float) -> bool:
+	if bounds.is_empty():
+		return false
+	return position.x >= float(bounds.get("min_x", 0.0)) - tolerance \
+		and position.x <= float(bounds.get("max_x", 0.0)) + tolerance \
+		and position.z >= float(bounds.get("min_z", 0.0)) - tolerance \
+		and position.z <= float(bounds.get("max_z", 0.0)) + tolerance
+
+func _is_in_route_corridor(position: Vector3) -> bool:
+	return _point_in_bounds(position, _service_alley_bounds, CORRIDOR_TOLERANCE_M) \
+		or _point_in_bounds(position, _connector_bounds, CORRIDOR_TOLERANCE_M)
+
+func sample_player_position(position: Vector3) -> void:
+	if not _configured or is_route_surveyed():
+		return
+	if not _is_access_open():
+		reset_transient_state()
+		return
+
+	var sample_side := _side_for_position(position)
+	if _armed_side == TraversalSide.NONE:
+		if sample_side == TraversalSide.NONE:
+			return
+		_armed_side = sample_side
+		_last_sample = position
+		_has_last_sample = true
+		_travel_distance_m = 0.0
+		return
+
+	if not _has_last_sample:
+		reset_transient_state()
+		return
+
+	var step_distance := _horizontal_distance(_last_sample, position)
+	if step_distance > MAX_SAMPLE_JUMP_M:
+		reset_transient_state()
+		return
+	if not _is_in_route_corridor(position):
+		reset_transient_state()
+		return
+
+	_travel_distance_m += step_distance
+	_last_sample = position
+
+	if sample_side == TraversalSide.NONE or sample_side == _armed_side:
+		return
+	if _travel_distance_m < MIN_TRAVERSAL_DISTANCE_M:
+		return
+
+	if bool(_progress_store.call("mark_surveyed", ROUTE_ID)):
+		_survey_record_count += 1
+	reset_transient_state()
+
+func reset_transient_state() -> void:
+	_armed_side = TraversalSide.NONE
+	_last_sample = Vector3.ZERO
+	_has_last_sample = false
+	_travel_distance_m = 0.0
+
+func _on_replay_pressed() -> void:
+	reset_transient_state()
+
+func is_route_surveyed() -> bool:
+	return _progress_store != null and bool(_progress_store.call("is_surveyed", ROUTE_ID))
+
+func get_survey_record_count() -> int:
+	return _survey_record_count
+
+func get_route_id() -> String:
+	return ROUTE_ID
+
+func get_progress_store():
+	return _progress_store
+
+func get_transient_state_name() -> String:
+	match _armed_side:
+		TraversalSide.ALLEY:
+			return "ARMED_ALLEY"
+		TraversalSide.CONNECTOR:
+			return "ARMED_CONNECTOR"
+		_:
+			return "IDLE"

--- a/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
+++ b/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
@@ -2,6 +2,7 @@ class_name GearsSurveyedServiceCutRuntime
 extends Node3D
 
 const SurveyedRouteProgressStoreScript = preload("res://scripts/progress/surveyed_route_progress_store.gd")
+const GearsLocalRouteSheetScript = preload("res://scripts/ui/gears_local_route_sheet.gd")
 
 const ROUTE_ID := "gears.service_alley_north_connector"
 const MAX_SAMPLE_JUMP_M := 3.0
@@ -9,6 +10,7 @@ const MIN_TRAVERSAL_DISTANCE_M := 12.0
 const ENTRY_RADIUS_M := 2.5
 const CONNECTOR_RADIUS_M := 3.2
 const CORRIDOR_TOLERANCE_M := 1.0
+const FOOT_TRAVERSAL_MODE := 0
 
 enum TraversalSide {
 	NONE,
@@ -26,6 +28,11 @@ var _connector: Node3D = null
 var _service_alley_bounds: Dictionary = {}
 var _connector_bounds: Dictionary = {}
 var _progress_store = null
+
+var _map_button: Button = null
+var _map_modal: ColorRect = null
+var _route_sheet: Control = null
+var _map_open := false
 
 var _configured := false
 var _armed_side := TraversalSide.NONE
@@ -46,11 +53,13 @@ func configure(root_controller: Node, district: Node3D, progress_store = null) -
 	_connector = district.get_node_or_null("NorthConnector") as Node3D
 	_service_alley_bounds = _surface_bounds("ServiceAlley")
 	_connector_bounds = _surface_bounds("NorthConnector")
-	if _player == null or _scrapper_runtime == null or _entry_socket == null or _connector == null:
+	if _player == null or _scrapper_runtime == null or _touch_ui == null or _entry_socket == null or _connector == null:
 		return false
 	if _service_alley_bounds.is_empty() or _connector_bounds.is_empty():
 		return false
 	if not _scrapper_runtime.has_method("get_access_state_name"):
+		return false
+	if not _touch_ui.has_signal("map_action_pressed") or not _touch_ui.has_method("trigger_map_action") or not _touch_ui.has_method("set_map_modal_active"):
 		return false
 
 	_progress_store = progress_store
@@ -60,13 +69,77 @@ func configure(root_controller: Node, district: Node3D, progress_store = null) -
 	if _progress_store == null or not _progress_store.has_method("is_surveyed") or not _progress_store.has_method("mark_surveyed"):
 		return false
 
-	if _touch_ui != null and _touch_ui.has_signal("replay_pressed"):
-		if not _touch_ui.replay_pressed.is_connected(_on_replay_pressed):
-			_touch_ui.replay_pressed.connect(_on_replay_pressed)
+	if _touch_ui.has_signal("replay_pressed") and not _touch_ui.replay_pressed.is_connected(_on_replay_pressed):
+		_touch_ui.replay_pressed.connect(_on_replay_pressed)
+	if not _touch_ui.map_action_pressed.is_connected(_on_map_action_pressed):
+		_touch_ui.map_action_pressed.connect(_on_map_action_pressed)
+	if _touch_ui.has_signal("ui_mode_changed") and not _touch_ui.ui_mode_changed.is_connected(_on_ui_mode_changed):
+		_touch_ui.ui_mode_changed.connect(_on_ui_mode_changed)
 
+	if not _build_map_ui():
+		return false
 	reset_transient_state()
+	refresh_map_presentation()
 	_configured = true
 	set_physics_process(true)
+	set_process(true)
+	_refresh_map_button_visibility()
+	return true
+
+func _build_map_ui() -> bool:
+	var right_touch := _touch_ui.get_node_or_null("SafeAreaRoot/RightTouchArea") as Control
+	if right_touch == null:
+		return false
+
+	_map_button = right_touch.get_node_or_null("MapButton") as Button
+	if _map_button == null:
+		_map_button = Button.new()
+		_map_button.name = "MapButton"
+		_map_button.text = "[ M ] MAP"
+		_map_button.anchor_left = 1.0
+		_map_button.anchor_top = 0.0
+		_map_button.anchor_right = 1.0
+		_map_button.anchor_bottom = 0.0
+		_map_button.offset_left = -124.0
+		_map_button.offset_top = 24.0
+		_map_button.offset_right = -24.0
+		_map_button.offset_bottom = 72.0
+		_map_button.grow_horizontal = Control.GROW_DIRECTION_BEGIN
+		_map_button.z_index = 220
+		right_touch.add_child(_map_button)
+	if not _map_button.pressed.is_connected(_on_map_button_pressed):
+		_map_button.pressed.connect(_on_map_button_pressed)
+
+	_map_modal = _touch_ui.get_node_or_null("GearsRouteSheetModal") as ColorRect
+	if _map_modal == null:
+		_map_modal = ColorRect.new()
+		_map_modal.name = "GearsRouteSheetModal"
+		_map_modal.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+		_map_modal.color = Color(0.01, 0.015, 0.018, 0.82)
+		_map_modal.mouse_filter = Control.MOUSE_FILTER_STOP
+		_map_modal.z_index = 200
+		_touch_ui.add_child(_map_modal)
+
+	_route_sheet = _map_modal.get_node_or_null("GearsLocalRouteSheet") as Control
+	if _route_sheet == null:
+		_route_sheet = GearsLocalRouteSheetScript.new() as Control
+		if _route_sheet == null:
+			return false
+		_route_sheet.name = "GearsLocalRouteSheet"
+		_route_sheet.anchor_left = 0.14
+		_route_sheet.anchor_top = 0.12
+		_route_sheet.anchor_right = 0.86
+		_route_sheet.anchor_bottom = 0.88
+		_route_sheet.offset_left = 0.0
+		_route_sheet.offset_top = 0.0
+		_route_sheet.offset_right = 0.0
+		_route_sheet.offset_bottom = 0.0
+		_map_modal.add_child(_route_sheet)
+	if not bool(_route_sheet.call("configure", _district)):
+		return false
+
+	_map_modal.visible = false
+	_map_open = false
 	return true
 
 func _surface_bounds(body_name: String) -> Dictionary:
@@ -86,6 +159,11 @@ func _surface_bounds(body_name: String) -> Dictionary:
 		"min_z": body.global_position.z - half.z,
 		"max_z": body.global_position.z + half.z,
 	}
+
+func _process(_delta: float) -> void:
+	if not _configured:
+		return
+	_refresh_map_button_visibility()
 
 func _physics_process(_delta: float) -> void:
 	if not _configured or _player == null or is_route_surveyed():
@@ -157,6 +235,71 @@ func sample_player_position(position: Vector3) -> void:
 	if bool(_progress_store.call("mark_surveyed", ROUTE_ID)):
 		_survey_record_count += 1
 	reset_transient_state()
+	refresh_map_presentation()
+
+func _on_map_button_pressed() -> void:
+	if _touch_ui != null:
+		_touch_ui.call("trigger_map_action")
+
+func _on_map_action_pressed() -> void:
+	if _map_open:
+		_close_map()
+		return
+	_try_open_map()
+
+func _try_open_map() -> bool:
+	if not _configured or _touch_ui == null or _player == null:
+		return false
+	if int(_touch_ui.get("current_mode")) != FOOT_TRAVERSAL_MODE:
+		return false
+	if bool(_touch_ui.call("is_interaction_input_locked")):
+		return false
+	if bool(_player.get("is_input_locked")):
+		return false
+	_map_open = true
+	_player.set("is_input_locked", true)
+	_touch_ui.call("set_map_modal_active", true)
+	refresh_map_presentation()
+	if _map_modal:
+		_map_modal.visible = true
+	if _map_button:
+		_map_button.text = "[ M ] CLOSE"
+	_refresh_map_button_visibility()
+	return true
+
+func _close_map() -> void:
+	if not _map_open:
+		return
+	_map_open = false
+	if _map_modal:
+		_map_modal.visible = false
+	if _touch_ui != null:
+		_touch_ui.call("set_map_modal_active", false)
+	if _player != null:
+		_player.set("is_input_locked", false)
+	if _map_button:
+		_map_button.text = "[ M ] MAP"
+	_refresh_map_button_visibility()
+
+func _on_ui_mode_changed(mode: int) -> void:
+	if mode != FOOT_TRAVERSAL_MODE and _map_open:
+		_close_map()
+	_refresh_map_button_visibility()
+
+func _refresh_map_button_visibility() -> void:
+	if _map_button == null or _touch_ui == null:
+		return
+	var on_foot := int(_touch_ui.get("current_mode")) == FOOT_TRAVERSAL_MODE
+	var gesture_locked := bool(_touch_ui.call("is_interaction_input_locked"))
+	_map_button.visible = on_foot and (_map_open or not gesture_locked)
+
+func refresh_map_presentation() -> void:
+	if _route_sheet == null:
+		return
+	var access_state := "JAMMED"
+	if _scrapper_runtime != null:
+		access_state = String(_scrapper_runtime.call("get_access_state_name"))
+	_route_sheet.call("set_route_state", is_route_surveyed(), access_state)
 
 func reset_transient_state() -> void:
 	_armed_side = TraversalSide.NONE
@@ -165,7 +308,14 @@ func reset_transient_state() -> void:
 	_travel_distance_m = 0.0
 
 func _on_replay_pressed() -> void:
+	if _map_open:
+		_close_map()
 	reset_transient_state()
+	refresh_map_presentation()
+
+func _exit_tree() -> void:
+	if _map_open:
+		_close_map()
 
 func is_route_surveyed() -> bool:
 	return _progress_store != null and bool(_progress_store.call("is_surveyed", ROUTE_ID))
@@ -178,6 +328,15 @@ func get_route_id() -> String:
 
 func get_progress_store():
 	return _progress_store
+
+func get_map_button() -> Button:
+	return _map_button
+
+func get_route_sheet() -> Control:
+	return _route_sheet
+
+func is_map_open() -> bool:
+	return _map_open
 
 func get_transient_state_name() -> String:
 	match _armed_side:

--- a/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
+++ b/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
@@ -63,7 +63,10 @@ func configure(root_controller: Node, district: Node3D, progress_store = null) -
 		return false
 	if not _scrapper_runtime.has_method("get_access_state_name"):
 		return false
-	if not _touch_ui.has_signal("map_action_pressed") or not _touch_ui.has_method("trigger_map_action") or not _touch_ui.has_method("set_map_modal_active"):
+	if not _touch_ui.has_signal("map_action_pressed") \
+		or not _touch_ui.has_method("trigger_map_action") \
+		or not _touch_ui.has_method("set_map_modal_active") \
+		or not _touch_ui.has_method("set_map_action_available"):
 		return false
 
 	_progress_store = progress_store
@@ -206,9 +209,15 @@ func _is_access_open() -> bool:
 	return _scrapper_runtime != null and String(_scrapper_runtime.call("get_access_state_name")) == "FORCED_OPEN"
 
 func _side_for_position(position: Vector3) -> int:
-	if _entry_socket != null and _horizontal_distance(position, _entry_socket.global_position) <= ENTRY_RADIUS_M:
+	var in_alley := _point_in_bounds(position, _service_alley_bounds, 0.0)
+	var in_connector := _point_in_bounds(position, _connector_bounds, 0.0)
+	if in_alley and not in_connector \
+		and _entry_socket != null \
+		and _horizontal_distance(position, _entry_socket.global_position) <= ENTRY_RADIUS_M:
 		return TraversalSide.ALLEY
-	if _connector != null and _horizontal_distance(position, _connector.global_position) <= CONNECTOR_RADIUS_M:
+	if in_connector and not in_alley \
+		and _connector != null \
+		and _horizontal_distance(position, _connector.global_position) <= CONNECTOR_RADIUS_M:
 		return TraversalSide.CONNECTOR
 	return TraversalSide.NONE
 
@@ -338,7 +347,10 @@ func _refresh_map_button_visibility() -> void:
 		return
 	var on_foot := int(_touch_ui.get("current_mode")) == FOOT_TRAVERSAL_MODE
 	var gesture_locked := bool(_touch_ui.call("is_interaction_input_locked"))
-	_map_button.visible = on_foot and (_map_open or not gesture_locked)
+	var player_locked := _player != null and bool(_player.get("is_input_locked"))
+	var map_available := _map_open or not player_locked
+	_touch_ui.call("set_map_action_available", map_available)
+	_map_button.visible = on_foot and (_map_open or (map_available and not gesture_locked))
 
 func refresh_map_presentation() -> void:
 	if _route_sheet == null:

--- a/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
+++ b/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
@@ -5,6 +5,8 @@ const SurveyedRouteProgressStoreScript = preload("res://scripts/progress/surveye
 const GearsLocalRouteSheetScript = preload("res://scripts/ui/gears_local_route_sheet.gd")
 
 const ROUTE_ID := "gears.service_alley_north_connector"
+const DISCOVERY_TEXT := "SERVICE CUT SURVEYED · ADDED TO GEARS ROUTE SHEET"
+const DISCOVERY_FEEDBACK_SECONDS := 2.5
 const MAX_SAMPLE_JUMP_M := 3.0
 const MIN_TRAVERSAL_DISTANCE_M := 12.0
 const ENTRY_RADIUS_M := 2.5
@@ -32,7 +34,9 @@ var _progress_store = null
 var _map_button: Button = null
 var _map_modal: ColorRect = null
 var _route_sheet: Control = null
+var _discovery_feedback: Label = null
 var _map_open := false
+var _discovery_feedback_generation := 0
 
 var _configured := false
 var _armed_side := TraversalSide.NONE
@@ -87,8 +91,9 @@ func configure(root_controller: Node, district: Node3D, progress_store = null) -
 	return true
 
 func _build_map_ui() -> bool:
+	var safe_area_root := _touch_ui.get_node_or_null("SafeAreaRoot") as Control
 	var right_touch := _touch_ui.get_node_or_null("SafeAreaRoot/RightTouchArea") as Control
-	if right_touch == null:
+	if safe_area_root == null or right_touch == null:
 		return false
 
 	_map_button = right_touch.get_node_or_null("MapButton") as Button
@@ -109,6 +114,28 @@ func _build_map_ui() -> bool:
 		right_touch.add_child(_map_button)
 	if not _map_button.pressed.is_connected(_on_map_button_pressed):
 		_map_button.pressed.connect(_on_map_button_pressed)
+
+	_discovery_feedback = safe_area_root.get_node_or_null("GearsRouteSurveyFeedback") as Label
+	if _discovery_feedback == null:
+		_discovery_feedback = Label.new()
+		_discovery_feedback.name = "GearsRouteSurveyFeedback"
+		_discovery_feedback.anchor_left = 0.5
+		_discovery_feedback.anchor_top = 0.0
+		_discovery_feedback.anchor_right = 0.5
+		_discovery_feedback.anchor_bottom = 0.0
+		_discovery_feedback.offset_left = -260.0
+		_discovery_feedback.offset_top = 92.0
+		_discovery_feedback.offset_right = 260.0
+		_discovery_feedback.offset_bottom = 126.0
+		_discovery_feedback.grow_horizontal = Control.GROW_DIRECTION_BOTH
+		_discovery_feedback.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		_discovery_feedback.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+		_discovery_feedback.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		_discovery_feedback.z_index = 190
+		_discovery_feedback.text = DISCOVERY_TEXT
+		_discovery_feedback.add_theme_color_override("font_color", Color(0.64, 0.94, 0.88, 1.0))
+		safe_area_root.add_child(_discovery_feedback)
+	_discovery_feedback.visible = false
 
 	_map_modal = _touch_ui.get_node_or_null("GearsRouteSheetModal") as ColorRect
 	if _map_modal == null:
@@ -234,8 +261,26 @@ func sample_player_position(position: Vector3) -> void:
 
 	if bool(_progress_store.call("mark_surveyed", ROUTE_ID)):
 		_survey_record_count += 1
+		_show_discovery_feedback()
 	reset_transient_state()
 	refresh_map_presentation()
+
+func _show_discovery_feedback() -> void:
+	if _discovery_feedback == null:
+		return
+	_discovery_feedback_generation += 1
+	var generation := _discovery_feedback_generation
+	_discovery_feedback.text = DISCOVERY_TEXT
+	_discovery_feedback.visible = true
+	get_tree().create_timer(DISCOVERY_FEEDBACK_SECONDS).timeout.connect(func():
+		if generation == _discovery_feedback_generation and _discovery_feedback != null:
+			_discovery_feedback.visible = false
+	)
+
+func _hide_discovery_feedback() -> void:
+	_discovery_feedback_generation += 1
+	if _discovery_feedback != null:
+		_discovery_feedback.visible = false
 
 func _on_map_button_pressed() -> void:
 	if _touch_ui != null:
@@ -310,10 +355,12 @@ func reset_transient_state() -> void:
 func _on_replay_pressed() -> void:
 	if _map_open:
 		_close_map()
+	_hide_discovery_feedback()
 	reset_transient_state()
 	refresh_map_presentation()
 
 func _exit_tree() -> void:
+	_hide_discovery_feedback()
 	if _map_open:
 		_close_map()
 
@@ -337,6 +384,12 @@ func get_route_sheet() -> Control:
 
 func is_map_open() -> bool:
 	return _map_open
+
+func is_discovery_feedback_visible() -> bool:
+	return _discovery_feedback != null and _discovery_feedback.visible
+
+func get_discovery_feedback_text() -> String:
+	return _discovery_feedback.text if _discovery_feedback != null else ""
 
 func get_transient_state_name() -> String:
 	match _armed_side:

--- a/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
+++ b/godot/scripts/world/gears_surveyed_service_cut_runtime.gd
@@ -124,9 +124,9 @@ func _build_map_ui() -> bool:
 		_discovery_feedback.anchor_right = 0.5
 		_discovery_feedback.anchor_bottom = 0.0
 		_discovery_feedback.offset_left = -260.0
-		_discovery_feedback.offset_top = 92.0
+		_discovery_feedback.offset_top = 142.0
 		_discovery_feedback.offset_right = 260.0
-		_discovery_feedback.offset_bottom = 126.0
+		_discovery_feedback.offset_bottom = 178.0
 		_discovery_feedback.grow_horizontal = Control.GROW_DIRECTION_BOTH
 		_discovery_feedback.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 		_discovery_feedback.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
@@ -134,6 +134,8 @@ func _build_map_ui() -> bool:
 		_discovery_feedback.z_index = 190
 		_discovery_feedback.text = DISCOVERY_TEXT
 		_discovery_feedback.add_theme_color_override("font_color", Color(0.64, 0.94, 0.88, 1.0))
+		_discovery_feedback.add_theme_color_override("font_outline_color", Color(0.01, 0.02, 0.02, 0.96))
+		_discovery_feedback.add_theme_constant_override("outline_size", 5)
 		safe_area_root.add_child(_discovery_feedback)
 	_discovery_feedback.visible = false
 

--- a/godot/tests/gears_surveyed_route_progress_store_test.gd
+++ b/godot/tests/gears_surveyed_route_progress_store_test.gd
@@ -1,0 +1,119 @@
+extends SceneTree
+
+const STORE_SCRIPT_PATH := "res://scripts/progress/surveyed_route_progress_store.gd"
+const ROUTE_ID := "gears.service_alley_north_connector"
+const TEST_PATH := "user://tests/p06_progress_store_contract.json"
+const MALFORMED_PATH := "user://tests/p06_progress_store_malformed.json"
+const NEWER_PATH := "user://tests/p06_progress_store_newer.json"
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _fail(message: String) -> void:
+	push_error("[GEARS_SURVEYED_ROUTE_PROGRESS] %s" % message)
+	_cleanup()
+	quit(1)
+
+func _cleanup() -> void:
+	for path in [TEST_PATH, MALFORMED_PATH, NEWER_PATH]:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+func _write_raw(path: String, text: String) -> bool:
+	var dir_error := DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path("user://tests"))
+	if dir_error != OK and dir_error != ERR_ALREADY_EXISTS:
+		return false
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		return false
+	file.store_string(text)
+	file.close()
+	return true
+
+func _read_raw(path: String) -> String:
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return ""
+	var text := file.get_as_text()
+	file.close()
+	return text
+
+func _run() -> void:
+	_cleanup()
+	var store_script := load(STORE_SCRIPT_PATH)
+	if store_script == null:
+		_fail("Production 06 SurveyedRouteProgressStore is absent")
+		return
+
+	var store = store_script.new()
+	if not store.has_method("configure") or not store.has_method("mark_surveyed") or not store.has_method("is_surveyed"):
+		_fail("SurveyedRouteProgressStore contract is incomplete")
+		return
+	store.call("configure", TEST_PATH)
+	if bool(store.call("is_surveyed", ROUTE_ID)):
+		_fail("Clean progress started with the route already surveyed")
+		return
+	if String(store.call("get_load_status")) != "CLEAN":
+		_fail("Clean progress did not report CLEAN load status")
+		return
+	if not bool(store.call("mark_surveyed", ROUTE_ID)):
+		_fail("First valid survey did not persist")
+		return
+	if not bool(store.call("is_surveyed", ROUTE_ID)) or int(store.call("get_write_count")) != 1:
+		_fail("First valid survey did not become known with exactly one write")
+		return
+	if bool(store.call("mark_surveyed", ROUTE_ID)) or int(store.call("get_write_count")) != 1:
+		_fail("Repeated survey duplicated durable progress")
+		return
+
+	var reloaded = store_script.new()
+	reloaded.call("configure", TEST_PATH)
+	if not bool(reloaded.call("is_surveyed", ROUTE_ID)):
+		_fail("Fresh store instance did not reload surveyed knowledge")
+		return
+	if String(reloaded.call("get_load_status")) != "LOADED":
+		_fail("Fresh store instance did not report LOADED status")
+		return
+
+	var default_store = store_script.new()
+	default_store.call("configure")
+	var default_path := String(default_store.call("get_storage_path"))
+	if default_path == "user://burnside_mapped_knowledge.json" or not default_path.begins_with("user://tests/"):
+		_fail("Automated test execution was not isolated from owner mapped knowledge")
+		return
+
+	var malformed_raw := "{ this is not valid JSON :: P06 }"
+	if not _write_raw(MALFORMED_PATH, malformed_raw):
+		_fail("Could not create malformed persistence fixture")
+		return
+	var malformed = store_script.new()
+	malformed.call("configure", MALFORMED_PATH)
+	if not bool(malformed.call("is_write_blocked")) or String(malformed.call("get_load_status")) != "MALFORMED":
+		_fail("Malformed progress did not enter fail-safe write-blocked mode")
+		return
+	if bool(malformed.call("mark_surveyed", ROUTE_ID)):
+		_fail("Malformed progress accepted a destructive write")
+		return
+	if _read_raw(MALFORMED_PATH) != malformed_raw:
+		_fail("Malformed progress bytes were silently destroyed")
+		return
+
+	var newer_raw := "{\"version\":99,\"surveyed_routes\":[\"future.route\"],\"future_field\":true}"
+	if not _write_raw(NEWER_PATH, newer_raw):
+		_fail("Could not create newer-version persistence fixture")
+		return
+	var newer = store_script.new()
+	newer.call("configure", NEWER_PATH)
+	if not bool(newer.call("is_write_blocked")) or String(newer.call("get_load_status")) != "UNSUPPORTED_VERSION":
+		_fail("Newer progress version did not enter fail-safe write-blocked mode")
+		return
+	if bool(newer.call("mark_surveyed", ROUTE_ID)):
+		_fail("Unsupported newer progress accepted a destructive write")
+		return
+	if _read_raw(NEWER_PATH) != newer_raw:
+		_fail("Unsupported newer progress bytes were silently destroyed")
+		return
+
+	print("[GEARS_SURVEYED_ROUTE_PROGRESS] PASS")
+	_cleanup()
+	quit(0)

--- a/godot/tests/gears_surveyed_route_progress_store_test.gd
+++ b/godot/tests/gears_surveyed_route_progress_store_test.gd
@@ -5,6 +5,10 @@ const ROUTE_ID := "gears.service_alley_north_connector"
 const TEST_PATH := "user://tests/p06_progress_store_contract.json"
 const MALFORMED_PATH := "user://tests/p06_progress_store_malformed.json"
 const NEWER_PATH := "user://tests/p06_progress_store_newer.json"
+const ATOMIC_DIR := "user://tests/p06_progress_store_atomic_guard"
+const ATOMIC_PATH := ATOMIC_DIR + "/mapped.json"
+const OWNER_RWX := 448
+const OWNER_RX := 320
 
 func _init() -> void:
 	call_deferred("_run")
@@ -15,20 +19,27 @@ func _fail(message: String) -> void:
 	quit(1)
 
 func _cleanup() -> void:
+	var atomic_dir_abs := ProjectSettings.globalize_path(ATOMIC_DIR)
+	if DirAccess.dir_exists_absolute(atomic_dir_abs):
+		FileAccess.set_unix_permissions(atomic_dir_abs, OWNER_RWX)
+		for atomic_file in [ATOMIC_PATH, ATOMIC_PATH + ".tmp"]:
+			if FileAccess.file_exists(atomic_file):
+				DirAccess.remove_absolute(ProjectSettings.globalize_path(atomic_file))
+		DirAccess.remove_absolute(atomic_dir_abs)
 	for path in [TEST_PATH, MALFORMED_PATH, NEWER_PATH]:
 		if FileAccess.file_exists(path):
 			DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
 
 func _write_raw(path: String, text: String) -> bool:
-	var dir_error := DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path("user://tests"))
+	var dir_error := DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(path.get_base_dir()))
 	if dir_error != OK and dir_error != ERR_ALREADY_EXISTS:
 		return false
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
 		return false
-	file.store_string(text)
+	var wrote := file.store_string(text)
 	file.close()
-	return true
+	return wrote
 
 func _read_raw(path: String) -> String:
 	var file := FileAccess.open(path, FileAccess.READ)
@@ -113,6 +124,35 @@ func _run() -> void:
 	if _read_raw(NEWER_PATH) != newer_raw:
 		_fail("Unsupported newer progress bytes were silently destroyed")
 		return
+
+	# Linux CI can make the parent directory non-writable while keeping the existing
+	# progress file writable. Direct in-place truncation would still succeed there;
+	# a durable staging+replace write must fail without touching the known-good bytes.
+	if OS.get_name() == "Linux":
+		var original_atomic_raw := "{\"version\":1,\"surveyed_routes\":[]}\n"
+		if not _write_raw(ATOMIC_PATH, original_atomic_raw):
+			_fail("Could not create atomic-write preservation fixture")
+			return
+		var atomic_store = store_script.new()
+		atomic_store.call("configure", ATOMIC_PATH)
+		if String(atomic_store.call("get_load_status")) != "LOADED":
+			_fail("Atomic-write fixture did not load as supported progress")
+			return
+		var atomic_dir_abs := ProjectSettings.globalize_path(ATOMIC_DIR)
+		if FileAccess.set_unix_permissions(atomic_dir_abs, OWNER_RX) != OK:
+			_fail("Could not make atomic-write fixture directory non-writable")
+			return
+		var accepted_failed_replace := bool(atomic_store.call("mark_surveyed", ROUTE_ID))
+		FileAccess.set_unix_permissions(atomic_dir_abs, OWNER_RWX)
+		if accepted_failed_replace:
+			_fail("Progress write mutated the live file instead of failing safely when atomic replacement was unavailable")
+			return
+		if bool(atomic_store.call("is_surveyed", ROUTE_ID)) or int(atomic_store.call("get_write_count")) != 0:
+			_fail("Failed durable write leaked surveyed state or write accounting")
+			return
+		if _read_raw(ATOMIC_PATH) != original_atomic_raw:
+			_fail("Failed durable write changed previously valid progress bytes")
+			return
 
 	print("[GEARS_SURVEYED_ROUTE_PROGRESS] PASS")
 	_cleanup()

--- a/godot/tests/gears_surveyed_route_web_probe.gd
+++ b/godot/tests/gears_surveyed_route_web_probe.gd
@@ -1,0 +1,83 @@
+extends Control
+
+const ROUTE_ID := "gears.service_alley_north_connector"
+const STORAGE_PATH := "user://p06_web_reload_probe.json"
+const WRITE_OK := "P06_WRITE_OK"
+const RELOAD_OK := "P06_RELOAD_OK"
+const FAIL := "P06_FAIL"
+const STORE_SCRIPT := preload("res://scripts/progress/surveyed_route_progress_store.gd")
+
+var _status_label: Label
+
+func _ready() -> void:
+	_status_label = Label.new()
+	_status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_status_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	_status_label.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(_status_label)
+	await _run_probe()
+
+func _run_probe() -> void:
+	if not OS.has_feature("web"):
+		_publish_raw(FAIL, {
+			"status": FAIL,
+			"reason": "NOT_WEB",
+			"route_id": ROUTE_ID,
+			"storage_path": STORAGE_PATH,
+		})
+		return
+
+	var store = STORE_SCRIPT.new()
+	store.configure(STORAGE_PATH)
+
+	if store.is_write_blocked():
+		_publish(FAIL, store, "WRITE_BLOCKED")
+		return
+
+	if store.is_surveyed(ROUTE_ID):
+		if store.get_load_status() != "LOADED":
+			_publish(FAIL, store, "SURVEYED_WITHOUT_LOADED_STATUS")
+			return
+		_publish(RELOAD_OK, store, "")
+		return
+
+	if store.get_load_status() != "CLEAN":
+		_publish(FAIL, store, "UNEXPECTED_INITIAL_LOAD_STATUS")
+		return
+
+	if not store.mark_surveyed(ROUTE_ID):
+		_publish(FAIL, store, "MARK_SURVEYED_FAILED")
+		return
+
+	if not store.is_surveyed(ROUTE_ID) or store.get_write_count() != 1:
+		_publish(FAIL, store, "WRITE_DID_NOT_COMMIT_EXPECTED_STATE")
+		return
+
+	JavaScriptBridge.force_fs_sync()
+	await get_tree().create_timer(1.0).timeout
+	_publish(WRITE_OK, store, "")
+
+func _publish(status: String, store, reason: String) -> void:
+	var payload := {
+		"status": status,
+		"reason": reason,
+		"route_id": ROUTE_ID,
+		"storage_path": store.get_storage_path(),
+		"load_status": store.get_load_status(),
+		"surveyed": store.is_surveyed(ROUTE_ID),
+		"write_count": store.get_write_count(),
+		"write_blocked": store.is_write_blocked(),
+		"userfs_persistent_hint": OS.is_userfs_persistent(),
+		"engine_version": String(Engine.get_version_info().get("string", "")),
+	}
+	_publish_raw(status, payload)
+
+func _publish_raw(status: String, payload: Dictionary) -> void:
+	_status_label.text = "%s\n%s" % [status, JSON.stringify(payload)]
+	DisplayServer.window_set_title(status)
+	if OS.has_feature("web"):
+		var script := "window.P06_WEB_PROBE = %s; document.title = %s;" % [
+			JSON.stringify(payload),
+			JSON.stringify(status),
+		]
+		JavaScriptBridge.eval(script, true)

--- a/godot/tests/gears_surveyed_route_web_probe.tscn
+++ b/godot/tests/gears_surveyed_route_web_probe.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://tests/gears_surveyed_route_web_probe.gd" id="1_probe"]
+
+[node name="P06WebPersistenceProbe" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_probe")

--- a/godot/tests/gears_surveyed_service_cut_input_test.gd
+++ b/godot/tests/gears_surveyed_service_cut_input_test.gd
@@ -1,0 +1,228 @@
+extends SceneTree
+
+const SCENE_PATH := "res://scenes/prototype/scrap_test_block.tscn"
+const AUTO_TEST_PATH := "user://tests/p06_gears_surveyed_service_cut_input_test.json"
+
+var _scene: Node = null
+var _wanted_runtime: Node = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _remove_test_progress() -> void:
+	if FileAccess.file_exists(AUTO_TEST_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(AUTO_TEST_PATH))
+
+func _finish(code: int) -> void:
+	if is_instance_valid(_scene):
+		_scene.queue_free()
+		await process_frame
+		await process_frame
+	if _wanted_runtime != null and _wanted_runtime.has_method("reset_runtime"):
+		_wanted_runtime.call("reset_runtime")
+	_remove_test_progress()
+	quit(code)
+
+func _fail(message: String) -> void:
+	push_error("[GEARS_SURVEYED_SERVICE_CUT_INPUT] %s" % message)
+	await _finish(1)
+
+func _press_m(touch_ui: Node, echo: bool = false) -> void:
+	var event := InputEventKey.new()
+	event.keycode = KEY_M
+	event.physical_keycode = KEY_M
+	event.pressed = true
+	event.echo = echo
+	touch_ui.call("_input", event)
+
+func _acquire_tool(scene: Node, player: Node3D, scrapper: Node) -> bool:
+	var pickup := scrapper.call("get_pickup") as Node3D
+	if pickup == null:
+		return false
+	player.global_position = pickup.global_position + Vector3(0.4, 0.0, 0.0)
+	pickup.call("update_player_distance", player.global_position)
+	scene.set("_active_target", pickup)
+	return bool(scrapper.call("acquire_active_pickup"))
+
+func _rect_contains_rect(outer: Rect2, inner: Rect2) -> bool:
+	return outer.has_point(inner.position) and outer.has_point(inner.position + inner.size)
+
+func _run() -> void:
+	_remove_test_progress()
+	_wanted_runtime = root.get_node_or_null("BurnsideWantedRuntime")
+	if _wanted_runtime == null:
+		await _fail("BurnsideWantedRuntime autoload is missing")
+		return
+	var packed := load(SCENE_PATH) as PackedScene
+	if packed == null:
+		await _fail("Production scene could not load")
+		return
+	_scene = packed.instantiate()
+	root.add_child(_scene)
+	await process_frame
+	await physics_frame
+	await process_frame
+	await process_frame
+	if not bool(_wanted_runtime.call("bind_to_scene", _scene)):
+		await _fail("Wanted runtime did not bind to production scene")
+		return
+
+	var touch_ui := _scene.get_node_or_null("CanvasLayer/TouchControlsUI")
+	var player := _scene.get_node_or_null("Runner") as Node3D
+	var scrapper := _scene.get_node_or_null("GearsScrapperToolRuntime")
+	var survey := _scene.get_node_or_null("GearsSurveyedServiceCutRuntime")
+	if touch_ui == null or player == null or scrapper == null:
+		await _fail("Retained input/player/P05 fixture is incomplete")
+		return
+	if survey == null:
+		await _fail("Production 06 surveyed-route runtime is absent")
+		return
+	if not touch_ui.has_signal("map_action_pressed") or not touch_ui.has_method("trigger_map_action") or not touch_ui.has_method("set_map_modal_active"):
+		await _fail("Production 06 dedicated Map input seam is absent")
+		return
+
+	var map_button := survey.call("get_map_button") as Button
+	var route_sheet := survey.call("get_route_sheet") as Control
+	var tool_button := touch_ui.get_node_or_null("SafeAreaRoot/RightTouchArea/ToolActionButton") as Button
+	if map_button == null or map_button.get_parent() == null or String(map_button.get_parent().name) != "RightTouchArea":
+		await _fail("Safe-area touch Map control is absent or mounted outside RightTouchArea")
+		return
+	if route_sheet == null or not route_sheet.has_method("is_service_cut_visible") or not route_sheet.has_method("get_access_status_text"):
+		await _fail("Bounded Gears local route sheet is absent")
+		return
+	if tool_button == null or not _acquire_tool(_scene, player, scrapper):
+		await _fail("Could not establish retained held-Tool fixture")
+		return
+	if not tool_button.visible:
+		await _fail("Held Tool Action was not available before Map ownership test")
+		return
+
+	var counts := {"action": 0, "tool": 0, "map": 0}
+	touch_ui.action_button_pressed.connect(func(): counts.action += 1)
+	touch_ui.tool_action_pressed.connect(func(): counts.tool += 1)
+	touch_ui.map_action_pressed.connect(func(): counts.map += 1)
+
+	# Real touch control toggles one modal transition and reveals no unearned route geometry.
+	map_button.pressed.emit()
+	await process_frame
+	if int(counts.map) != 1 or not bool(survey.call("is_map_open")):
+		await _fail("Touch Map did not open exactly once")
+		return
+	if not bool(player.get("is_input_locked")) or not bool(touch_ui.call("is_map_modal_active")):
+		await _fail("Map modal did not own locomotion/input")
+		return
+	if bool(route_sheet.call("is_service_cut_visible")) or String(route_sheet.call("get_access_status_text")) != "UNKNOWN ROUTE":
+		await _fail("Pre-survey route sheet exposed unearned service-cut knowledge")
+		return
+
+	# Programmatic and UI-equivalent Action/Tool paths are suppressed while the modal owns input.
+	touch_ui.call("trigger_action")
+	touch_ui.call("trigger_tool_action")
+	await process_frame
+	if int(counts.action) != 0 or int(counts.tool) != 0:
+		await _fail("Map modal leaked generic Action or Tool Action")
+		return
+	if tool_button.visible:
+		await _fail("Tool Action remained interactable through the Map modal")
+		return
+
+	map_button.pressed.emit()
+	await process_frame
+	if int(counts.map) != 2 or bool(survey.call("is_map_open")) or bool(player.get("is_input_locked")) or bool(touch_ui.call("is_map_modal_active")):
+		await _fail("Touch Map close did not restore prior input ownership exactly once")
+		return
+	if not tool_button.visible:
+		await _fail("Closing Map did not restore the held Tool Action")
+		return
+	touch_ui.call("trigger_action")
+	touch_ui.call("trigger_tool_action")
+	await process_frame
+	if int(counts.action) != 1 or int(counts.tool) != 1:
+		await _fail("Dedicated actions did not restore cleanly after Map close")
+		return
+
+	# Retained gesture ownership suppresses Map before it can emit/open.
+	var map_before_lock := int(counts.map)
+	touch_ui.call("show_gesture_overlay", "PEEL_PANEL")
+	touch_ui.call("trigger_map_action")
+	await process_frame
+	if bool(survey.call("is_map_open")) or int(counts.map) != map_before_lock:
+		await _fail("Retained gesture/input lock accepted Map")
+		return
+	touch_ui.call("close_interaction_overlay")
+
+	# A pre-existing player input lock cannot be stolen by Map.
+	player.set("is_input_locked", true)
+	touch_ui.call("trigger_map_action")
+	await process_frame
+	if bool(survey.call("is_map_open")):
+		await _fail("Map opened while another runtime owned player input")
+		return
+	player.set("is_input_locked", false)
+
+	# Vehicle mode suppresses both desktop/touch Map availability.
+	touch_ui.call("set_mode", TouchControlsUI.UIMode.VEHICLE_DRIVING)
+	var map_before_drive := int(counts.map)
+	touch_ui.call("trigger_map_action")
+	_press_m(touch_ui)
+	await process_frame
+	if bool(survey.call("is_map_open")) or int(counts.map) != map_before_drive or map_button.visible:
+		await _fail("Driving mode accepted or exposed Map")
+		return
+	touch_ui.call("set_mode", TouchControlsUI.UIMode.FOOT_TRAVERSAL)
+
+	# Desktop M toggles exactly once per non-echo press; echo cannot double-fire.
+	var map_before_desktop := int(counts.map)
+	_press_m(touch_ui)
+	await process_frame
+	if not bool(survey.call("is_map_open")) or int(counts.map) != map_before_desktop + 1:
+		await _fail("Desktop M did not open Map exactly once")
+		return
+	_press_m(touch_ui, true)
+	await process_frame
+	if not bool(survey.call("is_map_open")) or int(counts.map) != map_before_desktop + 1:
+		await _fail("Desktop key echo double-fired Map")
+		return
+	_press_m(touch_ui)
+	await process_frame
+	if bool(survey.call("is_map_open")) or int(counts.map) != map_before_desktop + 2:
+		await _fail("Desktop M did not close Map exactly once")
+		return
+
+	# Learned geography and current P05 access are separate presentation truths.
+	var store = survey.call("get_progress_store")
+	if store == null or not bool(store.call("mark_surveyed", String(survey.call("get_route_id")))):
+		await _fail("Could not establish known-route presentation fixture")
+		return
+	var writes_before_access_change := int(store.call("get_write_count"))
+	touch_ui.call("trigger_map_action")
+	await process_frame
+	if not bool(route_sheet.call("is_service_cut_visible")) or String(route_sheet.call("get_access_status_text")) != "KNOWN · ACCESS JAMMED":
+		await _fail("Surveyed + JAMMED did not present as known-but-blocked")
+		return
+	if not bool(scrapper.call("_force_access_open")):
+		await _fail("Could not force known route open for access presentation")
+		return
+	survey.call("refresh_map_presentation")
+	await process_frame
+	if String(route_sheet.call("get_access_status_text")) != "KNOWN · ACCESS OPEN":
+		await _fail("Known route did not reflect current FORCED_OPEN physical access")
+		return
+	if int(store.call("get_write_count")) != writes_before_access_change:
+		await _fail("Physical access change rewrote mapped knowledge")
+		return
+	touch_ui.call("trigger_map_action")
+	await process_frame
+
+	# Safe-area layout keeps the small Map control inside the resolved canvas-safe rectangle.
+	touch_ui.call("set_simulated_safe_area", Rect2i(100, 60, 1720, 900), Vector2i(1920, 1080))
+	await process_frame
+	await process_frame
+	var safe_rect := touch_ui.call("get_resolved_safe_rect") as Rect2
+	var button_rect := map_button.get_global_rect()
+	if not _rect_contains_rect(safe_rect, button_rect):
+		await _fail("Map control escaped the resolved mobile safe area")
+		return
+
+	print("[GEARS_SURVEYED_SERVICE_CUT_INPUT] PASS")
+	await _finish(0)

--- a/godot/tests/gears_surveyed_service_cut_input_test.gd
+++ b/godot/tests/gears_surveyed_service_cut_input_test.gd
@@ -143,14 +143,11 @@ func _run() -> void:
 		await _fail("Map modal leaked routed touch/drag into gameplay joystick ownership")
 		return
 
-	# A second routed finger can close Map without activating the still-held first finger underneath it.
-	var close_position := map_button.get_global_rect().get_center()
-	_push_touch(38, true, close_position)
-	await process_frame
-	_push_touch(38, false, close_position)
+	# Close through the proven Map control while the route-sheet-origin touch remains held.
+	map_button.pressed.emit()
 	await process_frame
 	if int(counts.map) != 2 or bool(survey.call("is_map_open")) or bool(player.get("is_input_locked")) or bool(touch_ui.call("is_map_modal_active")):
-		await _fail("Routed touch close did not restore Map ownership exactly once")
+		await _fail("Map close did not restore ownership exactly once with a modal-origin touch held")
 		return
 	_push_touch(modal_touch_index, false, Vector2(190.0, 390.0))
 	await process_frame

--- a/godot/tests/gears_surveyed_service_cut_input_test.gd
+++ b/godot/tests/gears_surveyed_service_cut_input_test.gd
@@ -47,6 +47,20 @@ func _acquire_tool(scene: Node, player: Node3D, scrapper: Node) -> bool:
 func _rect_contains_rect(outer: Rect2, inner: Rect2) -> bool:
 	return outer.has_point(inner.position) and outer.has_point(inner.position + inner.size)
 
+func _push_touch(index: int, pressed: bool, position: Vector2) -> void:
+	var event := InputEventScreenTouch.new()
+	event.index = index
+	event.pressed = pressed
+	event.position = position
+	root.push_input(event, true)
+
+func _push_drag(index: int, position: Vector2, relative: Vector2) -> void:
+	var event := InputEventScreenDrag.new()
+	event.index = index
+	event.position = position
+	event.relative = relative
+	root.push_input(event, true)
+
 func _run() -> void:
 	_remove_test_progress()
 	_wanted_runtime = root.get_node_or_null("BurnsideWantedRuntime")
@@ -79,6 +93,9 @@ func _run() -> void:
 		return
 	if not touch_ui.has_signal("map_action_pressed") or not touch_ui.has_method("trigger_map_action") or not touch_ui.has_method("set_map_modal_active"):
 		await _fail("Production 06 dedicated Map input seam is absent")
+		return
+	if not touch_ui.has_method("set_map_action_available"):
+		await _fail("Production 06 Map availability seam is absent")
 		return
 
 	var map_button := survey.call("get_map_button") as Button
@@ -115,6 +132,40 @@ func _run() -> void:
 		await _fail("Pre-survey route sheet exposed unearned service-cut knowledge")
 		return
 
+	# Actual Viewport GUI routing must keep route-sheet touches out of gameplay joystick ownership.
+	var modal_touch_index := 37
+	_push_touch(modal_touch_index, true, Vector2(140.0, 390.0))
+	await process_frame
+	_push_drag(modal_touch_index, Vector2(190.0, 390.0), Vector2(50.0, 0.0))
+	await process_frame
+	var modal_joystick: Vector2 = player.get("joystick_vector")
+	if modal_joystick.length() > 0.001 or bool(touch_ui.call("is_pointer_index_claimed", modal_touch_index)):
+		await _fail("Map modal leaked routed touch/drag into gameplay joystick ownership")
+		return
+
+	# A second routed finger can close Map without activating the still-held first finger underneath it.
+	var close_position := map_button.get_global_rect().get_center()
+	_push_touch(38, true, close_position)
+	await process_frame
+	_push_touch(38, false, close_position)
+	await process_frame
+	if int(counts.map) != 2 or bool(survey.call("is_map_open")) or bool(player.get("is_input_locked")) or bool(touch_ui.call("is_map_modal_active")):
+		await _fail("Routed touch close did not restore Map ownership exactly once")
+		return
+	_push_touch(modal_touch_index, false, Vector2(190.0, 390.0))
+	await process_frame
+	var released_modal_joystick: Vector2 = player.get("joystick_vector")
+	if released_modal_joystick.length() > 0.001:
+		await _fail("Map close exposed stale joystick input from a touch that began on the modal")
+		return
+
+	# Reopen for method-level Action/Tool suppression checks.
+	map_button.pressed.emit()
+	await process_frame
+	if int(counts.map) != 3 or not bool(survey.call("is_map_open")):
+		await _fail("Map did not reopen after routed touch ownership proof")
+		return
+
 	# Programmatic and UI-equivalent Action/Tool paths are suppressed while the modal owns input.
 	touch_ui.call("trigger_action")
 	touch_ui.call("trigger_tool_action")
@@ -128,7 +179,7 @@ func _run() -> void:
 
 	map_button.pressed.emit()
 	await process_frame
-	if int(counts.map) != 2 or bool(survey.call("is_map_open")) or bool(player.get("is_input_locked")) or bool(touch_ui.call("is_map_modal_active")):
+	if int(counts.map) != 4 or bool(survey.call("is_map_open")) or bool(player.get("is_input_locked")) or bool(touch_ui.call("is_map_modal_active")):
 		await _fail("Touch Map close did not restore prior input ownership exactly once")
 		return
 	if not tool_button.visible:
@@ -151,14 +202,20 @@ func _run() -> void:
 		return
 	touch_ui.call("close_interaction_overlay")
 
-	# A pre-existing player input lock cannot be stolen by Map.
+	# A pre-existing player input lock makes Map unavailable rather than merely rejecting it downstream.
 	player.set("is_input_locked", true)
+	await process_frame
+	var map_before_player_lock := int(counts.map)
 	touch_ui.call("trigger_map_action")
 	await process_frame
-	if bool(survey.call("is_map_open")):
-		await _fail("Map opened while another runtime owned player input")
+	if bool(survey.call("is_map_open")) or int(counts.map) != map_before_player_lock or map_button.visible:
+		await _fail("Map remained available while another runtime owned player input")
 		return
 	player.set("is_input_locked", false)
+	await process_frame
+	if not map_button.visible:
+		await _fail("Map did not become available again after external player input ownership cleared")
+		return
 
 	# Vehicle mode suppresses both desktop/touch Map availability.
 	touch_ui.call("set_mode", TouchControlsUI.UIMode.VEHICLE_DRIVING)
@@ -170,6 +227,7 @@ func _run() -> void:
 		await _fail("Driving mode accepted or exposed Map")
 		return
 	touch_ui.call("set_mode", TouchControlsUI.UIMode.FOOT_TRAVERSAL)
+	await process_frame
 
 	# Desktop M toggles exactly once per non-echo press; echo cannot double-fire.
 	var map_before_desktop := int(counts.map)

--- a/godot/tests/gears_surveyed_service_cut_render_capture.gd
+++ b/godot/tests/gears_surveyed_service_cut_render_capture.gd
@@ -1,0 +1,263 @@
+extends SceneTree
+
+const OUTPUT_DIR := "res://verification/production06"
+const SCENE_PATH := "res://scenes/prototype/scrap_test_block.tscn"
+const ROUTE_ID := "gears.service_alley_north_connector"
+const TEST_STORAGE := "user://tests/p06_gears_surveyed_service_cut_render_capture.json"
+
+var _scene: Node3D = null
+var _wanted_runtime: Node = null
+var _district: Node3D = null
+var _player: Node3D = null
+var _camera: Camera3D = null
+var _scrapper: Node = null
+var _survey: Node = null
+var _touch_ui: Node = null
+var _route_sheet: Control = null
+var _captures: Array[Dictionary] = []
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _remove_test_progress() -> void:
+	if FileAccess.file_exists(TEST_STORAGE):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(TEST_STORAGE))
+
+func _fail(message: String) -> void:
+	push_error("[GEARS_SURVEYED_SERVICE_CUT_RENDER] %s" % message)
+	_remove_test_progress()
+	quit(1)
+
+func _open_map() -> bool:
+	_touch_ui.call("trigger_map_action")
+	await process_frame
+	return bool(_survey.call("is_map_open"))
+
+func _close_map() -> void:
+	if bool(_survey.call("is_map_open")):
+		_touch_ui.call("trigger_map_action")
+		await process_frame
+
+func _sample_legitimate_route(entry: Vector3, connector_end: Vector3) -> void:
+	var y := _player.global_position.y
+	var continuous := [
+		entry,
+		Vector3(-10.0, y, -28.5),
+		Vector3(-10.0, y, -31.0),
+		Vector3(-10.0, y, -33.5),
+		Vector3(-10.0, y, -36.0),
+		Vector3(-10.0, y, -38.5),
+		Vector3(-10.0, y, -41.0),
+		Vector3(-10.0, y, -43.3),
+		Vector3(-9.2, y, -44.5),
+		connector_end,
+	]
+	for position in continuous:
+		_survey.call("sample_player_position", position)
+
+func _run() -> void:
+	_remove_test_progress()
+	var output_abs := ProjectSettings.globalize_path(OUTPUT_DIR)
+	var dir_error := DirAccess.make_dir_recursive_absolute(output_abs)
+	if dir_error != OK and dir_error != ERR_ALREADY_EXISTS:
+		_fail("Could not create output directory: %s" % dir_error)
+		return
+
+	_wanted_runtime = root.get_node_or_null("BurnsideWantedRuntime")
+	if _wanted_runtime == null:
+		_fail("BurnsideWantedRuntime autoload is missing")
+		return
+
+	var packed := load(SCENE_PATH) as PackedScene
+	if packed == null:
+		_fail("Could not load real playable scene")
+		return
+	_scene = packed.instantiate() as Node3D
+	if _scene == null:
+		_fail("Could not instantiate real playable scene")
+		return
+	root.add_child(_scene)
+	await process_frame
+	await physics_frame
+	await process_frame
+	if not bool(_wanted_runtime.call("bind_to_scene", _scene)):
+		_fail("Wanted runtime did not bind to real playable scene")
+		return
+	await process_frame
+
+	_district = _scene.get_node_or_null("GearsDistrictSlice01B") as Node3D
+	_player = _scene.get_node_or_null("Runner") as Node3D
+	_camera = _scene.get_node_or_null("ChinatownCamera3D") as Camera3D
+	_scrapper = _scene.get_node_or_null("GearsScrapperToolRuntime")
+	_survey = _scene.get_node_or_null("GearsSurveyedServiceCutRuntime")
+	_touch_ui = _scene.get_node_or_null("CanvasLayer/TouchControlsUI")
+	if _district == null or _player == null or _camera == null or _scrapper == null or _survey == null or _touch_ui == null:
+		_fail("Rendered proof is missing a production dependency")
+		return
+	_route_sheet = _survey.call("get_route_sheet") as Control
+	if _route_sheet == null:
+		_fail("Rendered proof could not resolve the P06 route sheet")
+		return
+	_survey.set_physics_process(false)
+
+	var store = _survey.call("get_progress_store")
+	if store == null or String(store.call("get_storage_path")) != TEST_STORAGE:
+		_fail("Rendered proof did not use isolated deterministic storage")
+		return
+	if bool(_survey.call("is_route_surveyed")):
+		_fail("Rendered proof did not begin clean")
+		return
+
+	var entry_socket := _district.get_node_or_null("ServiceAlleyEntrySocket") as Node3D
+	var connector := _district.get_node_or_null("NorthConnector") as Node3D
+	if entry_socket == null or connector == null:
+		_fail("Retained ServiceAlley/NorthConnector geometry is missing")
+		return
+	var entry := Vector3(entry_socket.global_position.x, _player.global_position.y, entry_socket.global_position.z)
+	var connector_end := Vector3(connector.global_position.x - 1.0, _player.global_position.y, connector.global_position.z)
+
+	# 1. Before learning, the ordinary Gears street context can be mapped but the cut is absent.
+	if not await _open_map():
+		_fail("Could not open pre-survey route sheet")
+		return
+	if bool(_route_sheet.call("is_service_cut_visible")) or String(_route_sheet.call("get_access_status_text")) != "UNKNOWN ROUTE":
+		_fail("Pre-survey route sheet exposed unearned geography")
+		return
+	var capture_error := await _capture("01_pre_survey_route_sheet.png", "PRE_SURVEY_UNKNOWN")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+	await _close_map()
+
+	# 2. P05 can physically open the cut without granting P06 knowledge.
+	if not bool(_scrapper.call("_force_access_open")) or String(_scrapper.call("get_access_state_name")) != "FORCED_OPEN":
+		_fail("Could not force retained P05 service access open")
+		return
+	if bool(_survey.call("is_route_surveyed")):
+		_fail("Force-open alone incorrectly granted mapped knowledge")
+		return
+	_player.global_position = entry + Vector3(0.0, 0.0, 1.5)
+	_camera.call("reset_camera_instant", _player)
+	capture_error = await _capture("02_open_unsurveyed_service_cut.png", "OPEN_UNSURVEYED")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+
+	# 3. Only a legitimate continuous crossing establishes the durable route fact.
+	_survey.call("reset_transient_state")
+	_sample_legitimate_route(entry, connector_end)
+	_player.global_position = connector_end
+	_camera.call("reset_camera_instant", _player)
+	if not bool(_survey.call("is_route_surveyed")) or int(_survey.call("get_survey_record_count")) != 1:
+		_fail("Legitimate crossing did not establish exactly one surveyed route")
+		return
+	if not bool(_survey.call("is_discovery_feedback_visible")) or not String(_survey.call("get_discovery_feedback_text")).contains("SERVICE CUT SURVEYED"):
+		_fail("First discovery confirmation is not visible in the rendered state")
+		return
+	capture_error = await _capture("03_first_crossing_learned.png", "FIRST_CROSSING_LEARNED")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+
+	# 4. The newly learned route appears accurately while current access is still open.
+	if not await _open_map():
+		_fail("Could not open post-survey route sheet")
+		return
+	if not bool(_route_sheet.call("is_service_cut_visible")) or String(_route_sheet.call("get_access_status_text")) != "KNOWN · ACCESS OPEN":
+		_fail("Post-survey route sheet did not show learned/open service cut")
+		return
+	capture_error = await _capture("04_post_survey_route_sheet.png", "KNOWN_OPEN")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+	await _close_map()
+
+	# 5. Replay resets physical P05 access to JAMMED but must not erase mapped knowledge.
+	_touch_ui.replay_pressed.emit()
+	await process_frame
+	await physics_frame
+	await physics_frame
+	if not bool(_survey.call("is_route_surveyed")) or String(_scrapper.call("get_access_state_name")) != "JAMMED":
+		_fail("Replay did not preserve known geography while restoring JAMMED access")
+		return
+	if not await _open_map():
+		_fail("Could not open learned + jammed route sheet after Replay")
+		return
+	if not bool(_route_sheet.call("is_service_cut_visible")) or String(_route_sheet.call("get_access_status_text")) != "KNOWN · ACCESS JAMMED":
+		_fail("Replay route sheet is not truthful about known-but-blocked state")
+		return
+	capture_error = await _capture("05_replay_known_jammed.png", "KNOWN_JAMMED")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+	await _close_map()
+
+	# 6. Reopening the known route changes physical truth only; knowledge remains one durable fact.
+	var writes_before_reopen := int(store.call("get_write_count"))
+	if not bool(_scrapper.call("_force_access_open")):
+		_fail("Could not reopen learned service cut")
+		return
+	_survey.call("refresh_map_presentation")
+	if int(store.call("get_write_count")) != writes_before_reopen:
+		_fail("Reopening learned access rewrote mapped knowledge")
+		return
+	if not await _open_map():
+		_fail("Could not open reopened known route sheet")
+		return
+	if String(_route_sheet.call("get_access_status_text")) != "KNOWN · ACCESS OPEN":
+		_fail("Reopened learned route did not report current usable access")
+		return
+	capture_error = await _capture("06_reopened_known_route.png", "KNOWN_REOPENED")
+	if not capture_error.is_empty():
+		_fail(capture_error)
+		return
+	await _close_map()
+
+	var report := {
+		"schema_version": 1,
+		"source_sha": OS.get_environment("SOURCE_SHA"),
+		"godot_version": Engine.get_version_info().get("string", "unknown"),
+		"display_server": DisplayServer.get_name(),
+		"renderer": RenderingServer.get_video_adapter_name(),
+		"real_playable_scene": true,
+		"route_id": ROUTE_ID,
+		"storage_path": String(store.call("get_storage_path")),
+		"survey_record_count": int(_survey.call("get_survey_record_count")),
+		"captures": _captures,
+	}
+	var report_file := FileAccess.open(OUTPUT_DIR + "/render_report.json", FileAccess.WRITE)
+	if report_file == null:
+		_fail("Could not write Production 06 rendered verification report")
+		return
+	report_file.store_string(JSON.stringify(report, "\t"))
+	report_file.close()
+
+	print("[GEARS_SURVEYED_SERVICE_CUT_RENDER] PASS: %s" % OUTPUT_DIR)
+	_scene.queue_free()
+	await process_frame
+	_remove_test_progress()
+	quit(0)
+
+func _capture(file_name: String, expected_state: String) -> String:
+	await process_frame
+	await process_frame
+	var image: Image = root.get_texture().get_image()
+	if image == null or image.is_empty():
+		return "Rendered viewport is empty for %s" % file_name
+	var path := OUTPUT_DIR + "/" + file_name
+	var save_error: Error = image.save_png(path)
+	if save_error != OK:
+		return "Could not save %s: %s" % [file_name, save_error]
+	_captures.append({
+		"file": file_name,
+		"state": expected_state,
+		"surveyed": bool(_survey.call("is_route_surveyed")),
+		"p05_access": String(_scrapper.call("get_access_state_name")),
+		"map_open": bool(_survey.call("is_map_open")),
+		"route_visible": bool(_route_sheet.call("is_service_cut_visible")),
+		"route_status": String(_route_sheet.call("get_access_status_text")),
+		"discovery_feedback_visible": bool(_survey.call("is_discovery_feedback_visible")),
+		"discovery_feedback_text": String(_survey.call("get_discovery_feedback_text")),
+		"player_position": [_player.global_position.x, _player.global_position.y, _player.global_position.z],
+	})
+	return ""

--- a/godot/tests/gears_surveyed_service_cut_test.gd
+++ b/godot/tests/gears_surveyed_service_cut_test.gd
@@ -109,9 +109,9 @@ func _run() -> void:
 		await _fail("Discontinuous teleport/test placement surveyed the route")
 		return
 
-	# Continuous legitimate travel through the authored alley qualifies exactly once.
+	# Continuous travel reaching only the overlapping authored join is not yet the opposite exclusive side.
 	survey.call("reset_transient_state")
-	var continuous := [
+	var continuous_to_overlap := [
 		entry,
 		Vector3(-10.0, player.global_position.y, -28.5),
 		Vector3(-10.0, player.global_position.y, -31.0),
@@ -121,9 +121,16 @@ func _run() -> void:
 		Vector3(-10.0, player.global_position.y, -41.0),
 		Vector3(-10.0, player.global_position.y, -43.3),
 		Vector3(-9.2, player.global_position.y, -44.5),
-		connector_end,
 	]
-	_sample_path(survey, continuous)
+	_sample_path(survey, continuous_to_overlap)
+	if bool(survey.call("is_route_surveyed")):
+		await _fail("Overlapping ServiceAlley/NorthConnector join counted as the opposite exclusive side")
+		return
+
+	# Reaching the real opposite exclusive connector side completes the legitimate traversal exactly once.
+	survey.call("sample_player_position", connector_end)
+	var continuous := continuous_to_overlap.duplicate()
+	continuous.append(connector_end)
 	if not bool(survey.call("is_route_surveyed")):
 		await _fail("Legitimate continuous traversal did not survey the route")
 		return
@@ -168,6 +175,28 @@ func _run() -> void:
 		return
 	if not bool(survey.call("is_route_surveyed")) or int(store.call("get_write_count")) != writes_before_reopen:
 		await _fail("Reopening known access rewrote or lost mapped knowledge")
+		return
+
+	# Re-arm clean progress and prove the production _physics_process sampling path, not just the deterministic seam.
+	_remove_test_progress()
+	store.call("configure", AUTO_TEST_PATH)
+	survey.call("reset_transient_state")
+	touch_ui.replay_pressed.emit()
+	await process_frame
+	await physics_frame
+	if String(scrapper.call("get_access_state_name")) != "JAMMED" or bool(survey.call("is_route_surveyed")):
+		await _fail("Could not establish clean live-physics traversal fixture")
+		return
+	if not bool(scrapper.call("_force_access_open")):
+		await _fail("Could not open live-physics traversal fixture")
+		return
+	survey.set_physics_process(true)
+	for position in continuous:
+		player.global_position = position
+		await physics_frame
+	survey.set_physics_process(false)
+	if not bool(survey.call("is_route_surveyed")) or int(store.call("get_write_count")) != 1:
+		await _fail("Production physics sampling did not record a real Runner traversal")
 		return
 
 	print("[GEARS_SURVEYED_SERVICE_CUT] PASS")

--- a/godot/tests/gears_surveyed_service_cut_test.gd
+++ b/godot/tests/gears_surveyed_service_cut_test.gd
@@ -28,9 +28,10 @@ func _fail(message: String) -> void:
 	push_error("[GEARS_SURVEYED_SERVICE_CUT] %s" % message)
 	await _finish(1)
 
-func _sample_path(survey: Node, positions: Array[Vector3]) -> void:
+func _sample_path(survey: Node, positions: Array) -> void:
 	for position in positions:
-		survey.call("sample_player_position", position)
+		if position is Vector3:
+			survey.call("sample_player_position", position)
 
 func _run() -> void:
 	_remove_test_progress()

--- a/godot/tests/gears_surveyed_service_cut_test.gd
+++ b/godot/tests/gears_surveyed_service_cut_test.gd
@@ -130,6 +130,12 @@ func _run() -> void:
 	if int(survey.call("get_survey_record_count")) != 1 or int(store.call("get_write_count")) != 1:
 		await _fail("First legitimate traversal was not recorded exactly once")
 		return
+	if not survey.has_method("is_discovery_feedback_visible") or not survey.has_method("get_discovery_feedback_text"):
+		await _fail("First survey has no bounded player-facing discovery feedback seam")
+		return
+	if not bool(survey.call("is_discovery_feedback_visible")) or not String(survey.call("get_discovery_feedback_text")).contains("SERVICE CUT SURVEYED"):
+		await _fail("First legitimate traversal did not present readable learned-route confirmation")
+		return
 
 	# Repeated traversal cannot duplicate progression.
 	var reverse := continuous.duplicate()

--- a/godot/tests/gears_surveyed_service_cut_test.gd
+++ b/godot/tests/gears_surveyed_service_cut_test.gd
@@ -1,0 +1,167 @@
+extends SceneTree
+
+const SCENE_PATH := "res://scenes/prototype/scrap_test_block.tscn"
+const ROUTE_ID := "gears.service_alley_north_connector"
+const AUTO_TEST_PATH := "user://tests/p06_gears_surveyed_service_cut_test.json"
+
+var _scene: Node = null
+var _wanted_runtime: Node = null
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _remove_test_progress() -> void:
+	if FileAccess.file_exists(AUTO_TEST_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(AUTO_TEST_PATH))
+
+func _finish(code: int) -> void:
+	if is_instance_valid(_scene):
+		_scene.queue_free()
+		await process_frame
+		await process_frame
+	if _wanted_runtime != null and _wanted_runtime.has_method("reset_runtime"):
+		_wanted_runtime.call("reset_runtime")
+	_remove_test_progress()
+	quit(code)
+
+func _fail(message: String) -> void:
+	push_error("[GEARS_SURVEYED_SERVICE_CUT] %s" % message)
+	await _finish(1)
+
+func _sample_path(survey: Node, positions: Array[Vector3]) -> void:
+	for position in positions:
+		survey.call("sample_player_position", position)
+
+func _run() -> void:
+	_remove_test_progress()
+	_wanted_runtime = root.get_node_or_null("BurnsideWantedRuntime")
+	if _wanted_runtime == null:
+		await _fail("BurnsideWantedRuntime autoload is missing")
+		return
+	var packed := load(SCENE_PATH) as PackedScene
+	if packed == null:
+		await _fail("Production scene could not load")
+		return
+	_scene = packed.instantiate()
+	root.add_child(_scene)
+	await process_frame
+	await physics_frame
+	await process_frame
+	await process_frame
+	if not bool(_wanted_runtime.call("bind_to_scene", _scene)):
+		await _fail("Wanted runtime did not bind to production scene")
+		return
+
+	var district := _scene.get_node_or_null("GearsDistrictSlice01B") as Node3D
+	var player := _scene.get_node_or_null("Runner") as Node3D
+	var scrapper := _scene.get_node_or_null("GearsScrapperToolRuntime")
+	var survey := _scene.get_node_or_null("GearsSurveyedServiceCutRuntime")
+	var touch_ui := _scene.get_node_or_null("CanvasLayer/TouchControlsUI")
+	if district == null or player == null or scrapper == null or touch_ui == null:
+		await _fail("Retained P05 route/input fixture is incomplete")
+		return
+	if survey == null:
+		await _fail("Production 06 GearsSurveyedServiceCutRuntime is absent")
+		return
+	if not survey.has_method("sample_player_position") or not survey.has_method("is_route_surveyed"):
+		await _fail("Production 06 traversal seam is incomplete")
+		return
+	survey.set_physics_process(false)
+
+	var store = survey.call("get_progress_store")
+	if store == null or String(store.call("get_storage_path")) != AUTO_TEST_PATH:
+		await _fail("Production scene did not use isolated deterministic P06 test storage")
+		return
+	if String(survey.call("get_route_id")) != ROUTE_ID or bool(survey.call("is_route_surveyed")):
+		await _fail("Clean runtime did not begin with the stable route unknown")
+		return
+
+	var entry_socket := district.get_node_or_null("ServiceAlleyEntrySocket") as Node3D
+	var connector := district.get_node_or_null("NorthConnector") as Node3D
+	if entry_socket == null or connector == null:
+		await _fail("Retained ServiceAlley/NorthConnector geometry is missing")
+		return
+	var entry := Vector3(entry_socket.global_position.x, player.global_position.y, entry_socket.global_position.z)
+	var connector_end := Vector3(connector.global_position.x - 1.0, player.global_position.y, connector.global_position.z)
+
+	# Observation/placement at the route cannot survey while physical access is jammed.
+	survey.call("sample_player_position", entry)
+	survey.call("sample_player_position", entry + Vector3(0.0, 0.0, -1.0))
+	if bool(survey.call("is_route_surveyed")):
+		await _fail("Observing/standing at the service cut surveyed it")
+		return
+
+	# P05 remains the only access owner. Forcing it open alone must not grant knowledge.
+	if not bool(scrapper.call("_force_access_open")) or String(scrapper.call("get_access_state_name")) != "FORCED_OPEN":
+		await _fail("Retained P05 service access could not be forced open")
+		return
+	await physics_frame
+	if bool(survey.call("is_route_surveyed")):
+		await _fail("Forcing JAMMED -> FORCED_OPEN alone surveyed the route")
+		return
+
+	# Direct relocation between endpoints is a rejected discontinuity, not discovery.
+	survey.call("reset_transient_state")
+	survey.call("sample_player_position", entry)
+	survey.call("sample_player_position", connector_end)
+	if bool(survey.call("is_route_surveyed")):
+		await _fail("Discontinuous teleport/test placement surveyed the route")
+		return
+
+	# Continuous legitimate travel through the authored alley qualifies exactly once.
+	survey.call("reset_transient_state")
+	var continuous := [
+		entry,
+		Vector3(-10.0, player.global_position.y, -28.5),
+		Vector3(-10.0, player.global_position.y, -31.0),
+		Vector3(-10.0, player.global_position.y, -33.5),
+		Vector3(-10.0, player.global_position.y, -36.0),
+		Vector3(-10.0, player.global_position.y, -38.5),
+		Vector3(-10.0, player.global_position.y, -41.0),
+		Vector3(-10.0, player.global_position.y, -43.3),
+		Vector3(-9.2, player.global_position.y, -44.5),
+		connector_end,
+	]
+	_sample_path(survey, continuous)
+	if not bool(survey.call("is_route_surveyed")):
+		await _fail("Legitimate continuous traversal did not survey the route")
+		return
+	if int(survey.call("get_survey_record_count")) != 1 or int(store.call("get_write_count")) != 1:
+		await _fail("First legitimate traversal was not recorded exactly once")
+		return
+
+	# Repeated traversal cannot duplicate progression.
+	var reverse := continuous.duplicate()
+	reverse.reverse()
+	_sample_path(survey, reverse)
+	_sample_path(survey, continuous)
+	if int(survey.call("get_survey_record_count")) != 1 or int(store.call("get_write_count")) != 1:
+		await _fail("Repeated crossings duplicated mapped progress")
+		return
+
+	# Full Replay restores P05 physical JAMMED access but preserves P06 Durable Mapped Knowledge.
+	touch_ui.replay_pressed.emit()
+	await process_frame
+	await physics_frame
+	await physics_frame
+	if not bool(survey.call("is_route_surveyed")):
+		await _fail("Replay erased surveyed mapped knowledge")
+		return
+	if String(scrapper.call("get_access_state_name")) != "JAMMED" or not bool(scrapper.call("is_service_access_blocking")):
+		await _fail("Replay did not restore retained P05 physical JAMMED access")
+		return
+	if String(survey.call("get_transient_state_name")) != "IDLE":
+		await _fail("Replay left stale P06 traversal qualification state")
+		return
+
+	# Knowledge is independent from physical access: reopening changes access only.
+	var writes_before_reopen := int(store.call("get_write_count"))
+	if not bool(scrapper.call("_force_access_open")):
+		await _fail("Known route could not reuse retained P05 force-open behavior")
+		return
+	if not bool(survey.call("is_route_surveyed")) or int(store.call("get_write_count")) != writes_before_reopen:
+		await _fail("Reopening known access rewrote or lost mapped knowledge")
+		return
+
+	print("[GEARS_SURVEYED_SERVICE_CUT] PASS")
+	await _finish(0)


### PR DESCRIPTION
Implements issue #134 against `main@cd4cdbe3180c6a372ffa1cfb1cd69bdfaf256961`.

Core contract:
- legitimate traversal of `ServiceAlley <-> NorthConnector` records durable mapped knowledge;
- Replay preserves learned geography while P05 physical access resets to `JAMMED`;
- learned route and current physical accessibility remain independent truths;
- bounded Gears local route sheet only; no generalized GPS/minimap/navigation;
- no unrelated Audio/canon authority changes.

Review repairs added after frozen-candidate audit:
- require authored exclusive endpoint-side arrival before survey completion;
- make Map unavailable while another runtime owns Runner input;
- prove actual production `_physics_process` Runner traversal;
- prove Viewport-routed map-modal touch/drag does not claim gameplay joystick ownership;
- persist mapped knowledge through checked staging + atomic replacement, preserving the existing valid file on failure.

Current exact head: `1b5c3dfc89e9e95d66ec24a935926ad534ef2e51`.

Do not merge until exact-head, synthetic-merge, production-Web, and final review gates are green.