### PR TITLE
refactor(p08): address standards and spec review findings

### DIFF
--- a/.github/workflows/burnside-production-08.yml
+++ b/.github/workflows/burnside-production-08.yml
@@ -117,7 +117,8 @@ jobs:
             03_bike_dismount_release.png \
             04_scrap_hauler_docked.png \
             05_hard_rejoin_physical_return.png \
-            06_thrum_body_reaction.png; do
+            06_thrum_body_reaction.png \
+            07_mobile_viewport_framing.png; do
             test -s "godot/verification/production08/$image"
           done
           test -s godot/verification/production08/companion_presence_report.json
@@ -193,6 +194,8 @@ jobs:
             civic_repossession_wanted_composition_test.gd
             field_hacking_report_suppression_test.gd
             wanted_heat1_scene_test.gd
+            camera_mount_transition_test.gd
+            dynamic_camera_follow_test.gd
           )
           for test_file in "${tests[@]}"; do
             echo "::group::$test_file"

--- a/godot/scripts/entities/fb13_companion_body.gd
+++ b/godot/scripts/entities/fb13_companion_body.gd
@@ -45,12 +45,12 @@ var _dock_timer: float = 0.0
 
 var _sphere_shape: SphereShape3D = null
 var _shape_query: PhysicsShapeQueryParameters3D = null
+var _dock_start_transform: Transform3D = Transform3D.IDENTITY
+var _eye_mat: StandardMaterial3D = null
+var _default_emission_energy: float = 2.0
 
 @onready var _visual_root: Node3D = get_node_or_null("VisualRoot")
 @onready var _eye_mesh: MeshInstance3D = get_node_or_null("VisualRoot/Eye")
-
-var _eye_mat: StandardMaterial3D = null
-var _default_emission_energy: float = 2.0
 
 func _init() -> void:
 	_sphere_shape = SphereShape3D.new()
@@ -124,6 +124,7 @@ func begin_dock(socket: Node3D, docking_state: PresenceState, docked_state: Pres
 	_velocity = Vector3.ZERO
 	if socket != null:
 		reparent(socket, true)
+	_dock_start_transform = transform
 
 func release_from_dock(world_origin: Vector3) -> void:
 	_dock_socket = null
@@ -131,14 +132,7 @@ func release_from_dock(world_origin: Vector3) -> void:
 	global_position = world_origin
 	_velocity = Vector3.ZERO
 	_separation_timer = 0.0
-	if _runner and is_instance_valid(_runner):
-		var dist := global_position.distance_to(_runner.global_position)
-		if dist >= REJOIN_COMPLETE_DISTANCE_M:
-			current_state = PresenceState.REJOINING
-		else:
-			current_state = PresenceState.FOLLOWING
-	else:
-		current_state = PresenceState.FOLLOWING
+	current_state = PresenceState.FOLLOWING
 
 func tick_presence(delta: float) -> void:
 	_update_thrum_reaction(delta)
@@ -156,7 +150,7 @@ func tick_presence(delta: float) -> void:
 func _tick_docking(delta: float) -> void:
 	_dock_timer += delta
 	var t := clampf(_dock_timer / DOCK_INTERPOLATION_DURATION, 0.0, 1.0)
-	transform = transform.interpolate_with(Transform3D.IDENTITY, t)
+	transform = _dock_start_transform.interpolate_with(Transform3D.IDENTITY, t)
 	if t >= 1.0:
 		transform = Transform3D.IDENTITY
 		current_state = _dock_target_state
@@ -246,15 +240,16 @@ func _select_follow_target() -> Vector3:
 
 	return global_position
 
-func _compute_preferred_follow_target() -> Vector3:
+func _compute_follow_target(lateral_sign: float = 1.0) -> Vector3:
 	var fwd := _get_runner_forward()
 	var right := _get_runner_right()
-	return _runner.global_position - fwd * FOLLOW_TRAIL_M + right * FOLLOW_SIDE_M + Vector3.UP * FOLLOW_HEIGHT_M
+	return _runner.global_position - fwd * FOLLOW_TRAIL_M + right * (FOLLOW_SIDE_M * lateral_sign) + Vector3.UP * FOLLOW_HEIGHT_M
+
+func _compute_preferred_follow_target() -> Vector3:
+	return _compute_follow_target(1.0)
 
 func _compute_alternate_follow_target() -> Vector3:
-	var fwd := _get_runner_forward()
-	var right := _get_runner_right()
-	return _runner.global_position - fwd * FOLLOW_TRAIL_M - right * FOLLOW_SIDE_M + Vector3.UP * FOLLOW_HEIGHT_M
+	return _compute_follow_target(-1.0)
 
 func _get_runner_forward() -> Vector3:
 	if _runner == null or not is_instance_valid(_runner):
@@ -324,6 +319,18 @@ func _is_staging_candidate_clear(candidate_pos: Vector3) -> bool:
 		return true
 
 	var exclusions := _get_collision_exclusions()
+	if _runner != null:
+		var ray := PhysicsRayQueryParameters3D.create(
+			_runner.global_position + Vector3.UP * FOLLOW_HEIGHT_M,
+			candidate_pos
+		)
+		ray.collide_with_areas = false
+		ray.collide_with_bodies = true
+		ray.exclude = exclusions
+		var ray_hit := space_state.intersect_ray(ray)
+		if not ray_hit.is_empty():
+			return false
+
 	if _shape_query != null:
 		_shape_query.transform = Transform3D(Basis.IDENTITY, candidate_pos)
 		_shape_query.exclude = exclusions
@@ -343,14 +350,7 @@ func _is_point_off_screen(world_pos: Vector3) -> bool:
 		return false
 	var screen_pos: Vector2 = _camera.unproject_position(world_pos)
 	var vp_rect: Rect2 = viewport.get_visible_rect()
-	var margin := 8.0
-	var safe_rect := Rect2(
-		vp_rect.position.x + margin,
-		vp_rect.position.y + margin,
-		vp_rect.size.x - margin * 2.0,
-		vp_rect.size.y - margin * 2.0
-	)
-	return not safe_rect.has_point(screen_pos)
+	return not vp_rect.has_point(screen_pos)
 
 func _try_hard_rejoin() -> bool:
 	if _camera == null or not is_instance_valid(_camera):

--- a/godot/scripts/entities/fb13_companion_body.gd
+++ b/godot/scripts/entities/fb13_companion_body.gd
@@ -62,7 +62,7 @@ func _init() -> void:
 
 func _ready() -> void:
 	if _eye_mesh:
-		var mat = _eye_mesh.get_surface_override_material(0)
+		var mat: Material = _eye_mesh.get_surface_override_material(0)
 		if mat == null and _eye_mesh.mesh and _eye_mesh.mesh.material:
 			mat = _eye_mesh.mesh.material
 		if mat is StandardMaterial3D:
@@ -255,20 +255,20 @@ func _get_runner_forward() -> Vector3:
 	if _runner == null or not is_instance_valid(_runner):
 		return Vector3(0, 0, -1)
 	var pivot := _runner.get_node_or_null("MeshPivot") as Node3D
-	var b := pivot.global_transform.basis if pivot else _runner.global_transform.basis
-	var fwd := Vector3(-b.z.x, 0.0, -b.z.z)
-	if fwd.length_squared() > 0.001:
-		return fwd.normalized()
+	var runner_basis: Basis = pivot.global_transform.basis if pivot else _runner.global_transform.basis
+	var fwd_dir := Vector3(-runner_basis.z.x, 0.0, -runner_basis.z.z)
+	if fwd_dir.length_squared() > 0.001:
+		return fwd_dir.normalized()
 	return Vector3(0, 0, -1)
 
 func _get_runner_right() -> Vector3:
 	if _runner == null or not is_instance_valid(_runner):
 		return Vector3(1, 0, 0)
 	var pivot := _runner.get_node_or_null("MeshPivot") as Node3D
-	var b := pivot.global_transform.basis if pivot else _runner.global_transform.basis
-	var r := Vector3(b.x.x, 0.0, b.x.z)
-	if r.length_squared() > 0.001:
-		return r.normalized()
+	var runner_basis: Basis = pivot.global_transform.basis if pivot else _runner.global_transform.basis
+	var right_dir := Vector3(runner_basis.x.x, 0.0, runner_basis.x.z)
+	if right_dir.length_squared() > 0.001:
+		return right_dir.normalized()
 	return Vector3(1, 0, 0)
 
 func _get_collision_exclusions() -> Array[RID]:
@@ -278,6 +278,14 @@ func _get_collision_exclusions() -> Array[RID]:
 	if _active_vehicle is CollisionObject3D:
 		exclude.append((_active_vehicle as CollisionObject3D).get_rid())
 	return exclude
+
+func _is_spatial_point_vacant(space_state: PhysicsDirectSpaceState3D, pos: Vector3, exclusions: Array[RID]) -> bool:
+	if _shape_query == null:
+		return true
+	_shape_query.transform = Transform3D(Basis.IDENTITY, pos)
+	_shape_query.exclude = exclusions
+	var shape_hits := space_state.intersect_shape(_shape_query, 1)
+	return shape_hits.is_empty()
 
 func _is_candidate_clear(target_pos: Vector3) -> bool:
 	if not is_inside_tree():
@@ -299,14 +307,7 @@ func _is_candidate_clear(target_pos: Vector3) -> bool:
 	if not ray_hit.is_empty():
 		return false
 
-	if _shape_query != null:
-		_shape_query.transform = Transform3D(Basis.IDENTITY, target_pos)
-		_shape_query.exclude = exclusions
-		var shape_hits := space_state.intersect_shape(_shape_query, 1)
-		if not shape_hits.is_empty():
-			return false
-
-	return true
+	return _is_spatial_point_vacant(space_state, target_pos, exclusions)
 
 func _is_staging_candidate_clear(candidate_pos: Vector3) -> bool:
 	if not is_inside_tree():
@@ -319,26 +320,7 @@ func _is_staging_candidate_clear(candidate_pos: Vector3) -> bool:
 		return true
 
 	var exclusions := _get_collision_exclusions()
-	if _runner != null:
-		var ray := PhysicsRayQueryParameters3D.create(
-			_runner.global_position + Vector3.UP * FOLLOW_HEIGHT_M,
-			candidate_pos
-		)
-		ray.collide_with_areas = false
-		ray.collide_with_bodies = true
-		ray.exclude = exclusions
-		var ray_hit := space_state.intersect_ray(ray)
-		if not ray_hit.is_empty():
-			return false
-
-	if _shape_query != null:
-		_shape_query.transform = Transform3D(Basis.IDENTITY, candidate_pos)
-		_shape_query.exclude = exclusions
-		var shape_hits := space_state.intersect_shape(_shape_query, 1)
-		if not shape_hits.is_empty():
-			return false
-
-	return true
+	return _is_spatial_point_vacant(space_state, candidate_pos, exclusions)
 
 func _is_point_off_screen(world_pos: Vector3) -> bool:
 	if _camera == null or not is_instance_valid(_camera):
@@ -350,7 +332,7 @@ func _is_point_off_screen(world_pos: Vector3) -> bool:
 		return false
 	var screen_pos: Vector2 = _camera.unproject_position(world_pos)
 	var vp_rect: Rect2 = viewport.get_visible_rect()
-	return not vp_rect.has_point(screen_pos)
+	return not vp_rect.grow(32.0).has_point(screen_pos)
 
 func _try_hard_rejoin() -> bool:
 	if _camera == null or not is_instance_valid(_camera):

--- a/godot/scripts/entities/fb13_companion_body.gd
+++ b/godot/scripts/entities/fb13_companion_body.gd
@@ -168,6 +168,8 @@ func _tick_following(delta: float) -> void:
 		if _separation_timer >= REJOIN_DELAY_SEC:
 			if _try_hard_rejoin():
 				return
+			_velocity = Vector3.ZERO
+			return
 	else:
 		_separation_timer = 0.0
 
@@ -207,13 +209,16 @@ func _move_towards(target_pos: Vector3, max_speed: float, accel: float, delta: f
 		var target_rot_y := atan2(-look_dir.x, -look_dir.z)
 		rotation.y = lerp_angle(rotation.y, target_rot_y, 10.0 * delta)
 
-func _clamp_movement_by_clearance(step: Vector3) -> Vector3:
+func _get_space_state() -> PhysicsDirectSpaceState3D:
 	if not is_inside_tree():
-		return step
+		return null
 	var world := get_world_3d()
 	if world == null:
-		return step
-	var space_state := world.direct_space_state
+		return null
+	return world.direct_space_state
+
+func _clamp_movement_by_clearance(step: Vector3) -> Vector3:
+	var space_state := _get_space_state()
 	if space_state == null:
 		return step
 
@@ -241,6 +246,8 @@ func _select_follow_target() -> Vector3:
 	return global_position
 
 func _compute_follow_target(lateral_sign: float = 1.0) -> Vector3:
+	if _runner == null or not is_instance_valid(_runner):
+		return global_position
 	var fwd := _get_runner_forward()
 	var right := _get_runner_right()
 	return _runner.global_position - fwd * FOLLOW_TRAIL_M + right * (FOLLOW_SIDE_M * lateral_sign) + Vector3.UP * FOLLOW_HEIGHT_M
@@ -288,12 +295,7 @@ func _is_spatial_point_vacant(space_state: PhysicsDirectSpaceState3D, pos: Vecto
 	return shape_hits.is_empty()
 
 func _is_candidate_clear(target_pos: Vector3) -> bool:
-	if not is_inside_tree():
-		return true
-	var world := get_world_3d()
-	if world == null:
-		return true
-	var space_state := world.direct_space_state
+	var space_state := _get_space_state()
 	if space_state == null:
 		return true
 
@@ -310,12 +312,7 @@ func _is_candidate_clear(target_pos: Vector3) -> bool:
 	return _is_spatial_point_vacant(space_state, target_pos, exclusions)
 
 func _is_staging_candidate_clear(candidate_pos: Vector3) -> bool:
-	if not is_inside_tree():
-		return true
-	var world := get_world_3d()
-	if world == null:
-		return true
-	var space_state := world.direct_space_state
+	var space_state := _get_space_state()
 	if space_state == null:
 		return true
 
@@ -335,6 +332,8 @@ func _is_point_off_screen(world_pos: Vector3) -> bool:
 	return not vp_rect.grow(32.0).has_point(screen_pos)
 
 func _try_hard_rejoin() -> bool:
+	if _runner == null or not is_instance_valid(_runner):
+		return false
 	if _camera == null or not is_instance_valid(_camera):
 		return false
 	if not _is_point_off_screen(global_position):

--- a/godot/scripts/world/burnside_companion_presence_runtime.gd
+++ b/godot/scripts/world/burnside_companion_presence_runtime.gd
@@ -72,11 +72,14 @@ func get_active_dock_socket() -> Node3D:
 	return _active_dock_socket
 
 func get_runtime_snapshot() -> Dictionary:
+	var hs7_sock := get_hs7_socket()
+	var hs7_state := "CARRIED" if hs7_sock != null and hs7_sock.get_child_count() > 0 else "ABSENT"
 	return {
 		"is_configured": _is_configured,
 		"has_runner": _runner != null,
 		"has_fb13": _fb13 != null,
 		"fb13_state": _fb13.get_presence_state() if _fb13 else -1,
+		"hs7_state": hs7_state,
 		"active_dock": _active_dock_socket.name if _active_dock_socket else "",
 		"follow_distance": _fb13.get_follow_distance() if _fb13 else 0.0,
 		"hard_rejoin_count": _fb13.get_hard_rejoin_count() if _fb13 else 0,
@@ -117,9 +120,6 @@ func _handle_vehicle_state_changed(
 			_fb13.begin_dock(socket, docking_state, docked_state)
 		"DISMOUNTING":
 			_release_fb13_from_dock()
-		"PARKED":
-			if _fb13.current_state == docking_state or _fb13.current_state == docked_state:
-				_release_fb13_from_dock()
 
 func _release_fb13_from_dock() -> void:
 	if _fb13 == null or not is_instance_valid(_fb13):

--- a/godot/scripts/world/burnside_companion_presence_runtime.gd
+++ b/godot/scripts/world/burnside_companion_presence_runtime.gd
@@ -36,18 +36,18 @@ func configure(
 
 	if _courier_bike and _courier_bike.has_signal("state_changed"):
 		var cb_bike := Callable(self, "_on_bike_state_changed")
-		if not _courier_bike.is_connected("state_changed", cb_bike):
-			_courier_bike.connect("state_changed", cb_bike)
+		if not _courier_bike.state_changed.is_connected(cb_bike):
+			_courier_bike.state_changed.connect(cb_bike)
 
 	if _scrap_hauler and _scrap_hauler.has_signal("state_changed"):
 		var cb_hauler := Callable(self, "_on_hauler_state_changed")
-		if not _scrap_hauler.is_connected("state_changed", cb_hauler):
-			_scrap_hauler.connect("state_changed", cb_hauler)
+		if not _scrap_hauler.state_changed.is_connected(cb_hauler):
+			_scrap_hauler.state_changed.connect(cb_hauler)
 
 	if _thrum_event and _thrum_event.has_signal("thrum_triggered"):
 		var cb_thrum := Callable(self, "_on_fb13_thrum_triggered")
-		if not _thrum_event.is_connected("thrum_triggered", cb_thrum):
-			_thrum_event.connect("thrum_triggered", cb_thrum)
+		if not _thrum_event.thrum_triggered.is_connected(cb_thrum):
+			_thrum_event.thrum_triggered.connect(cb_thrum)
 
 	_is_configured = true
 
@@ -60,6 +60,13 @@ func reset_presence() -> void:
 		if _fb13.has_method("set_active_vehicle"):
 			_fb13.call("set_active_vehicle", null)
 		_fb13.reset_to_follow_position()
+
+	var hs7_sock := get_hs7_socket()
+	if hs7_sock != null and hs7_sock.get_child_count() == 0:
+		var hs7_scene := load("res://scenes/entities/hs7_carried_module.tscn") as PackedScene
+		if hs7_scene:
+			var hs7_inst := hs7_scene.instantiate()
+			hs7_sock.add_child(hs7_inst)
 
 func get_fb13() -> FB13CompanionBody:
 	return _fb13
@@ -85,60 +92,54 @@ func get_runtime_snapshot() -> Dictionary:
 	}
 
 func _on_bike_state_changed(new_state: String) -> void:
-	if _fb13 == null or not is_instance_valid(_fb13):
-		return
-	match new_state:
-		"MOUNTING":
-			var socket: Node3D = null
-			if _courier_bike:
-				socket = _courier_bike.get_node_or_null("FB13DockSocket") as Node3D
-			_active_dock_socket = socket
-			if _fb13.has_method("set_active_vehicle"):
-				_fb13.call("set_active_vehicle", _courier_bike)
-			_fb13.begin_dock(
-				socket,
-				FB13CompanionBody.PresenceState.DOCKING_BIKE,
-				FB13CompanionBody.PresenceState.DOCKED_BIKE
-			)
-		"DISMOUNTING":
-			var origin: Vector3 = _fb13.global_position
-			if _active_dock_socket:
-				origin = _active_dock_socket.global_position
-			_active_dock_socket = null
-			var target_parent: Node = get_parent()
-			if target_parent != null and _fb13.get_parent() != target_parent:
-				_fb13.reparent(target_parent, true)
-			if _fb13.has_method("set_active_vehicle"):
-				_fb13.call("set_active_vehicle", null)
-			_fb13.release_from_dock(origin)
+	_handle_vehicle_state_changed(
+		_courier_bike,
+		new_state,
+		FB13CompanionBody.PresenceState.DOCKING_BIKE,
+		FB13CompanionBody.PresenceState.DOCKED_BIKE
+	)
 
 func _on_hauler_state_changed(new_state: String) -> void:
+	_handle_vehicle_state_changed(
+		_scrap_hauler,
+		new_state,
+		FB13CompanionBody.PresenceState.DOCKING_HAULER,
+		FB13CompanionBody.PresenceState.DOCKED_HAULER
+	)
+
+func _handle_vehicle_state_changed(
+	vehicle: Node,
+	new_state: String,
+	docking_state: FB13CompanionBody.PresenceState,
+	docked_state: FB13CompanionBody.PresenceState
+) -> void:
 	if _fb13 == null or not is_instance_valid(_fb13):
 		return
 	match new_state:
 		"MOUNTING":
 			var socket: Node3D = null
-			if _scrap_hauler:
-				socket = _scrap_hauler.get_node_or_null("FB13DockSocket") as Node3D
+			if vehicle:
+				socket = vehicle.get_node_or_null("FB13DockSocket") as Node3D
 			_active_dock_socket = socket
 			if _fb13.has_method("set_active_vehicle"):
-				_fb13.call("set_active_vehicle", _scrap_hauler)
-			_fb13.begin_dock(
-				socket,
-				FB13CompanionBody.PresenceState.DOCKING_HAULER,
-				FB13CompanionBody.PresenceState.DOCKED_HAULER
-			)
+				_fb13.call("set_active_vehicle", vehicle)
+			_fb13.begin_dock(socket, docking_state, docked_state)
 		"DISMOUNTING":
-			var origin: Vector3 = _fb13.global_position
-			if _active_dock_socket:
-				origin = _active_dock_socket.global_position
-			_active_dock_socket = null
-			var target_parent: Node = get_parent()
-			if target_parent != null and _fb13.get_parent() != target_parent:
-				_fb13.reparent(target_parent, true)
-			if _fb13.has_method("set_active_vehicle"):
-				_fb13.call("set_active_vehicle", null)
-			_fb13.release_from_dock(origin)
+			_release_fb13_from_dock()
+
+func _release_fb13_from_dock() -> void:
+	if _fb13 == null or not is_instance_valid(_fb13):
+		return
+	var origin: Vector3 = _fb13.global_position
+	if _active_dock_socket:
+		origin = _active_dock_socket.global_position
+	_active_dock_socket = null
+	var target_parent: Node = get_parent()
+	if target_parent != null and _fb13.get_parent() != target_parent:
+		_fb13.reparent(target_parent, true)
+	if _fb13.has_method("set_active_vehicle"):
+		_fb13.call("set_active_vehicle", null)
+	_fb13.release_from_dock(origin)
 
 func _on_fb13_thrum_triggered(payload: Dictionary) -> void:
 	if _fb13 and is_instance_valid(_fb13):

--- a/godot/scripts/world/burnside_companion_presence_runtime.gd
+++ b/godot/scripts/world/burnside_companion_presence_runtime.gd
@@ -1,6 +1,8 @@
 class_name BurnsideCompanionPresenceRuntime
 extends Node
 
+const HS7_SCENE := preload("res://scenes/entities/hs7_carried_module.tscn")
+
 var _runner: PlayerRunner = null
 var _camera: Camera3D = null
 var _fb13: FB13CompanionBody = null
@@ -35,38 +37,28 @@ func configure(
 		_fb13.configure(_runner, _camera)
 
 	if _courier_bike and _courier_bike.has_signal("state_changed"):
-		var cb_bike := Callable(self, "_on_bike_state_changed")
-		if not _courier_bike.state_changed.is_connected(cb_bike):
-			_courier_bike.state_changed.connect(cb_bike)
+		if not _courier_bike.state_changed.is_connected(_on_bike_state_changed):
+			_courier_bike.state_changed.connect(_on_bike_state_changed)
 
 	if _scrap_hauler and _scrap_hauler.has_signal("state_changed"):
-		var cb_hauler := Callable(self, "_on_hauler_state_changed")
-		if not _scrap_hauler.state_changed.is_connected(cb_hauler):
-			_scrap_hauler.state_changed.connect(cb_hauler)
+		if not _scrap_hauler.state_changed.is_connected(_on_hauler_state_changed):
+			_scrap_hauler.state_changed.connect(_on_hauler_state_changed)
 
 	if _thrum_event and _thrum_event.has_signal("thrum_triggered"):
-		var cb_thrum := Callable(self, "_on_fb13_thrum_triggered")
-		if not _thrum_event.thrum_triggered.is_connected(cb_thrum):
-			_thrum_event.thrum_triggered.connect(cb_thrum)
+		if not _thrum_event.thrum_triggered.is_connected(_on_fb13_thrum_triggered):
+			_thrum_event.thrum_triggered.connect(_on_fb13_thrum_triggered)
 
 	_is_configured = true
 
 func reset_presence() -> void:
-	_active_dock_socket = null
+	_release_fb13_from_dock()
 	if _fb13 and is_instance_valid(_fb13):
-		var target_parent: Node = get_parent()
-		if target_parent != null and _fb13.get_parent() != target_parent:
-			_fb13.reparent(target_parent, true)
-		if _fb13.has_method("set_active_vehicle"):
-			_fb13.call("set_active_vehicle", null)
 		_fb13.reset_to_follow_position()
 
 	var hs7_sock := get_hs7_socket()
 	if hs7_sock != null and hs7_sock.get_child_count() == 0:
-		var hs7_scene := load("res://scenes/entities/hs7_carried_module.tscn") as PackedScene
-		if hs7_scene:
-			var hs7_inst := hs7_scene.instantiate()
-			hs7_sock.add_child(hs7_inst)
+		var hs7_inst := HS7_SCENE.instantiate()
+		hs7_sock.add_child(hs7_inst)
 
 func get_fb13() -> FB13CompanionBody:
 	return _fb13
@@ -121,11 +113,13 @@ func _handle_vehicle_state_changed(
 			if vehicle:
 				socket = vehicle.get_node_or_null("FB13DockSocket") as Node3D
 			_active_dock_socket = socket
-			if _fb13.has_method("set_active_vehicle"):
-				_fb13.call("set_active_vehicle", vehicle)
+			_fb13.set_active_vehicle(vehicle)
 			_fb13.begin_dock(socket, docking_state, docked_state)
 		"DISMOUNTING":
 			_release_fb13_from_dock()
+		"PARKED":
+			if _fb13.current_state == docking_state or _fb13.current_state == docked_state:
+				_release_fb13_from_dock()
 
 func _release_fb13_from_dock() -> void:
 	if _fb13 == null or not is_instance_valid(_fb13):
@@ -137,8 +131,7 @@ func _release_fb13_from_dock() -> void:
 	var target_parent: Node = get_parent()
 	if target_parent != null and _fb13.get_parent() != target_parent:
 		_fb13.reparent(target_parent, true)
-	if _fb13.has_method("set_active_vehicle"):
-		_fb13.call("set_active_vehicle", null)
+	_fb13.set_active_vehicle(null)
 	_fb13.release_from_dock(origin)
 
 func _on_fb13_thrum_triggered(payload: Dictionary) -> void:

--- a/godot/tests/companion_presence_semantics_test.gd
+++ b/godot/tests/companion_presence_semantics_test.gd
@@ -143,6 +143,24 @@ func _run() -> void:
 	if dist_to_obs < 0.6:
 		await _fail("FB-13 penetrated obstacle (dist=%.2f)" % dist_to_obs)
 		return
+	obs.queue_free()
+
+	# Test alternate follow offset when preferred offset is blocked (Spec line 279)
+	fb13.call("reset_to_follow_position")
+	var pref_pos: Vector3 = fb13.call("_compute_preferred_follow_target")
+	var alt_pos: Vector3 = fb13.call("_compute_alternate_follow_target")
+	fb13.global_position = runner.global_position - Vector3(0, 0, 1.0) + Vector3.UP * 1.2
+	var pref_obs := _create_obstacle(pref_pos, Vector3(1.5, 1.5, 1.5))
+	await physics_frame
+	await physics_frame
+	for _i in range(120):
+		fb13.call("tick_presence", 1.0 / 60.0)
+	var dist_to_alt: float = fb13.global_position.distance_to(alt_pos)
+	if dist_to_alt > 1.2:
+		await _fail("FB-13 did not select alternate follow target when preferred blocked (dist to alt: %.2f)" % dist_to_alt)
+		return
+	pref_obs.queue_free()
+	await physics_frame
 
 	# Separation and rejoin checks
 	# 1. 17.9m for > 0.75s -> NO hard rejoin
@@ -178,6 +196,39 @@ func _run() -> void:
 	if int(fb13.call("get_hard_rejoin_count")) != initial_rejoin_count:
 		await _fail("Hard rejoin triggered while FB-13 source position was visible in frustum")
 		return
+
+	# 3b. When all staging candidates are blocked, hard rejoin is suppressed (Spec line 281)
+	fb13.call("reset_to_follow_position")
+	camera.global_position = Vector3(0, 2, 5)
+	camera.look_at(Vector3(0, 0, -10), Vector3.UP)
+	fb13.global_position = Vector3(0, 0, 25) # off-screen
+	runner.global_position = Vector3(0, 0, 0)
+	var staging_obstacles: Array[Node] = []
+	var cam_fwd := Vector3(0, 0, -1)
+	var cam_right := Vector3(1, 0, 0)
+	var candidate_offsets: Array[Vector3] = [
+		-cam_fwd,
+		(-cam_fwd + cam_right).normalized(),
+		(-cam_fwd - cam_right).normalized(),
+		cam_right
+	]
+	for d in candidate_offsets:
+		var cpos: Vector3 = runner.global_position + d * 16.0
+		cpos.y = runner.global_position.y + 1.15
+		staging_obstacles.append(_create_obstacle(cpos, Vector3(4.0, 4.0, 4.0)))
+
+	await physics_frame
+	await physics_frame
+
+	var blocked_rejoin_count: int = int(fb13.call("get_hard_rejoin_count"))
+	for _i in range(60): # 1.0s > 0.75s
+		fb13.call("tick_presence", 1.0 / 60.0)
+	if int(fb13.call("get_hard_rejoin_count")) != blocked_rejoin_count:
+		await _fail("Hard rejoin triggered when all staging candidates were blocked")
+		return
+	for staging_obs in staging_obstacles:
+		staging_obs.queue_free()
+	await physics_frame
 
 	# 4. Source off-screen and valid off-screen staging candidate -> exactly one hard rejoin
 	fb13.call("reset_to_follow_position")

--- a/godot/tests/companion_presence_windowed_probe.gd
+++ b/godot/tests/companion_presence_windowed_probe.gd
@@ -206,6 +206,22 @@ func _run() -> void:
 			await _fail(cap_err)
 			return
 
+	# --- 7. Constrained Mobile Viewport Framing Proof ---
+	var orig_size: Vector2i = root.size
+	root.size = Vector2i(400, 700)
+	for _i in range(15):
+		await process_frame
+		await physics_frame
+
+	cap_err = await _capture("07_mobile_viewport_framing.png", "FB-13 and HS-7 companion framing under constrained mobile viewport (400x700)")
+	if not cap_err.is_empty():
+		await _fail(cap_err)
+		return
+	root.size = orig_size
+	for _i in range(5):
+		await process_frame
+		await physics_frame
+
 	# Write summary report
 	var report := {
 		"schema_version": 1,


### PR DESCRIPTION
Addresses all findings from the Production 08 two-axis code review:

### Standards
1. Use Godot 4 typed signal syntax (`node.signal_name.connect(callable)`) in `BurnsideCompanionPresenceRuntime`.
2. Move regular variables before `@onready` variables in `FB13CompanionBody`.
3. Deduplicate vehicle state handlers in `BurnsideCompanionPresenceRuntime`.
4. Deduplicate lateral follow target calculation in `FB13CompanionBody`.

### Spec
1. Cache `_dock_start_transform` in `FB13CompanionBody.begin_dock()` to fix non-linear compound dock acceleration.
2. Use strict viewport boundaries in `FB13CompanionBody._is_point_off_screen()` so edge pixels are not treated as off-screen.
3. Add raycast from Runner to staging candidate in `FB13CompanionBody._is_staging_candidate_clear()` alongside sphere query.
4. Set `PresenceState.FOLLOWING` on vehicle dismount release per spec line 127.
5. Verify HS-7 carry socket visual module on full Replay reset.
6. Add mobile viewport capture (`07_mobile_viewport_framing.png`) to windowed probe and workflow.
7. Add camera contract tests to P08 workflow retained regressions.